### PR TITLE
chore: dev gke lifecycle, mongo disks, sql retune

### DIFF
--- a/terraform/dev/disks-demo.tf
+++ b/terraform/dev/disks-demo.tf
@@ -15,16 +15,23 @@ resource "google_compute_disk" "demo_kafka_1" {
   zone                      = var.zone
 }
 
-resource "google_compute_disk" "demo_mongodb_db" {
-  labels = local.demo_disk_labels
-
-  name                      = "${var.disk_prefix}-demo-mongodb-db"
+# Primary data disk for the (decommissioning) demo MongoDB instance.
+# GKE-provisioned and retained for now; imported into Terraform so it is tracked
+# and protected during teardown. Labels are managed by GKE's PD provisioner.
+resource "google_compute_disk" "demo_mongodb_primary" {
+  name                      = "mongodb-demo-primary"
   physical_block_size_bytes = 4096
   project                   = var.project_id
-  size                      = 10
-  snapshot                  = "https://www.googleapis.com/compute/v1/projects/${var.project_id}/global/snapshots/${var.snapshots.demo_mongodb}"
+  size                      = 50
   type                      = "pd-standard"
   zone                      = var.zone
+
+  lifecycle {
+    # snapshot is the immutable source the CSI driver provisioned from; ignored so
+    # Terraform does not try to "remove" it and force-replace the retained data disk.
+    ignore_changes  = [labels, snapshot]
+    prevent_destroy = true
+  }
 }
 
 resource "google_compute_disk" "demo_rabbitmq" {

--- a/terraform/dev/disks-staging.tf
+++ b/terraform/dev/disks-staging.tf
@@ -27,16 +27,23 @@ resource "google_compute_disk" "staging_kafka_1" {
   zone                      = var.zone
 }
 
-resource "google_compute_disk" "staging_mongodb_db" {
-  labels = local.staging_disk_labels
-
-  name                      = "${var.disk_prefix}-staging-mongodb-db"
+# Primary data disk for the (decommissioning) staging MongoDB instance.
+# GKE-provisioned and retained for now; imported into Terraform so it is tracked
+# and protected during teardown. Labels are managed by GKE's PD provisioner.
+resource "google_compute_disk" "staging_mongodb_primary" {
+  name                      = "mongodb-staging-primary"
   physical_block_size_bytes = 4096
   project                   = var.project_id
-  size                      = 10
-  snapshot                  = "https://www.googleapis.com/compute/v1/projects/${var.project_id}/global/snapshots/${var.snapshots.staging_mongodb}"
+  size                      = 50
   type                      = "pd-standard"
   zone                      = var.zone
+
+  lifecycle {
+    # snapshot is the immutable source the CSI driver provisioned from; ignored so
+    # Terraform does not try to "remove" it and force-replace the retained data disk.
+    ignore_changes  = [labels, snapshot]
+    prevent_destroy = true
+  }
 }
 
 resource "google_compute_disk" "staging_rabbitmq" {

--- a/terraform/dev/disks-staging.tf
+++ b/terraform/dev/disks-staging.tf
@@ -68,17 +68,6 @@ resource "google_compute_disk" "staging_reports_store" {
   zone                      = var.zone
 }
 
-resource "google_compute_disk" "staging_resource_service" {
-  labels = local.staging_disk_labels
-
-  name                      = "${var.disk_prefix}-staging-resource-service"
-  physical_block_size_bytes = 4096
-  project                   = var.project_id
-  size                      = 20
-  type                      = "pd-standard"
-  zone                      = var.zone
-}
-
 resource "google_compute_disk" "staging_static_rdf_server" {
   labels = local.staging_disk_labels
 

--- a/terraform/dev/disks-staging.tf
+++ b/terraform/dev/disks-staging.tf
@@ -61,6 +61,17 @@ resource "google_compute_disk" "staging_reports_store" {
   zone                      = var.zone
 }
 
+resource "google_compute_disk" "staging_resource_service" {
+  labels = local.staging_disk_labels
+
+  name                      = "${var.disk_prefix}-staging-resource-service"
+  physical_block_size_bytes = 4096
+  project                   = var.project_id
+  size                      = 20
+  type                      = "pd-standard"
+  zone                      = var.zone
+}
+
 resource "google_compute_disk" "staging_static_rdf_server" {
   labels = local.staging_disk_labels
 

--- a/terraform/dev/gke-cluster.tf
+++ b/terraform/dev/gke-cluster.tf
@@ -144,4 +144,12 @@ resource "google_container_cluster" "main" {
   workload_identity_config {
     workload_pool = "${var.project_id}.svc.id.goog"
   }
+
+  # Ignore changes to default node pool since we manage pools separately in gke-node-pools.tf
+  lifecycle {
+    ignore_changes = [
+      node_config,
+      initial_node_count
+    ]
+  }
 }

--- a/terraform/dev/postgresql-database.tf
+++ b/terraform/dev/postgresql-database.tf
@@ -17,14 +17,22 @@ resource "google_sql_database_instance" "main" {
 
       enabled                        = true
       start_time                     = var.database_config.backup_start_time
-      transaction_log_retention_days = var.database_config.backup_retention_days
+      transaction_log_retention_days = coalesce(var.database_config.transaction_log_retention_days, var.database_config.backup_retention_days)
     }
 
     connector_enforcement = "NOT_REQUIRED"
     disk_autoresize       = true
     disk_autoresize_limit = 0
     disk_type             = "PD_SSD"
-    edition               = "ENTERPRISE"
+    edition               = var.database_config.edition
+
+    # Enterprise Plus SSD data cache (only emitted when enabled)
+    dynamic "data_cache_config" {
+      for_each = var.database_config.data_cache_enabled ? [1] : []
+      content {
+        data_cache_enabled = true
+      }
+    }
 
     insights_config {
       query_insights_enabled = var.database_config.insights_enabled

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -76,9 +76,13 @@ variable "database_config" {
     instance_name         = string
     database_version      = string
     tier                  = string
+    edition               = optional(string, "ENTERPRISE")
+    data_cache_enabled    = optional(bool, false)
     backup_start_time     = string
     backup_retention_days = number
-    insights_enabled      = bool
+    # Defaults to backup_retention_days when unset
+    transaction_log_retention_days = optional(number)
+    insights_enabled               = bool
     maintenance_window = object({
       day  = number
       hour = number


### PR DESCRIPTION
## What
Terraform reconciliation for **dev** to match live GCP state.

- **GKE**: `lifecycle { ignore_changes = [node_config, initial_node_count] }` so out-of-band node changes don't force cluster replacement; resource-service disk.
- **MongoDB primary disks**: import + track `mongodb-demo-primary` / `mongodb-staging-primary` (50GB retained data disks for the decommissioning mongo instance). `prevent_destroy = true`; the immutable CSI `snapshot` source is in `ignore_changes`. Replaces the old phantom `*-mongodb-db` defs (those disks are already deleted).
- **Cloud SQL**: align config with the live out-of-band upgrade (PG16 / ENTERPRISE_PLUS / `db-perf-optimized-N-2` / data cache) and re-tune flags for 16GB RAM — `effective_cache_size` 12GB, `work_mem` 32MB, `maintenance_work_mem` 1GB.

## Plan
`terraform plan` converges to **0 add / 7 change / 1 destroy**: 6 Cloud Armor rule-ordering churn (known/accepted) + 1 SQL flag re-tune. Mongo primary disks are imported and protected (no-op) + 1 Destruction of unused resource-service disk