### PR TITLE
fix: grafana dashboard url in dev alert rule

### DIFF
--- a/infrastructure/dev/alerts.yaml
+++ b/infrastructure/dev/alerts.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   retryInterval: 10s
-  path: ./infrastructure/base/alerts
+  path: ./infrastructure/dev/alerts
   prune: true
   sourceRef:
     kind: GitRepository

--- a/infrastructure/dev/alerts/kustomization.yaml
+++ b/infrastructure/dev/alerts/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/alerts
+patches:
+- target:
+    kind: PrometheusRule
+    name: image-critical-vulnerabilities
+  patch: |-
+    - op: replace
+      path: /spec/groups/0/rules/0/labels/dashboard_url
+      value: https://grafana.dev.fellesdatakatalog.digdir.no/d/trivy/trivy?orgId=1


### PR DESCRIPTION
Overwrites (patches) dashboard_url label in dev cluster.