### PR TITLE
fix: restore flux gotk metrics via kube-state-metrics

### DIFF
--- a/infrastructure/base/monitoring/helm-release-prometheus.yaml
+++ b/infrastructure/base/monitoring/helm-release-prometheus.yaml
@@ -50,6 +50,117 @@ spec:
       enabled: false
     kubeProxy:
       enabled: false
+    # Restore the Flux GitOps Toolkit metrics that the removed monitoring-config
+    # (issue #221) used to provide. kube-state-metrics generates
+    # gotk_reconcile_condition and gotk_suspend_status from the Flux custom
+    # resources; flux-alerts.yaml depends on both metrics (without them the
+    # reconciliation-failure and suspended alerts are silent no-ops).
+    kube-state-metrics:
+      rbac:
+        extraRules:
+          - apiGroups:
+              - kustomize.toolkit.fluxcd.io
+              - helm.toolkit.fluxcd.io
+              - source.toolkit.fluxcd.io
+            resources:
+              - "*"
+            verbs:
+              - list
+              - watch
+      customResourceState:
+        enabled: true
+        config:
+          kind: CustomResourceStateMetrics
+          spec:
+            resources:
+              - groupVersionKind:
+                  group: kustomize.toolkit.fluxcd.io
+                  kind: Kustomization
+                  version: v1
+                metricNamePrefix: gotk
+                labelsFromPath:
+                  name: [metadata, name]
+                commonLabels:
+                  kind: Kustomization
+                metrics: &gotkMetrics
+                  - name: reconcile_condition
+                    help: "The current reconciliation condition status of a Flux resource."
+                    each:
+                      type: StateSet
+                      stateSet:
+                        labelName: status
+                        labelsFromPath:
+                          type: [type]
+                        path: [status, conditions]
+                        valueFrom: [status]
+                        list: ["True", "False", "Unknown"]
+                  - name: suspend_status
+                    help: "The suspend status of a Flux resource."
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [spec, suspend]
+                        nilIsZero: true
+              - groupVersionKind:
+                  group: helm.toolkit.fluxcd.io
+                  kind: HelmRelease
+                  version: v2
+                metricNamePrefix: gotk
+                labelsFromPath:
+                  name: [metadata, name]
+                commonLabels:
+                  kind: HelmRelease
+                metrics: *gotkMetrics
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  kind: GitRepository
+                  version: v1
+                metricNamePrefix: gotk
+                labelsFromPath:
+                  name: [metadata, name]
+                commonLabels:
+                  kind: GitRepository
+                metrics: *gotkMetrics
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  kind: HelmRepository
+                  version: v1
+                metricNamePrefix: gotk
+                labelsFromPath:
+                  name: [metadata, name]
+                commonLabels:
+                  kind: HelmRepository
+                metrics: *gotkMetrics
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  kind: HelmChart
+                  version: v1
+                metricNamePrefix: gotk
+                labelsFromPath:
+                  name: [metadata, name]
+                commonLabels:
+                  kind: HelmChart
+                metrics: *gotkMetrics
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  kind: Bucket
+                  version: v1
+                metricNamePrefix: gotk
+                labelsFromPath:
+                  name: [metadata, name]
+                commonLabels:
+                  kind: Bucket
+                metrics: *gotkMetrics
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  kind: OCIRepository
+                  version: v1
+                metricNamePrefix: gotk
+                labelsFromPath:
+                  name: [metadata, name]
+                commonLabels:
+                  kind: OCIRepository
+                metrics: *gotkMetrics
     alertmanager:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/infrastructure/base/monitoring/helm-release-prometheus.yaml
+++ b/infrastructure/base/monitoring/helm-release-prometheus.yaml
@@ -50,11 +50,6 @@ spec:
       enabled: false
     kubeProxy:
       enabled: false
-    # Restore the Flux GitOps Toolkit metrics that the removed monitoring-config
-    # (issue #221) used to provide. kube-state-metrics generates
-    # gotk_reconcile_condition and gotk_suspend_status from the Flux custom
-    # resources; flux-alerts.yaml depends on both metrics (without them the
-    # reconciliation-failure and suspended alerts are silent no-ops).
     kube-state-metrics:
       rbac:
         extraRules:


### PR DESCRIPTION
# Summary

- Add a kube-state-metrics CustomResourceState config to the kube-prometheus-stack HelmRelease so it emits `gotk_reconcile_condition` and `gotk_suspend_status` for all reconcilable Flux kinds (Kustomization, HelmRelease, GitRepository, HelmRepository, HelmChart, Bucket, OCIRepository)
- These metrics were lost when the upstream flux monitoring-config was removed, leaving 5 of 7 alerts in `flux-alerts.yaml` (reconciliation-failure / suspended / per-kind failures) as silent no-ops
- Grant kube-state-metrics RBAC (list/watch) on the Flux API groups
- Metrics carry the exact labels the alerts query (`kind`, `name`, `namespace`, `type`, `status`)

Closes #221
