### PR TITLE
fix: add release label so Prometheus loads alert rules

### DIFF
--- a/infrastructure/base/alerts/postgres-connection-alerts.yaml
+++ b/infrastructure/base/alerts/postgres-connection-alerts.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     prometheus: kube-prometheus
     role: alert-rules
+    # Required for Prometheus to load these rules: the kube-prometheus-stack
+    # Prometheus ruleSelector matches on this label. Without it the whole
+    # PrometheusRule is silently ignored.
+    release: monitoring-kube-prometheus-stack
 spec:
   groups:
     - name: postgresql.connection.rules

--- a/infrastructure/base/monitoring/flux-alerts.yaml
+++ b/infrastructure/base/monitoring/flux-alerts.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: monitoring
   labels:
     app.kubernetes.io/part-of: flux
+    # Required for Prometheus to load these rules: the kube-prometheus-stack
+    # Prometheus ruleSelector matches on this label. Without it the whole
+    # PrometheusRule is silently ignored.
+    release: monitoring-kube-prometheus-stack
 spec:
   groups:
     - name: flux-reconciliation


### PR DESCRIPTION
# Summary

- Add `release: monitoring-kube-prometheus-stack` to the `flux-alerts` and `postgres-connection-alerts` PrometheusRules
- The kube-prometheus-stack Prometheus `ruleSelector` matches on this label; without it the entire PrometheusRule is silently ignored, so none of the rules were ever loaded or evaluated (in dev and prod)
- Verified live: with the label, all 7 Flux rules load and go pending against real failures (thanos HelmRelease, keycloak Kustomizations)