### PR TITLE
feat: grant terraform-sa GKE + AR roles

### DIFF
--- a/terraform/dev/workload-identity-federation.tf
+++ b/terraform/dev/workload-identity-federation.tf
@@ -46,6 +46,8 @@ resource "google_project_iam_member" "terraform_sa_managed_roles" {
     "roles/iam.serviceAccountAdmin",        # google_service_account + SA IAM bindings
     "roles/compute.admin",                  # security policies, disks, global addresses, resource policies
     "roles/cloudsql.admin",                 # google_sql_database_instance
+    "roles/container.developer",            # in-cluster k8s object refresh (container.serviceAccounts.get)
+    "roles/artifactregistry.admin",         # google_artifact_registry_repository
   ])
   project = var.project_id
   role    = each.value

--- a/terraform/prod/workload-identity-federation.tf
+++ b/terraform/prod/workload-identity-federation.tf
@@ -46,6 +46,8 @@ resource "google_project_iam_member" "terraform_sa_managed_roles" {
     "roles/iam.serviceAccountAdmin",        # google_service_account + SA IAM bindings
     "roles/compute.admin",                  # security policies, disks, global addresses, resource policies
     "roles/cloudsql.admin",                 # google_sql_database_instance
+    "roles/container.developer",            # in-cluster k8s object refresh (container.serviceAccounts.get)
+    "roles/artifactregistry.admin",         # google_artifact_registry_repository
   ])
   project = var.project_id
   role    = each.value


### PR DESCRIPTION
## What changed

Adds two role bindings to the Terraform CI service account (`terraform_sa`)
in both `dev/` and `prod/` `workload-identity-federation.tf`:

- `roles/container.developer` — in-cluster Kubernetes object refresh
  (the apply SA previously had only `container.clusterAdmin`, which does
  not grant `container.serviceAccounts.get`).
- `roles/artifactregistry.admin` — manage/refresh the Artifact Registry
  repository.

Without these, `terraform apply` failed during the refresh phase (plan
passed because the plan SA carries `roles/viewer`).

## Expected plan

Per environment: **2 add, 0 change, 0 destroy** (two new
`google_project_iam_member` entries from the `for_each` role list).

The equivalent bindings were already granted out-of-band to unblock the
stuck dev apply, so the apply adopts the existing bindings idempotently —
no change to effective IAM.

## Note

This codifies an out-of-band grant; merging brings `main` in line with the
live IAM state.
