### PR TITLE
fix: add prod postgres-exporter external secret

### DIFF
--- a/infrastructure/prod/cloud-sql-proxy/kustomization.yaml
+++ b/infrastructure/prod/cloud-sql-proxy/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - monitoring-kustomization.yaml

--- a/infrastructure/prod/cloud-sql-proxy/monitoring-kustomization.yaml
+++ b/infrastructure/prod/cloud-sql-proxy/monitoring-kustomization.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cloud-sql-proxy-monitoring
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: ./infrastructure/base/cloud-sql-proxy
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: monitoring
+  patches:
+    - patch: |-
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: postgresql-sqlproxy
+          namespace: monitoring
+        spec:
+          template:
+            spec:
+              containers:
+                - name: cloud-sql-proxy
+                  command:
+                    - /cloud-sql-proxy
+                    - --structured-logs
+                    - --address=0.0.0.0
+                    - --port=5432
+                    - digdir-fdk-prod:europe-north1:digdir-fdk-prod
+      target:
+        kind: Deployment
+        name: postgresql-sqlproxy

--- a/infrastructure/prod/external-secrets/crs/monitoring/postgres-exporter.yaml
+++ b/infrastructure/prod/external-secrets/crs/monitoring/postgres-exporter.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: postgres-exporter
+  namespace: monitoring
+spec:
+  secretStoreRef:
+    name: gcp-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: postgres-exporter
+    creationPolicy: Owner
+  data:
+    - secretKey: DATA_SOURCE_NAME
+      remoteRef:
+        key: postgres-exporter
+        property: connection_string

--- a/infrastructure/prod/kustomization.yaml
+++ b/infrastructure/prod/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - alerts.yaml
+  - cloud-sql-proxy
   - external-secrets.yaml
   - keycloak-operator.yaml
   - cert-manager.yaml


### PR DESCRIPTION
# Summary

- Add missing ExternalSecret `postgres-exporter` in the prod `monitoring` namespace (maps GSM `postgres-exporter` → `connection_string` into `DATA_SOURCE_NAME`)
- Add prod `cloud-sql-proxy` for the `monitoring` namespace (mirrors dev; Cloud SQL instance `digdir-fdk-prod:europe-north1:digdir-fdk-prod`, via the terraform-managed `cloud-sql-sa` workload-identity SA)
- Wire `cloud-sql-proxy` into `infrastructure/prod/kustomization.yaml`
- Together these fix the prod `prometheus-postgres-exporter` pod: clears CreateContainerConfigError (missing secret) and gives it a reachable DB endpoint at `postgresql-sqlproxy:5432`