### PR TITLE
chore: set grafana deployment strategy to recreate

### DIFF
--- a/infrastructure/base/monitoring/helm-release-prometheus.yaml
+++ b/infrastructure/base/monitoring/helm-release-prometheus.yaml
@@ -145,6 +145,8 @@ spec:
                         alertname%3D%22{{- .Labels.alertname -}}%22%7D
                       {{- end -}}
     grafana:
+      deploymentStrategy:
+        type: Recreate
       sidecar:
         datasources:
           url: http://monitoring-thanos-query-frontend.monitoring:9090


### PR DESCRIPTION
For å løse issue med at Grafana ikke klarer å starte opp ved prometheus-oppgradering