### PR TITLE
fix: deploy cloud-sql-proxy in prod namespace

### DIFF
--- a/infrastructure/prod/cloud-sql-proxy/kustomization.yaml
+++ b/infrastructure/prod/cloud-sql-proxy/kustomization.yaml
@@ -2,4 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - prod-kustomization.yaml
   - monitoring-kustomization.yaml

--- a/infrastructure/prod/cloud-sql-proxy/prod-kustomization.yaml
+++ b/infrastructure/prod/cloud-sql-proxy/prod-kustomization.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cloud-sql-proxy-prod
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: ./infrastructure/base/cloud-sql-proxy
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: prod
+  patches:
+    - patch: |-
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: postgresql-sqlproxy
+          namespace: prod
+        spec:
+          template:
+            spec:
+              containers:
+                - name: cloud-sql-proxy
+                  command:
+                    - /cloud-sql-proxy
+                    - --structured-logs
+                    - --address=0.0.0.0
+                    - --port=5432
+                    - digdir-fdk-prod:europe-north1:digdir-fdk-prod
+      target:
+        kind: Deployment
+        name: postgresql-sqlproxy


### PR DESCRIPTION
# Summary

- Add Flux Kustomization deploying postgresql-sqlproxy into the prod namespace
- Wire the new overlay into infrastructure/prod/cloud-sql-proxy/kustomization.yaml