### PR TITLE
fix: add config-map as resource instead of patch

### DIFF
--- a/apps/dev/nginx-harvester-demo/kustomization.yaml
+++ b/apps/dev/nginx-harvester-demo/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base/nginx-harvester
+  - config-map.yaml
 patches:
   - patch: |-
       - op: add
@@ -24,4 +25,3 @@ patches:
     target:
       kind: Service
       name: nginx-harvester
-  - path: config-map.yaml

--- a/apps/dev/nginx-harvester-staging/kustomization.yaml
+++ b/apps/dev/nginx-harvester-staging/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base/nginx-harvester
+- config-map.yaml
 patches:
   - patch: |-
       - op: add
@@ -24,4 +25,3 @@ patches:
     target:
       kind: Service
       name: nginx-harvester
-  - path: config-map.yaml

--- a/apps/prod/nginx-harvester/kustomization.yaml
+++ b/apps/prod/nginx-harvester/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base/nginx-harvester
+- config-map.yaml
 patches:
   - patch: |-
       - op: add
@@ -24,4 +25,3 @@ patches:
     target:
       kind: Service
       name: nginx-harvester
-  - path: config-map.yaml


### PR DESCRIPTION
Nginx-harvester skal erstatte dagens ingress i gcp