### PR TITLE
fix: remove invalid cert-manager podSecurityContext

### DIFF
--- a/infrastructure/base/cert-manager/cert-manager.yaml
+++ b/infrastructure/base/cert-manager/cert-manager.yaml
@@ -33,11 +33,6 @@ spec:
       runAsUser: 1001
       runAsGroup: 1001
       fsGroup: 1001
-    podSecurityContext:
-      runAsNonRoot: true
-      runAsUser: 1001
-      runAsGroup: 1001
-      fsGroup: 1001
     nodeSelector: {}
     tolerations: []
     affinity: {}


### PR DESCRIPTION
# Summary

- Remove the `podSecurityContext` value from the cert-manager HelmRelease — it is not a valid chart key (the chart uses `securityContext` for the pod-level context, which is already set with identical values)
- The v1.13.3 chart ignored the unknown key, but v1.18.2 ships a strict `values.schema.json` that rejects it, leaving the HelmRelease stuck `Ready=False` (`Additional property podSecurityContext is not allowed`) on both dev and prod
- Verified `helm template cert-manager@v1.18.2` renders cleanly with the corrected values
