### PR TITLE
chore: bump keycloak to 26.6.3

### DIFF
--- a/apps/dev/keycloak-demo/keycloak.yaml
+++ b/apps/dev/keycloak-demo/keycloak.yaml
@@ -1,4 +1,4 @@
-apiVersion: k8s.keycloak.org/v2alpha1
+apiVersion: k8s.keycloak.org/v2beta1
 kind: Keycloak
 metadata:
   name: keycloak
@@ -10,7 +10,7 @@ spec:
   instances: 3
   update:
     strategy: Explicit
-    revision: "6"
+    revision: "7"
   http:
     httpEnabled: false
     httpsPort: 8443

--- a/apps/dev/keycloak-staging/keycloak.yaml
+++ b/apps/dev/keycloak-staging/keycloak.yaml
@@ -1,4 +1,4 @@
-apiVersion: k8s.keycloak.org/v2alpha1
+apiVersion: k8s.keycloak.org/v2beta1
 kind: Keycloak
 metadata:
   name: keycloak
@@ -10,7 +10,7 @@ spec:
   instances: 3
   update:
     strategy: Explicit
-    revision: "18"
+    revision: "19"
   http:
     httpEnabled: false
     httpsPort: 8443

--- a/apps/prod/keycloak/keycloak.yaml
+++ b/apps/prod/keycloak/keycloak.yaml
@@ -1,4 +1,4 @@
-apiVersion: k8s.keycloak.org/v2alpha1
+apiVersion: k8s.keycloak.org/v2beta1
 kind: Keycloak
 metadata:
   name: keycloak
@@ -10,7 +10,7 @@ spec:
   instances: 3
   update:
     strategy: Explicit
-    revision: "5"
+    revision: "6"
   http:
     httpEnabled: false
     httpsPort: 8443

--- a/clusters/dev/flux-system/gotk-sync.yaml
+++ b/clusters/dev/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: chore/not/keycloak-26-6-3
+    branch: main
   secretRef:
     name: flux-system
   url: ssh://git@github.com/Informasjonsforvaltning/fdk-infra

--- a/clusters/dev/flux-system/gotk-sync.yaml
+++ b/clusters/dev/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/not/keycloak-26-6-3
   secretRef:
     name: flux-system
   url: ssh://git@github.com/Informasjonsforvaltning/fdk-infra

--- a/infrastructure/base/keycloak-operator/keycloak-crd.yaml
+++ b/infrastructure/base/keycloak-operator/keycloak-crd.yaml
@@ -13,7 +13,7 @@ spec:
     singular: "keycloak"
   scope: "Namespaced"
   versions:
-  - name: "v2alpha1"
+  - name: "v2beta1"
     schema:
       openAPIV3Schema:
         properties:
@@ -40,6 +40,21 @@ spec:
                       type: "string"
                   type: "object"
                 type: "array"
+              admin:
+                description: "In this section you can find all properties related\
+                  \ to making admin connections from the operator to the server. These\
+                  \ settings are not used by the server."
+                properties:
+                  tlsSecret:
+                    description: "If mTLS is required, this references a secret containing\
+                      \ the client TLS configuration for the admin client. Reference:\
+                      \ https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets."
+                    type: "string"
+                type: "object"
+              automountServiceAccountToken:
+                description: "Set this to to false to disable automounting the default\
+                  \ ServiceAccount Token and Service CA. This is enabled by default."
+                type: "boolean"
               bootstrapAdmin:
                 description: "In this section you can configure Keycloak's bootstrap\
                   \ admin - will be used only for initial cluster creation."
@@ -227,6 +242,21 @@ spec:
                       type: "string"
                     description: "Labels to be appended to the Service object"
                     type: "object"
+                  serviceHttpPort:
+                    description: "The HTTP port exposed on the Kubernetes Service.\
+                      \ When set, the Service will use this port while the pod still\
+                      \ listens on httpPort."
+                    type: "integer"
+                  serviceHttpsPort:
+                    description: "The HTTPS port exposed on the Kubernetes Service.\
+                      \ When set, the Service will use this port while the pod still\
+                      \ listens on httpsPort."
+                    type: "integer"
+                  serviceName:
+                    description: "The name of the Kubernetes Service. When not set,\
+                      \ the name defaults to the Keycloak CR name with a \"-service\"\
+                      \ suffix."
+                    type: "string"
                   tlsSecret:
                     description: "A secret containing the TLS configuration for HTTPS.\
                       \ Reference: https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets."
@@ -1314,6 +1344,11 @@ spec:
               serviceMonitor:
                 description: "Configuration related to the generated ServiceMonitor"
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: "string"
+                    description: "Annotations to be appended to the Service object"
+                    type: "object"
                   enabled:
                     default: true
                     description: "Enables or disables the creation of the ServiceMonitor."
@@ -1322,6 +1357,11 @@ spec:
                     default: "30s"
                     description: "Interval at which metrics should be scraped"
                     type: "string"
+                  labels:
+                    additionalProperties:
+                      type: "string"
+                    description: "Labels to be appended to the Service object"
+                    type: "object"
                   scrapeTimeout:
                     default: "10s"
                     description: "Timeout after which the scrape is ended"
@@ -1340,6 +1380,29 @@ spec:
                     type: "integer"
                   periodSeconds:
                     type: "integer"
+                type: "object"
+              telemetry:
+                description: "In this section you can configure general shared OpenTelemetry\
+                  \ settings for Keycloak."
+                properties:
+                  endpoint:
+                    description: "OpenTelemetry endpoint to connect to."
+                    type: "string"
+                  protocol:
+                    description: "OpenTelemetry protocol used for the telemetry data\
+                      \ (default 'grpc'). For more information, check the OpenTelemetry\
+                      \ guide."
+                    type: "string"
+                  resourceAttributes:
+                    additionalProperties:
+                      type: "string"
+                    description: "OpenTelemetry resource attributes present in the\
+                      \ exported telemetry data to characterize the telemetry producer."
+                    type: "object"
+                  serviceName:
+                    description: "OpenTelemetry service name. Takes precedence over\
+                      \ 'service.name' defined in the 'resourceAttributes' map."
+                    type: "string"
                 type: "object"
               tracing:
                 description: "In this section you can configure OpenTelemetry Tracing\
@@ -1364,7 +1427,8 @@ spec:
                   resourceAttributes:
                     additionalProperties:
                       type: "string"
-                    description: "OpenTelemetry resource attributes present in the\
+                    description: "DEPRECATED - use the 'telemetry.resourceAttributes'\
+                      \ instead. OpenTelemetry resource attributes present in the\
                       \ exported trace to characterize the telemetry producer."
                     type: "object"
                   samplerRatio:
@@ -1376,8 +1440,9 @@ spec:
                       \ 'traceidratio'). For more information, check the Tracing guide."
                     type: "string"
                   serviceName:
-                    description: "OpenTelemetry service name. Takes precedence over\
-                      \ 'service.name' defined in the 'resourceAttributes' map."
+                    description: "DEPRECATED - use the 'telemetry.serviceName' instead.\
+                      \ OpenTelemetry service name. Takes precedence over 'service.name'\
+                      \ defined in the 'resourceAttributes' map."
                     type: "string"
                 type: "object"
               transaction:
@@ -1872,6 +1937,17 @@ spec:
                                               fieldPath:
                                                 type: "string"
                                             type: "object"
+                                          fileKeyRef:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              optional:
+                                                type: "boolean"
+                                              path:
+                                                type: "string"
+                                              volumeName:
+                                                type: "string"
+                                            type: "object"
                                           resourceFieldRef:
                                             properties:
                                               containerName:
@@ -2200,6 +2276,22 @@ spec:
                                   type: "object"
                                 restartPolicy:
                                   type: "string"
+                                restartPolicyRules:
+                                  items:
+                                    properties:
+                                      action:
+                                        type: "string"
+                                      exitCodes:
+                                        properties:
+                                          operator:
+                                            type: "string"
+                                          values:
+                                            items:
+                                              type: "integer"
+                                            type: "array"
+                                        type: "object"
+                                    type: "object"
+                                  type: "array"
                                 securityContext:
                                   properties:
                                     allowPrivilegeEscalation:
@@ -2428,6 +2520,17 @@ spec:
                                               fieldPath:
                                                 type: "string"
                                             type: "object"
+                                          fileKeyRef:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              optional:
+                                                type: "boolean"
+                                              path:
+                                                type: "string"
+                                              volumeName:
+                                                type: "string"
+                                            type: "object"
                                           resourceFieldRef:
                                             properties:
                                               containerName:
@@ -2756,6 +2859,22 @@ spec:
                                   type: "object"
                                 restartPolicy:
                                   type: "string"
+                                restartPolicyRules:
+                                  items:
+                                    properties:
+                                      action:
+                                        type: "string"
+                                      exitCodes:
+                                        properties:
+                                          operator:
+                                            type: "string"
+                                          values:
+                                            items:
+                                              type: "integer"
+                                            type: "array"
+                                        type: "object"
+                                    type: "object"
+                                  type: "array"
                                 securityContext:
                                   properties:
                                     allowPrivilegeEscalation:
@@ -2947,6 +3066,8 @@ spec:
                             type: "boolean"
                           hostname:
                             type: "string"
+                          hostnameOverride:
+                            type: "string"
                           imagePullSecrets:
                             items:
                               properties:
@@ -2988,6 +3109,17 @@ spec:
                                               apiVersion:
                                                 type: "string"
                                               fieldPath:
+                                                type: "string"
+                                            type: "object"
+                                          fileKeyRef:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              optional:
+                                                type: "boolean"
+                                              path:
+                                                type: "string"
+                                              volumeName:
                                                 type: "string"
                                             type: "object"
                                           resourceFieldRef:
@@ -3318,6 +3450,22 @@ spec:
                                   type: "object"
                                 restartPolicy:
                                   type: "string"
+                                restartPolicyRules:
+                                  items:
+                                    properties:
+                                      action:
+                                        type: "string"
+                                      exitCodes:
+                                        properties:
+                                          operator:
+                                            type: "string"
+                                          values:
+                                            items:
+                                              type: "integer"
+                                            type: "array"
+                                        type: "object"
+                                    type: "object"
+                                  type: "array"
                                 securityContext:
                                   properties:
                                     allowPrivilegeEscalation:
@@ -4239,6 +4387,21 @@ spec:
                                                   type: "object"
                                                 type: "array"
                                             type: "object"
+                                          podCertificate:
+                                            properties:
+                                              certificateChainPath:
+                                                type: "string"
+                                              credentialBundlePath:
+                                                type: "string"
+                                              keyPath:
+                                                type: "string"
+                                              keyType:
+                                                type: "string"
+                                              maxExpirationSeconds:
+                                                type: "integer"
+                                              signerName:
+                                                type: "string"
+                                            type: "object"
                                           secret:
                                             properties:
                                               items:
@@ -4389,6 +4552,12 @@ spec:
               update:
                 description: "Configuration related to Keycloak deployment updates."
                 properties:
+                  labels:
+                    additionalProperties:
+                      type: "string"
+                    description: "Optionally set to add additional labels to the Job\
+                      \ created for the update."
+                    type: "object"
                   revision:
                     description: "When use the Explicit strategy, the revision signals\
                       \ if a rolling update can be used or not."
@@ -4825,6 +4994,4995 @@ spec:
         type: "object"
     served: true
     storage: true
+    subresources:
+      scale:
+        labelSelectorPath: ".status.selector"
+        specReplicasPath: ".spec.instances"
+        statusReplicasPath: ".status.instances"
+      status: {}
+  - deprecated: true
+    deprecationWarning: "Please migrate to v2beta1"
+    name: "v2alpha1"
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              additionalOptions:
+                description: |-
+                  Configuration of the Keycloak server.
+                  expressed as a keys (reference: https://www.keycloak.org/server/all-config) and values that can be either direct values or references to secrets.
+                items:
+                  properties:
+                    name:
+                      type: "string"
+                    secret:
+                      properties:
+                        key:
+                          type: "string"
+                        name:
+                          type: "string"
+                        optional:
+                          type: "boolean"
+                      type: "object"
+                    value:
+                      type: "string"
+                  type: "object"
+                type: "array"
+              admin:
+                description: "In this section you can find all properties related\
+                  \ to making admin connections from the operator to the server. These\
+                  \ settings are not used by the server."
+                properties:
+                  tlsSecret:
+                    description: "If mTLS is required, this references a secret containing\
+                      \ the client TLS configuration for the admin client. Reference:\
+                      \ https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets."
+                    type: "string"
+                type: "object"
+              automountServiceAccountToken:
+                description: "Set this to to false to disable automounting the default\
+                  \ ServiceAccount Token and Service CA. This is enabled by default."
+                type: "boolean"
+              bootstrapAdmin:
+                description: "In this section you can configure Keycloak's bootstrap\
+                  \ admin - will be used only for initial cluster creation."
+                properties:
+                  service:
+                    description: "Configures the bootstrap admin service account"
+                    properties:
+                      secret:
+                        description: "Name of the Secret that contains the client-id\
+                          \ and client-secret keys"
+                        type: "string"
+                    type: "object"
+                  user:
+                    description: "Configures the bootstrap admin user"
+                    properties:
+                      secret:
+                        description: "Name of the Secret that contains the username\
+                          \ and password keys"
+                        type: "string"
+                    type: "object"
+                type: "object"
+              cache:
+                description: "In this section you can configure Keycloak's cache"
+                properties:
+                  configMapFile:
+                    properties:
+                      key:
+                        type: "string"
+                      name:
+                        type: "string"
+                      optional:
+                        type: "boolean"
+                    type: "object"
+                type: "object"
+              db:
+                description: "In this section you can find all properties related\
+                  \ to connect to a database."
+                properties:
+                  database:
+                    description: "Sets the database name of the default JDBC URL of\
+                      \ the chosen vendor. If the `url` option is set, this option\
+                      \ is ignored."
+                    type: "string"
+                  host:
+                    description: "Sets the hostname of the default JDBC URL of the\
+                      \ chosen vendor. If the `url` option is set, this option is\
+                      \ ignored."
+                    type: "string"
+                  passwordSecret:
+                    description: "The reference to a secret holding the password of\
+                      \ the database user."
+                    properties:
+                      key:
+                        type: "string"
+                      name:
+                        type: "string"
+                      optional:
+                        type: "boolean"
+                    type: "object"
+                  poolInitialSize:
+                    description: "The initial size of the connection pool."
+                    type: "integer"
+                  poolMaxSize:
+                    description: "The maximum size of the connection pool."
+                    type: "integer"
+                  poolMinSize:
+                    description: "The minimal size of the connection pool."
+                    type: "integer"
+                  port:
+                    description: "Sets the port of the default JDBC URL of the chosen\
+                      \ vendor. If the `url` option is set, this option is ignored."
+                    type: "integer"
+                  schema:
+                    description: "The database schema to be used."
+                    type: "string"
+                  url:
+                    description: "The full database JDBC URL. If not provided, a default\
+                      \ URL is set based on the selected database vendor. For instance,\
+                      \ if using 'postgres', the default JDBC URL would be 'jdbc:postgresql://localhost/keycloak'. "
+                    type: "string"
+                  usernameSecret:
+                    description: "The reference to a secret holding the username of\
+                      \ the database user."
+                    properties:
+                      key:
+                        type: "string"
+                      name:
+                        type: "string"
+                      optional:
+                        type: "boolean"
+                    type: "object"
+                  vendor:
+                    description: "The database vendor."
+                    type: "string"
+                type: "object"
+              env:
+                description: |-
+                  Environment variables for the Keycloak server.
+                  Values can be either direct values or references to secrets. Use additionalOptions for first-class options rather than KC_ values here.
+                items:
+                  properties:
+                    name:
+                      type: "string"
+                    secret:
+                      properties:
+                        key:
+                          type: "string"
+                        name:
+                          type: "string"
+                        optional:
+                          type: "boolean"
+                      type: "object"
+                    value:
+                      type: "string"
+                  type: "object"
+                type: "array"
+              features:
+                description: "In this section you can configure Keycloak features,\
+                  \ which should be enabled/disabled."
+                properties:
+                  disabled:
+                    description: "Disabled Keycloak features"
+                    items:
+                      type: "string"
+                    type: "array"
+                  enabled:
+                    description: "Enabled Keycloak features"
+                    items:
+                      type: "string"
+                    type: "array"
+                type: "object"
+              hostname:
+                description: "In this section you can configure Keycloak hostname\
+                  \ and related properties."
+                properties:
+                  admin:
+                    description: "The hostname for accessing the administration console.\
+                      \ Applicable for Hostname v1 and v2."
+                    type: "string"
+                  adminUrl:
+                    description: "DEPRECATED. Sets the base URL for accessing the\
+                      \ administration console, including scheme, host, port and path.\
+                      \ Applicable for Hostname v1."
+                    type: "string"
+                  backchannelDynamic:
+                    description: "Enables dynamic resolving of backchannel URLs, including\
+                      \ hostname, scheme, port and context path. Set to true if your\
+                      \ application accesses Keycloak via a private network. Applicable\
+                      \ for Hostname v2."
+                    type: "boolean"
+                  hostname:
+                    description: "Hostname for the Keycloak server. Applicable for\
+                      \ Hostname v1 and v2."
+                    type: "string"
+                  strict:
+                    description: "Disables dynamically resolving the hostname from\
+                      \ request headers. Applicable for Hostname v1 and v2."
+                    type: "boolean"
+                  strictBackchannel:
+                    description: "DEPRECATED. By default backchannel URLs are dynamically\
+                      \ resolved from request headers to allow internal and external\
+                      \ applications. Applicable for Hostname v1."
+                    type: "boolean"
+                type: "object"
+              http:
+                description: "In this section you can configure Keycloak features\
+                  \ related to HTTP and HTTPS"
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: "string"
+                    description: "Annotations to be appended to the Service object"
+                    type: "object"
+                  httpEnabled:
+                    description: "Enables the HTTP listener."
+                    type: "boolean"
+                  httpPort:
+                    description: "The used HTTP port."
+                    type: "integer"
+                  httpsPort:
+                    description: "The used HTTPS port."
+                    type: "integer"
+                  labels:
+                    additionalProperties:
+                      type: "string"
+                    description: "Labels to be appended to the Service object"
+                    type: "object"
+                  serviceHttpPort:
+                    description: "The HTTP port exposed on the Kubernetes Service.\
+                      \ When set, the Service will use this port while the pod still\
+                      \ listens on httpPort."
+                    type: "integer"
+                  serviceHttpsPort:
+                    description: "The HTTPS port exposed on the Kubernetes Service.\
+                      \ When set, the Service will use this port while the pod still\
+                      \ listens on httpsPort."
+                    type: "integer"
+                  serviceName:
+                    description: "The name of the Kubernetes Service. When not set,\
+                      \ the name defaults to the Keycloak CR name with a \"-service\"\
+                      \ suffix."
+                    type: "string"
+                  tlsSecret:
+                    description: "A secret containing the TLS configuration for HTTPS.\
+                      \ Reference: https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets."
+                    type: "string"
+                type: "object"
+              httpManagement:
+                description: "In this section you can configure Keycloak's management\
+                  \ interface setting."
+                properties:
+                  port:
+                    description: "Port of the management interface."
+                    type: "integer"
+                type: "object"
+              image:
+                description: "Custom Keycloak image to be used."
+                type: "string"
+              imagePullSecrets:
+                description: "Secret(s) that might be used when pulling an image from\
+                  \ a private container image registry or repository."
+                items:
+                  properties:
+                    name:
+                      type: "string"
+                  type: "object"
+                type: "array"
+              import:
+                description: "In this section you can configure import Jobs"
+                properties:
+                  scheduling:
+                    description: "In this section you can configure import jobs scheduling"
+                    properties:
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                      type: "object"
+                                    weight:
+                                      type: "integer"
+                                  type: "object"
+                                type: "array"
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                      type: "object"
+                                    type: "array"
+                                type: "object"
+                            type: "object"
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: "string"
+                                                  operator:
+                                                    type: "string"
+                                                  values:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                type: "object"
+                                              type: "array"
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: "string"
+                                              type: "object"
+                                          type: "object"
+                                        matchLabelKeys:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: "string"
+                                                  operator:
+                                                    type: "string"
+                                                  values:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                type: "object"
+                                              type: "array"
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: "string"
+                                              type: "object"
+                                          type: "object"
+                                        namespaces:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        topologyKey:
+                                          type: "string"
+                                      type: "object"
+                                    weight:
+                                      type: "integer"
+                                  type: "object"
+                                type: "array"
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: "string"
+                                          type: "object"
+                                      type: "object"
+                                    matchLabelKeys:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: "string"
+                                          type: "object"
+                                      type: "object"
+                                    namespaces:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    topologyKey:
+                                      type: "string"
+                                  type: "object"
+                                type: "array"
+                            type: "object"
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: "string"
+                                                  operator:
+                                                    type: "string"
+                                                  values:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                type: "object"
+                                              type: "array"
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: "string"
+                                              type: "object"
+                                          type: "object"
+                                        matchLabelKeys:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: "string"
+                                                  operator:
+                                                    type: "string"
+                                                  values:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                type: "object"
+                                              type: "array"
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: "string"
+                                              type: "object"
+                                          type: "object"
+                                        namespaces:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        topologyKey:
+                                          type: "string"
+                                      type: "object"
+                                    weight:
+                                      type: "integer"
+                                  type: "object"
+                                type: "array"
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: "string"
+                                          type: "object"
+                                      type: "object"
+                                    matchLabelKeys:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: "string"
+                                          type: "object"
+                                      type: "object"
+                                    namespaces:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    topologyKey:
+                                      type: "string"
+                                  type: "object"
+                                type: "array"
+                            type: "object"
+                        type: "object"
+                      priorityClassName:
+                        type: "string"
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: "string"
+                            key:
+                              type: "string"
+                            operator:
+                              type: "string"
+                            tolerationSeconds:
+                              type: "integer"
+                            value:
+                              type: "string"
+                          type: "object"
+                        type: "array"
+                      topologySpreadConstraints:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: "string"
+                                      operator:
+                                        type: "string"
+                                      values:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                    type: "object"
+                                  type: "array"
+                                matchLabels:
+                                  additionalProperties:
+                                    type: "string"
+                                  type: "object"
+                              type: "object"
+                            matchLabelKeys:
+                              items:
+                                type: "string"
+                              type: "array"
+                            maxSkew:
+                              type: "integer"
+                            minDomains:
+                              type: "integer"
+                            nodeAffinityPolicy:
+                              type: "string"
+                            nodeTaintsPolicy:
+                              type: "string"
+                            topologyKey:
+                              type: "string"
+                            whenUnsatisfiable:
+                              type: "string"
+                          type: "object"
+                        type: "array"
+                    type: "object"
+                type: "object"
+              ingress:
+                description: |-
+                  The deployment is, by default, exposed through a basic ingress.
+                  You can change this behaviour by setting the enabled property to false.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: "string"
+                    description: "Additional annotations to be appended to the Ingress\
+                      \ object"
+                    type: "object"
+                  className:
+                    type: "string"
+                  enabled:
+                    type: "boolean"
+                  labels:
+                    additionalProperties:
+                      type: "string"
+                    description: "Additional labels to be appended to the Ingress\
+                      \ object"
+                    type: "object"
+                  tlsSecret:
+                    description: "A secret containing the TLS configuration for re-encrypt\
+                      \ or TLS termination scenarios. Reference: https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets."
+                    type: "string"
+                type: "object"
+              instances:
+                description: "Number of Keycloak instances. Default is 1."
+                type: "integer"
+              livenessProbe:
+                description: "Configuration for liveness probe, by default it is 10\
+                  \ for periodSeconds and 3 for failureThreshold"
+                properties:
+                  failureThreshold:
+                    type: "integer"
+                  periodSeconds:
+                    type: "integer"
+                type: "object"
+              networkPolicy:
+                description: "Controls the ingress traffic flow into Keycloak pods."
+                properties:
+                  enabled:
+                    default: true
+                    description: "Enables or disables the ingress traffic control."
+                    type: "boolean"
+                  http:
+                    description: "A list of sources which should be able to access\
+                      \ this endpoint. Items in this list are combined using a logical\
+                      \ OR operation. If this field is empty or missing, this rule\
+                      \ matches all sources (traffic not restricted by source). If\
+                      \ this field is present and contains at least one item, this\
+                      \ rule allows traffic only if the traffic matches at least one\
+                      \ item in the from list."
+                    items:
+                      properties:
+                        ipBlock:
+                          properties:
+                            cidr:
+                              type: "string"
+                            except:
+                              items:
+                                type: "string"
+                              type: "array"
+                          type: "object"
+                        namespaceSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: "string"
+                                  operator:
+                                    type: "string"
+                                  values:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              type: "array"
+                            matchLabels:
+                              additionalProperties:
+                                type: "string"
+                              type: "object"
+                          type: "object"
+                        podSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: "string"
+                                  operator:
+                                    type: "string"
+                                  values:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              type: "array"
+                            matchLabels:
+                              additionalProperties:
+                                type: "string"
+                              type: "object"
+                          type: "object"
+                      type: "object"
+                    type: "array"
+                  https:
+                    description: "A list of sources which should be able to access\
+                      \ this endpoint. Items in this list are combined using a logical\
+                      \ OR operation. If this field is empty or missing, this rule\
+                      \ matches all sources (traffic not restricted by source). If\
+                      \ this field is present and contains at least one item, this\
+                      \ rule allows traffic only if the traffic matches at least one\
+                      \ item in the from list."
+                    items:
+                      properties:
+                        ipBlock:
+                          properties:
+                            cidr:
+                              type: "string"
+                            except:
+                              items:
+                                type: "string"
+                              type: "array"
+                          type: "object"
+                        namespaceSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: "string"
+                                  operator:
+                                    type: "string"
+                                  values:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              type: "array"
+                            matchLabels:
+                              additionalProperties:
+                                type: "string"
+                              type: "object"
+                          type: "object"
+                        podSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: "string"
+                                  operator:
+                                    type: "string"
+                                  values:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              type: "array"
+                            matchLabels:
+                              additionalProperties:
+                                type: "string"
+                              type: "object"
+                          type: "object"
+                      type: "object"
+                    type: "array"
+                  management:
+                    description: "A list of sources which should be able to access\
+                      \ this endpoint. Items in this list are combined using a logical\
+                      \ OR operation. If this field is empty or missing, this rule\
+                      \ matches all sources (traffic not restricted by source). If\
+                      \ this field is present and contains at least one item, this\
+                      \ rule allows traffic only if the traffic matches at least one\
+                      \ item in the from list."
+                    items:
+                      properties:
+                        ipBlock:
+                          properties:
+                            cidr:
+                              type: "string"
+                            except:
+                              items:
+                                type: "string"
+                              type: "array"
+                          type: "object"
+                        namespaceSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: "string"
+                                  operator:
+                                    type: "string"
+                                  values:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              type: "array"
+                            matchLabels:
+                              additionalProperties:
+                                type: "string"
+                              type: "object"
+                          type: "object"
+                        podSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: "string"
+                                  operator:
+                                    type: "string"
+                                  values:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              type: "array"
+                            matchLabels:
+                              additionalProperties:
+                                type: "string"
+                              type: "object"
+                          type: "object"
+                      type: "object"
+                    type: "array"
+                type: "object"
+              proxy:
+                description: "In this section you can configure Keycloak's reverse\
+                  \ proxy setting"
+                properties:
+                  headers:
+                    description: "The proxy headers that should be accepted by the\
+                      \ server. Misconfiguration might leave the server exposed to\
+                      \ security vulnerabilities."
+                    type: "string"
+                type: "object"
+              readinessProbe:
+                description: "Configuration for readiness probe, by default it is\
+                  \ 10 for periodSeconds and 3 for failureThreshold"
+                properties:
+                  failureThreshold:
+                    type: "integer"
+                  periodSeconds:
+                    type: "integer"
+                type: "object"
+              resources:
+                description: "Compute Resources required by Keycloak container"
+                properties:
+                  claims:
+                    items:
+                      properties:
+                        name:
+                          type: "string"
+                        request:
+                          type: "string"
+                      type: "object"
+                    type: "array"
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: "integer"
+                      - type: "string"
+                      x-kubernetes-int-or-string: true
+                    type: "object"
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: "integer"
+                      - type: "string"
+                      x-kubernetes-int-or-string: true
+                    type: "object"
+                type: "object"
+              scheduling:
+                description: "In this section you can configure Keycloak's scheduling"
+                properties:
+                  affinity:
+                    properties:
+                      nodeAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                preference:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: "string"
+                                          operator:
+                                            type: "string"
+                                          values:
+                                            items:
+                                              type: "string"
+                                            type: "array"
+                                        type: "object"
+                                      type: "array"
+                                    matchFields:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: "string"
+                                          operator:
+                                            type: "string"
+                                          values:
+                                            items:
+                                              type: "string"
+                                            type: "array"
+                                        type: "object"
+                                      type: "array"
+                                  type: "object"
+                                weight:
+                                  type: "integer"
+                              type: "object"
+                            type: "array"
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            properties:
+                              nodeSelectorTerms:
+                                items:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: "string"
+                                          operator:
+                                            type: "string"
+                                          values:
+                                            items:
+                                              type: "string"
+                                            type: "array"
+                                        type: "object"
+                                      type: "array"
+                                    matchFields:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: "string"
+                                          operator:
+                                            type: "string"
+                                          values:
+                                            items:
+                                              type: "string"
+                                            type: "array"
+                                        type: "object"
+                                      type: "array"
+                                  type: "object"
+                                type: "array"
+                            type: "object"
+                        type: "object"
+                      podAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                podAffinityTerm:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: "string"
+                                          type: "object"
+                                      type: "object"
+                                    matchLabelKeys:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: "string"
+                                          type: "object"
+                                      type: "object"
+                                    namespaces:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    topologyKey:
+                                      type: "string"
+                                  type: "object"
+                                weight:
+                                  type: "integer"
+                              type: "object"
+                            type: "array"
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: "string"
+                                          operator:
+                                            type: "string"
+                                          values:
+                                            items:
+                                              type: "string"
+                                            type: "array"
+                                        type: "object"
+                                      type: "array"
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: "string"
+                                      type: "object"
+                                  type: "object"
+                                matchLabelKeys:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                mismatchLabelKeys:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                namespaceSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: "string"
+                                          operator:
+                                            type: "string"
+                                          values:
+                                            items:
+                                              type: "string"
+                                            type: "array"
+                                        type: "object"
+                                      type: "array"
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: "string"
+                                      type: "object"
+                                  type: "object"
+                                namespaces:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                topologyKey:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                        type: "object"
+                      podAntiAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                podAffinityTerm:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: "string"
+                                          type: "object"
+                                      type: "object"
+                                    matchLabelKeys:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: "string"
+                                          type: "object"
+                                      type: "object"
+                                    namespaces:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    topologyKey:
+                                      type: "string"
+                                  type: "object"
+                                weight:
+                                  type: "integer"
+                              type: "object"
+                            type: "array"
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: "string"
+                                          operator:
+                                            type: "string"
+                                          values:
+                                            items:
+                                              type: "string"
+                                            type: "array"
+                                        type: "object"
+                                      type: "array"
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: "string"
+                                      type: "object"
+                                  type: "object"
+                                matchLabelKeys:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                mismatchLabelKeys:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                namespaceSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: "string"
+                                          operator:
+                                            type: "string"
+                                          values:
+                                            items:
+                                              type: "string"
+                                            type: "array"
+                                        type: "object"
+                                      type: "array"
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: "string"
+                                      type: "object"
+                                  type: "object"
+                                namespaces:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                topologyKey:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                        type: "object"
+                    type: "object"
+                  priorityClassName:
+                    type: "string"
+                  tolerations:
+                    items:
+                      properties:
+                        effect:
+                          type: "string"
+                        key:
+                          type: "string"
+                        operator:
+                          type: "string"
+                        tolerationSeconds:
+                          type: "integer"
+                        value:
+                          type: "string"
+                      type: "object"
+                    type: "array"
+                  topologySpreadConstraints:
+                    items:
+                      properties:
+                        labelSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: "string"
+                                  operator:
+                                    type: "string"
+                                  values:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              type: "array"
+                            matchLabels:
+                              additionalProperties:
+                                type: "string"
+                              type: "object"
+                          type: "object"
+                        matchLabelKeys:
+                          items:
+                            type: "string"
+                          type: "array"
+                        maxSkew:
+                          type: "integer"
+                        minDomains:
+                          type: "integer"
+                        nodeAffinityPolicy:
+                          type: "string"
+                        nodeTaintsPolicy:
+                          type: "string"
+                        topologyKey:
+                          type: "string"
+                        whenUnsatisfiable:
+                          type: "string"
+                      type: "object"
+                    type: "array"
+                type: "object"
+              serviceMonitor:
+                description: "Configuration related to the generated ServiceMonitor"
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: "string"
+                    description: "Annotations to be appended to the Service object"
+                    type: "object"
+                  enabled:
+                    default: true
+                    description: "Enables or disables the creation of the ServiceMonitor."
+                    type: "boolean"
+                  interval:
+                    default: "30s"
+                    description: "Interval at which metrics should be scraped"
+                    type: "string"
+                  labels:
+                    additionalProperties:
+                      type: "string"
+                    description: "Labels to be appended to the Service object"
+                    type: "object"
+                  scrapeTimeout:
+                    default: "10s"
+                    description: "Timeout after which the scrape is ended"
+                    type: "string"
+                type: "object"
+              startOptimized:
+                description: "Set to force the behavior of the --optimized flag for\
+                  \ the start command. If left unspecified the operator will assume\
+                  \ custom images have already been augmented."
+                type: "boolean"
+              startupProbe:
+                description: "Configuration for startup probe, by default it is 1\
+                  \ for periodSeconds and 600 for failureThreshold"
+                properties:
+                  failureThreshold:
+                    type: "integer"
+                  periodSeconds:
+                    type: "integer"
+                type: "object"
+              telemetry:
+                description: "In this section you can configure general shared OpenTelemetry\
+                  \ settings for Keycloak."
+                properties:
+                  endpoint:
+                    description: "OpenTelemetry endpoint to connect to."
+                    type: "string"
+                  protocol:
+                    description: "OpenTelemetry protocol used for the telemetry data\
+                      \ (default 'grpc'). For more information, check the OpenTelemetry\
+                      \ guide."
+                    type: "string"
+                  resourceAttributes:
+                    additionalProperties:
+                      type: "string"
+                    description: "OpenTelemetry resource attributes present in the\
+                      \ exported telemetry data to characterize the telemetry producer."
+                    type: "object"
+                  serviceName:
+                    description: "OpenTelemetry service name. Takes precedence over\
+                      \ 'service.name' defined in the 'resourceAttributes' map."
+                    type: "string"
+                type: "object"
+              tracing:
+                description: "In this section you can configure OpenTelemetry Tracing\
+                  \ for Keycloak."
+                properties:
+                  compression:
+                    description: "OpenTelemetry compression method used to compress\
+                      \ payloads. If unset, compression is disabled. Possible values\
+                      \ are: gzip, none."
+                    type: "string"
+                  enabled:
+                    description: "Enables the OpenTelemetry tracing."
+                    type: "boolean"
+                  endpoint:
+                    description: "OpenTelemetry endpoint to connect to."
+                    type: "string"
+                  protocol:
+                    description: "OpenTelemetry protocol used for the telemetry data\
+                      \ (default 'grpc'). For more information, check the Tracing\
+                      \ guide."
+                    type: "string"
+                  resourceAttributes:
+                    additionalProperties:
+                      type: "string"
+                    description: "DEPRECATED - use the 'telemetry.resourceAttributes'\
+                      \ instead. OpenTelemetry resource attributes present in the\
+                      \ exported trace to characterize the telemetry producer."
+                    type: "object"
+                  samplerRatio:
+                    description: "OpenTelemetry sampler ratio. Probability that a\
+                      \ span will be sampled. Expected double value in interval [0,1]."
+                    type: "number"
+                  samplerType:
+                    description: "OpenTelemetry sampler to use for tracing (default\
+                      \ 'traceidratio'). For more information, check the Tracing guide."
+                    type: "string"
+                  serviceName:
+                    description: "DEPRECATED - use the 'telemetry.serviceName' instead.\
+                      \ OpenTelemetry service name. Takes precedence over 'service.name'\
+                      \ defined in the 'resourceAttributes' map."
+                    type: "string"
+                type: "object"
+              transaction:
+                description: "In this section you can find all properties related\
+                  \ to the settings of transaction behavior."
+                properties:
+                  xaEnabled:
+                    description: "Determine whether Keycloak should use a non-XA datasource\
+                      \ in case the database does not support XA transactions."
+                    type: "boolean"
+                type: "object"
+              truststores:
+                additionalProperties:
+                  properties:
+                    configMap:
+                      description: "The ConfigMap containing the trust material -\
+                        \ only set one of the other secret or configMap"
+                      properties:
+                        name:
+                          type: "string"
+                        optional:
+                          type: "boolean"
+                      required:
+                      - "name"
+                      type: "object"
+                    name:
+                      description: "Not used. To be removed in later versions."
+                      type: "string"
+                    secret:
+                      description: "The Secret containing the trust material - only\
+                        \ set one of the other secret or configMap"
+                      properties:
+                        name:
+                          type: "string"
+                        optional:
+                          type: "boolean"
+                      required:
+                      - "name"
+                      type: "object"
+                  type: "object"
+                description: "In this section you can configure Keycloak truststores."
+                type: "object"
+              unsupported:
+                description: |-
+                  In this section you can configure podTemplate advanced features, not production-ready, and not supported settings.
+                  Use at your own risk and open an issue with your use-case if you don't find an alternative way.
+                properties:
+                  podTemplate:
+                    description: |-
+                      You can configure that will be merged with the one configured by default by the operator.
+                      Use at your own risk, we reserve the possibility to remove/change the way any field gets merged in future releases without notice.
+                      Reference: https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: "string"
+                            type: "object"
+                          creationTimestamp:
+                            type: "string"
+                          deletionGracePeriodSeconds:
+                            type: "integer"
+                          deletionTimestamp:
+                            type: "string"
+                          finalizers:
+                            items:
+                              type: "string"
+                            type: "array"
+                          generateName:
+                            type: "string"
+                          generation:
+                            type: "integer"
+                          labels:
+                            additionalProperties:
+                              type: "string"
+                            type: "object"
+                          managedFields:
+                            items:
+                              properties:
+                                apiVersion:
+                                  type: "string"
+                                fieldsType:
+                                  type: "string"
+                                fieldsV1:
+                                  type: "object"
+                                manager:
+                                  type: "string"
+                                operation:
+                                  type: "string"
+                                subresource:
+                                  type: "string"
+                                time:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                          name:
+                            type: "string"
+                          namespace:
+                            type: "string"
+                          ownerReferences:
+                            items:
+                              properties:
+                                apiVersion:
+                                  type: "string"
+                                blockOwnerDeletion:
+                                  type: "boolean"
+                                controller:
+                                  type: "boolean"
+                                kind:
+                                  type: "string"
+                                name:
+                                  type: "string"
+                                uid:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                          resourceVersion:
+                            type: "string"
+                          selfLink:
+                            type: "string"
+                          uid:
+                            type: "string"
+                        type: "object"
+                      spec:
+                        properties:
+                          activeDeadlineSeconds:
+                            type: "integer"
+                          affinity:
+                            properties:
+                              nodeAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        preference:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: "string"
+                                                  operator:
+                                                    type: "string"
+                                                  values:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                type: "object"
+                                              type: "array"
+                                            matchFields:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: "string"
+                                                  operator:
+                                                    type: "string"
+                                                  values:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                type: "object"
+                                              type: "array"
+                                          type: "object"
+                                        weight:
+                                          type: "integer"
+                                      type: "object"
+                                    type: "array"
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    properties:
+                                      nodeSelectorTerms:
+                                        items:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: "string"
+                                                  operator:
+                                                    type: "string"
+                                                  values:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                type: "object"
+                                              type: "array"
+                                            matchFields:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: "string"
+                                                  operator:
+                                                    type: "string"
+                                                  values:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                type: "object"
+                                              type: "array"
+                                          type: "object"
+                                        type: "array"
+                                    type: "object"
+                                type: "object"
+                              podAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        podAffinityTerm:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: "string"
+                                                      operator:
+                                                        type: "string"
+                                                      values:
+                                                        items:
+                                                          type: "string"
+                                                        type: "array"
+                                                    type: "object"
+                                                  type: "array"
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: "string"
+                                                  type: "object"
+                                              type: "object"
+                                            matchLabelKeys:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: "string"
+                                                      operator:
+                                                        type: "string"
+                                                      values:
+                                                        items:
+                                                          type: "string"
+                                                        type: "array"
+                                                    type: "object"
+                                                  type: "array"
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: "string"
+                                                  type: "object"
+                                              type: "object"
+                                            namespaces:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                            topologyKey:
+                                              type: "string"
+                                          type: "object"
+                                        weight:
+                                          type: "integer"
+                                      type: "object"
+                                    type: "array"
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: "string"
+                                                  operator:
+                                                    type: "string"
+                                                  values:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                type: "object"
+                                              type: "array"
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: "string"
+                                              type: "object"
+                                          type: "object"
+                                        matchLabelKeys:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: "string"
+                                                  operator:
+                                                    type: "string"
+                                                  values:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                type: "object"
+                                              type: "array"
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: "string"
+                                              type: "object"
+                                          type: "object"
+                                        namespaces:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        topologyKey:
+                                          type: "string"
+                                      type: "object"
+                                    type: "array"
+                                type: "object"
+                              podAntiAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        podAffinityTerm:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: "string"
+                                                      operator:
+                                                        type: "string"
+                                                      values:
+                                                        items:
+                                                          type: "string"
+                                                        type: "array"
+                                                    type: "object"
+                                                  type: "array"
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: "string"
+                                                  type: "object"
+                                              type: "object"
+                                            matchLabelKeys:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: "string"
+                                                      operator:
+                                                        type: "string"
+                                                      values:
+                                                        items:
+                                                          type: "string"
+                                                        type: "array"
+                                                    type: "object"
+                                                  type: "array"
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: "string"
+                                                  type: "object"
+                                              type: "object"
+                                            namespaces:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                            topologyKey:
+                                              type: "string"
+                                          type: "object"
+                                        weight:
+                                          type: "integer"
+                                      type: "object"
+                                    type: "array"
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: "string"
+                                                  operator:
+                                                    type: "string"
+                                                  values:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                type: "object"
+                                              type: "array"
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: "string"
+                                              type: "object"
+                                          type: "object"
+                                        matchLabelKeys:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: "string"
+                                                  operator:
+                                                    type: "string"
+                                                  values:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                type: "object"
+                                              type: "array"
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: "string"
+                                              type: "object"
+                                          type: "object"
+                                        namespaces:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        topologyKey:
+                                          type: "string"
+                                      type: "object"
+                                    type: "array"
+                                type: "object"
+                            type: "object"
+                          automountServiceAccountToken:
+                            type: "boolean"
+                          containers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                command:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: "string"
+                                      value:
+                                        type: "string"
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              name:
+                                                type: "string"
+                                              optional:
+                                                type: "boolean"
+                                            type: "object"
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: "string"
+                                              fieldPath:
+                                                type: "string"
+                                            type: "object"
+                                          fileKeyRef:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              optional:
+                                                type: "boolean"
+                                              path:
+                                                type: "string"
+                                              volumeName:
+                                                type: "string"
+                                            type: "object"
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: "string"
+                                              divisor:
+                                                anyOf:
+                                                - type: "integer"
+                                                - type: "string"
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: "string"
+                                            type: "object"
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              name:
+                                                type: "string"
+                                              optional:
+                                                type: "boolean"
+                                            type: "object"
+                                        type: "object"
+                                    type: "object"
+                                  type: "array"
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            type: "string"
+                                          optional:
+                                            type: "boolean"
+                                        type: "object"
+                                      prefix:
+                                        type: "string"
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: "string"
+                                          optional:
+                                            type: "boolean"
+                                        type: "object"
+                                    type: "object"
+                                  type: "array"
+                                image:
+                                  type: "string"
+                                imagePullPolicy:
+                                  type: "string"
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                          type: "object"
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: "string"
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: "string"
+                                                  value:
+                                                    type: "string"
+                                                type: "object"
+                                              type: "array"
+                                            path:
+                                              type: "string"
+                                            port:
+                                              anyOf:
+                                              - type: "integer"
+                                              - type: "string"
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: "string"
+                                          type: "object"
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: "integer"
+                                          type: "object"
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: "string"
+                                            port:
+                                              anyOf:
+                                              - type: "integer"
+                                              - type: "string"
+                                              x-kubernetes-int-or-string: true
+                                          type: "object"
+                                      type: "object"
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                          type: "object"
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: "string"
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: "string"
+                                                  value:
+                                                    type: "string"
+                                                type: "object"
+                                              type: "array"
+                                            path:
+                                              type: "string"
+                                            port:
+                                              anyOf:
+                                              - type: "integer"
+                                              - type: "string"
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: "string"
+                                          type: "object"
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: "integer"
+                                          type: "object"
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: "string"
+                                            port:
+                                              anyOf:
+                                              - type: "integer"
+                                              - type: "string"
+                                              x-kubernetes-int-or-string: true
+                                          type: "object"
+                                      type: "object"
+                                    stopSignal:
+                                      type: "string"
+                                  type: "object"
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                      type: "object"
+                                    failureThreshold:
+                                      type: "integer"
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: "integer"
+                                        service:
+                                          type: "string"
+                                      type: "object"
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: "string"
+                                              value:
+                                                type: "string"
+                                            type: "object"
+                                          type: "array"
+                                        path:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: "string"
+                                      type: "object"
+                                    initialDelaySeconds:
+                                      type: "integer"
+                                    periodSeconds:
+                                      type: "integer"
+                                    successThreshold:
+                                      type: "integer"
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                      type: "object"
+                                    terminationGracePeriodSeconds:
+                                      type: "integer"
+                                    timeoutSeconds:
+                                      type: "integer"
+                                  type: "object"
+                                name:
+                                  type: "string"
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        type: "integer"
+                                      hostIP:
+                                        type: "string"
+                                      hostPort:
+                                        type: "integer"
+                                      name:
+                                        type: "string"
+                                      protocol:
+                                        type: "string"
+                                    type: "object"
+                                  type: "array"
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                      type: "object"
+                                    failureThreshold:
+                                      type: "integer"
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: "integer"
+                                        service:
+                                          type: "string"
+                                      type: "object"
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: "string"
+                                              value:
+                                                type: "string"
+                                            type: "object"
+                                          type: "array"
+                                        path:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: "string"
+                                      type: "object"
+                                    initialDelaySeconds:
+                                      type: "integer"
+                                    periodSeconds:
+                                      type: "integer"
+                                    successThreshold:
+                                      type: "integer"
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                      type: "object"
+                                    terminationGracePeriodSeconds:
+                                      type: "integer"
+                                    timeoutSeconds:
+                                      type: "integer"
+                                  type: "object"
+                                resizePolicy:
+                                  items:
+                                    properties:
+                                      resourceName:
+                                        type: "string"
+                                      restartPolicy:
+                                        type: "string"
+                                    type: "object"
+                                  type: "array"
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: "string"
+                                          request:
+                                            type: "string"
+                                        type: "object"
+                                      type: "array"
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: "integer"
+                                        - type: "string"
+                                        x-kubernetes-int-or-string: true
+                                      type: "object"
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: "integer"
+                                        - type: "string"
+                                        x-kubernetes-int-or-string: true
+                                      type: "object"
+                                  type: "object"
+                                restartPolicy:
+                                  type: "string"
+                                restartPolicyRules:
+                                  items:
+                                    properties:
+                                      action:
+                                        type: "string"
+                                      exitCodes:
+                                        properties:
+                                          operator:
+                                            type: "string"
+                                          values:
+                                            items:
+                                              type: "integer"
+                                            type: "array"
+                                        type: "object"
+                                    type: "object"
+                                  type: "array"
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: "boolean"
+                                    appArmorProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: "string"
+                                        type:
+                                          type: "string"
+                                      type: "object"
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        drop:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                      type: "object"
+                                    privileged:
+                                      type: "boolean"
+                                    procMount:
+                                      type: "string"
+                                    readOnlyRootFilesystem:
+                                      type: "boolean"
+                                    runAsGroup:
+                                      type: "integer"
+                                    runAsNonRoot:
+                                      type: "boolean"
+                                    runAsUser:
+                                      type: "integer"
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: "string"
+                                        role:
+                                          type: "string"
+                                        type:
+                                          type: "string"
+                                        user:
+                                          type: "string"
+                                      type: "object"
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: "string"
+                                        type:
+                                          type: "string"
+                                      type: "object"
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: "string"
+                                        gmsaCredentialSpecName:
+                                          type: "string"
+                                        hostProcess:
+                                          type: "boolean"
+                                        runAsUserName:
+                                          type: "string"
+                                      type: "object"
+                                  type: "object"
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                      type: "object"
+                                    failureThreshold:
+                                      type: "integer"
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: "integer"
+                                        service:
+                                          type: "string"
+                                      type: "object"
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: "string"
+                                              value:
+                                                type: "string"
+                                            type: "object"
+                                          type: "array"
+                                        path:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: "string"
+                                      type: "object"
+                                    initialDelaySeconds:
+                                      type: "integer"
+                                    periodSeconds:
+                                      type: "integer"
+                                    successThreshold:
+                                      type: "integer"
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                      type: "object"
+                                    terminationGracePeriodSeconds:
+                                      type: "integer"
+                                    timeoutSeconds:
+                                      type: "integer"
+                                  type: "object"
+                                stdin:
+                                  type: "boolean"
+                                stdinOnce:
+                                  type: "boolean"
+                                terminationMessagePath:
+                                  type: "string"
+                                terminationMessagePolicy:
+                                  type: "string"
+                                tty:
+                                  type: "boolean"
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: "string"
+                                      name:
+                                        type: "string"
+                                    type: "object"
+                                  type: "array"
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: "string"
+                                      mountPropagation:
+                                        type: "string"
+                                      name:
+                                        type: "string"
+                                      readOnly:
+                                        type: "boolean"
+                                      recursiveReadOnly:
+                                        type: "string"
+                                      subPath:
+                                        type: "string"
+                                      subPathExpr:
+                                        type: "string"
+                                    type: "object"
+                                  type: "array"
+                                workingDir:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                          dnsConfig:
+                            properties:
+                              nameservers:
+                                items:
+                                  type: "string"
+                                type: "array"
+                              options:
+                                items:
+                                  properties:
+                                    name:
+                                      type: "string"
+                                    value:
+                                      type: "string"
+                                  type: "object"
+                                type: "array"
+                              searches:
+                                items:
+                                  type: "string"
+                                type: "array"
+                            type: "object"
+                          dnsPolicy:
+                            type: "string"
+                          enableServiceLinks:
+                            type: "boolean"
+                          ephemeralContainers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                command:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: "string"
+                                      value:
+                                        type: "string"
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              name:
+                                                type: "string"
+                                              optional:
+                                                type: "boolean"
+                                            type: "object"
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: "string"
+                                              fieldPath:
+                                                type: "string"
+                                            type: "object"
+                                          fileKeyRef:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              optional:
+                                                type: "boolean"
+                                              path:
+                                                type: "string"
+                                              volumeName:
+                                                type: "string"
+                                            type: "object"
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: "string"
+                                              divisor:
+                                                anyOf:
+                                                - type: "integer"
+                                                - type: "string"
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: "string"
+                                            type: "object"
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              name:
+                                                type: "string"
+                                              optional:
+                                                type: "boolean"
+                                            type: "object"
+                                        type: "object"
+                                    type: "object"
+                                  type: "array"
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            type: "string"
+                                          optional:
+                                            type: "boolean"
+                                        type: "object"
+                                      prefix:
+                                        type: "string"
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: "string"
+                                          optional:
+                                            type: "boolean"
+                                        type: "object"
+                                    type: "object"
+                                  type: "array"
+                                image:
+                                  type: "string"
+                                imagePullPolicy:
+                                  type: "string"
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                          type: "object"
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: "string"
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: "string"
+                                                  value:
+                                                    type: "string"
+                                                type: "object"
+                                              type: "array"
+                                            path:
+                                              type: "string"
+                                            port:
+                                              anyOf:
+                                              - type: "integer"
+                                              - type: "string"
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: "string"
+                                          type: "object"
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: "integer"
+                                          type: "object"
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: "string"
+                                            port:
+                                              anyOf:
+                                              - type: "integer"
+                                              - type: "string"
+                                              x-kubernetes-int-or-string: true
+                                          type: "object"
+                                      type: "object"
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                          type: "object"
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: "string"
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: "string"
+                                                  value:
+                                                    type: "string"
+                                                type: "object"
+                                              type: "array"
+                                            path:
+                                              type: "string"
+                                            port:
+                                              anyOf:
+                                              - type: "integer"
+                                              - type: "string"
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: "string"
+                                          type: "object"
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: "integer"
+                                          type: "object"
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: "string"
+                                            port:
+                                              anyOf:
+                                              - type: "integer"
+                                              - type: "string"
+                                              x-kubernetes-int-or-string: true
+                                          type: "object"
+                                      type: "object"
+                                    stopSignal:
+                                      type: "string"
+                                  type: "object"
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                      type: "object"
+                                    failureThreshold:
+                                      type: "integer"
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: "integer"
+                                        service:
+                                          type: "string"
+                                      type: "object"
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: "string"
+                                              value:
+                                                type: "string"
+                                            type: "object"
+                                          type: "array"
+                                        path:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: "string"
+                                      type: "object"
+                                    initialDelaySeconds:
+                                      type: "integer"
+                                    periodSeconds:
+                                      type: "integer"
+                                    successThreshold:
+                                      type: "integer"
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                      type: "object"
+                                    terminationGracePeriodSeconds:
+                                      type: "integer"
+                                    timeoutSeconds:
+                                      type: "integer"
+                                  type: "object"
+                                name:
+                                  type: "string"
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        type: "integer"
+                                      hostIP:
+                                        type: "string"
+                                      hostPort:
+                                        type: "integer"
+                                      name:
+                                        type: "string"
+                                      protocol:
+                                        type: "string"
+                                    type: "object"
+                                  type: "array"
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                      type: "object"
+                                    failureThreshold:
+                                      type: "integer"
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: "integer"
+                                        service:
+                                          type: "string"
+                                      type: "object"
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: "string"
+                                              value:
+                                                type: "string"
+                                            type: "object"
+                                          type: "array"
+                                        path:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: "string"
+                                      type: "object"
+                                    initialDelaySeconds:
+                                      type: "integer"
+                                    periodSeconds:
+                                      type: "integer"
+                                    successThreshold:
+                                      type: "integer"
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                      type: "object"
+                                    terminationGracePeriodSeconds:
+                                      type: "integer"
+                                    timeoutSeconds:
+                                      type: "integer"
+                                  type: "object"
+                                resizePolicy:
+                                  items:
+                                    properties:
+                                      resourceName:
+                                        type: "string"
+                                      restartPolicy:
+                                        type: "string"
+                                    type: "object"
+                                  type: "array"
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: "string"
+                                          request:
+                                            type: "string"
+                                        type: "object"
+                                      type: "array"
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: "integer"
+                                        - type: "string"
+                                        x-kubernetes-int-or-string: true
+                                      type: "object"
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: "integer"
+                                        - type: "string"
+                                        x-kubernetes-int-or-string: true
+                                      type: "object"
+                                  type: "object"
+                                restartPolicy:
+                                  type: "string"
+                                restartPolicyRules:
+                                  items:
+                                    properties:
+                                      action:
+                                        type: "string"
+                                      exitCodes:
+                                        properties:
+                                          operator:
+                                            type: "string"
+                                          values:
+                                            items:
+                                              type: "integer"
+                                            type: "array"
+                                        type: "object"
+                                    type: "object"
+                                  type: "array"
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: "boolean"
+                                    appArmorProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: "string"
+                                        type:
+                                          type: "string"
+                                      type: "object"
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        drop:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                      type: "object"
+                                    privileged:
+                                      type: "boolean"
+                                    procMount:
+                                      type: "string"
+                                    readOnlyRootFilesystem:
+                                      type: "boolean"
+                                    runAsGroup:
+                                      type: "integer"
+                                    runAsNonRoot:
+                                      type: "boolean"
+                                    runAsUser:
+                                      type: "integer"
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: "string"
+                                        role:
+                                          type: "string"
+                                        type:
+                                          type: "string"
+                                        user:
+                                          type: "string"
+                                      type: "object"
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: "string"
+                                        type:
+                                          type: "string"
+                                      type: "object"
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: "string"
+                                        gmsaCredentialSpecName:
+                                          type: "string"
+                                        hostProcess:
+                                          type: "boolean"
+                                        runAsUserName:
+                                          type: "string"
+                                      type: "object"
+                                  type: "object"
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                      type: "object"
+                                    failureThreshold:
+                                      type: "integer"
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: "integer"
+                                        service:
+                                          type: "string"
+                                      type: "object"
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: "string"
+                                              value:
+                                                type: "string"
+                                            type: "object"
+                                          type: "array"
+                                        path:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: "string"
+                                      type: "object"
+                                    initialDelaySeconds:
+                                      type: "integer"
+                                    periodSeconds:
+                                      type: "integer"
+                                    successThreshold:
+                                      type: "integer"
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                      type: "object"
+                                    terminationGracePeriodSeconds:
+                                      type: "integer"
+                                    timeoutSeconds:
+                                      type: "integer"
+                                  type: "object"
+                                stdin:
+                                  type: "boolean"
+                                stdinOnce:
+                                  type: "boolean"
+                                targetContainerName:
+                                  type: "string"
+                                terminationMessagePath:
+                                  type: "string"
+                                terminationMessagePolicy:
+                                  type: "string"
+                                tty:
+                                  type: "boolean"
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: "string"
+                                      name:
+                                        type: "string"
+                                    type: "object"
+                                  type: "array"
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: "string"
+                                      mountPropagation:
+                                        type: "string"
+                                      name:
+                                        type: "string"
+                                      readOnly:
+                                        type: "boolean"
+                                      recursiveReadOnly:
+                                        type: "string"
+                                      subPath:
+                                        type: "string"
+                                      subPathExpr:
+                                        type: "string"
+                                    type: "object"
+                                  type: "array"
+                                workingDir:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                          hostAliases:
+                            items:
+                              properties:
+                                hostnames:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                ip:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                          hostIPC:
+                            type: "boolean"
+                          hostNetwork:
+                            type: "boolean"
+                          hostPID:
+                            type: "boolean"
+                          hostUsers:
+                            type: "boolean"
+                          hostname:
+                            type: "string"
+                          hostnameOverride:
+                            type: "string"
+                          imagePullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                          initContainers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                command:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: "string"
+                                      value:
+                                        type: "string"
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              name:
+                                                type: "string"
+                                              optional:
+                                                type: "boolean"
+                                            type: "object"
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: "string"
+                                              fieldPath:
+                                                type: "string"
+                                            type: "object"
+                                          fileKeyRef:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              optional:
+                                                type: "boolean"
+                                              path:
+                                                type: "string"
+                                              volumeName:
+                                                type: "string"
+                                            type: "object"
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: "string"
+                                              divisor:
+                                                anyOf:
+                                                - type: "integer"
+                                                - type: "string"
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: "string"
+                                            type: "object"
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              name:
+                                                type: "string"
+                                              optional:
+                                                type: "boolean"
+                                            type: "object"
+                                        type: "object"
+                                    type: "object"
+                                  type: "array"
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            type: "string"
+                                          optional:
+                                            type: "boolean"
+                                        type: "object"
+                                      prefix:
+                                        type: "string"
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: "string"
+                                          optional:
+                                            type: "boolean"
+                                        type: "object"
+                                    type: "object"
+                                  type: "array"
+                                image:
+                                  type: "string"
+                                imagePullPolicy:
+                                  type: "string"
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                          type: "object"
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: "string"
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: "string"
+                                                  value:
+                                                    type: "string"
+                                                type: "object"
+                                              type: "array"
+                                            path:
+                                              type: "string"
+                                            port:
+                                              anyOf:
+                                              - type: "integer"
+                                              - type: "string"
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: "string"
+                                          type: "object"
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: "integer"
+                                          type: "object"
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: "string"
+                                            port:
+                                              anyOf:
+                                              - type: "integer"
+                                              - type: "string"
+                                              x-kubernetes-int-or-string: true
+                                          type: "object"
+                                      type: "object"
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                          type: "object"
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: "string"
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: "string"
+                                                  value:
+                                                    type: "string"
+                                                type: "object"
+                                              type: "array"
+                                            path:
+                                              type: "string"
+                                            port:
+                                              anyOf:
+                                              - type: "integer"
+                                              - type: "string"
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: "string"
+                                          type: "object"
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: "integer"
+                                          type: "object"
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: "string"
+                                            port:
+                                              anyOf:
+                                              - type: "integer"
+                                              - type: "string"
+                                              x-kubernetes-int-or-string: true
+                                          type: "object"
+                                      type: "object"
+                                    stopSignal:
+                                      type: "string"
+                                  type: "object"
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                      type: "object"
+                                    failureThreshold:
+                                      type: "integer"
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: "integer"
+                                        service:
+                                          type: "string"
+                                      type: "object"
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: "string"
+                                              value:
+                                                type: "string"
+                                            type: "object"
+                                          type: "array"
+                                        path:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: "string"
+                                      type: "object"
+                                    initialDelaySeconds:
+                                      type: "integer"
+                                    periodSeconds:
+                                      type: "integer"
+                                    successThreshold:
+                                      type: "integer"
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                      type: "object"
+                                    terminationGracePeriodSeconds:
+                                      type: "integer"
+                                    timeoutSeconds:
+                                      type: "integer"
+                                  type: "object"
+                                name:
+                                  type: "string"
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        type: "integer"
+                                      hostIP:
+                                        type: "string"
+                                      hostPort:
+                                        type: "integer"
+                                      name:
+                                        type: "string"
+                                      protocol:
+                                        type: "string"
+                                    type: "object"
+                                  type: "array"
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                      type: "object"
+                                    failureThreshold:
+                                      type: "integer"
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: "integer"
+                                        service:
+                                          type: "string"
+                                      type: "object"
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: "string"
+                                              value:
+                                                type: "string"
+                                            type: "object"
+                                          type: "array"
+                                        path:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: "string"
+                                      type: "object"
+                                    initialDelaySeconds:
+                                      type: "integer"
+                                    periodSeconds:
+                                      type: "integer"
+                                    successThreshold:
+                                      type: "integer"
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                      type: "object"
+                                    terminationGracePeriodSeconds:
+                                      type: "integer"
+                                    timeoutSeconds:
+                                      type: "integer"
+                                  type: "object"
+                                resizePolicy:
+                                  items:
+                                    properties:
+                                      resourceName:
+                                        type: "string"
+                                      restartPolicy:
+                                        type: "string"
+                                    type: "object"
+                                  type: "array"
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: "string"
+                                          request:
+                                            type: "string"
+                                        type: "object"
+                                      type: "array"
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: "integer"
+                                        - type: "string"
+                                        x-kubernetes-int-or-string: true
+                                      type: "object"
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: "integer"
+                                        - type: "string"
+                                        x-kubernetes-int-or-string: true
+                                      type: "object"
+                                  type: "object"
+                                restartPolicy:
+                                  type: "string"
+                                restartPolicyRules:
+                                  items:
+                                    properties:
+                                      action:
+                                        type: "string"
+                                      exitCodes:
+                                        properties:
+                                          operator:
+                                            type: "string"
+                                          values:
+                                            items:
+                                              type: "integer"
+                                            type: "array"
+                                        type: "object"
+                                    type: "object"
+                                  type: "array"
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: "boolean"
+                                    appArmorProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: "string"
+                                        type:
+                                          type: "string"
+                                      type: "object"
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        drop:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                      type: "object"
+                                    privileged:
+                                      type: "boolean"
+                                    procMount:
+                                      type: "string"
+                                    readOnlyRootFilesystem:
+                                      type: "boolean"
+                                    runAsGroup:
+                                      type: "integer"
+                                    runAsNonRoot:
+                                      type: "boolean"
+                                    runAsUser:
+                                      type: "integer"
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: "string"
+                                        role:
+                                          type: "string"
+                                        type:
+                                          type: "string"
+                                        user:
+                                          type: "string"
+                                      type: "object"
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: "string"
+                                        type:
+                                          type: "string"
+                                      type: "object"
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: "string"
+                                        gmsaCredentialSpecName:
+                                          type: "string"
+                                        hostProcess:
+                                          type: "boolean"
+                                        runAsUserName:
+                                          type: "string"
+                                      type: "object"
+                                  type: "object"
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                      type: "object"
+                                    failureThreshold:
+                                      type: "integer"
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: "integer"
+                                        service:
+                                          type: "string"
+                                      type: "object"
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: "string"
+                                              value:
+                                                type: "string"
+                                            type: "object"
+                                          type: "array"
+                                        path:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: "string"
+                                      type: "object"
+                                    initialDelaySeconds:
+                                      type: "integer"
+                                    periodSeconds:
+                                      type: "integer"
+                                    successThreshold:
+                                      type: "integer"
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: "string"
+                                        port:
+                                          anyOf:
+                                          - type: "integer"
+                                          - type: "string"
+                                          x-kubernetes-int-or-string: true
+                                      type: "object"
+                                    terminationGracePeriodSeconds:
+                                      type: "integer"
+                                    timeoutSeconds:
+                                      type: "integer"
+                                  type: "object"
+                                stdin:
+                                  type: "boolean"
+                                stdinOnce:
+                                  type: "boolean"
+                                terminationMessagePath:
+                                  type: "string"
+                                terminationMessagePolicy:
+                                  type: "string"
+                                tty:
+                                  type: "boolean"
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: "string"
+                                      name:
+                                        type: "string"
+                                    type: "object"
+                                  type: "array"
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: "string"
+                                      mountPropagation:
+                                        type: "string"
+                                      name:
+                                        type: "string"
+                                      readOnly:
+                                        type: "boolean"
+                                      recursiveReadOnly:
+                                        type: "string"
+                                      subPath:
+                                        type: "string"
+                                      subPathExpr:
+                                        type: "string"
+                                    type: "object"
+                                  type: "array"
+                                workingDir:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                          nodeName:
+                            type: "string"
+                          nodeSelector:
+                            additionalProperties:
+                              type: "string"
+                            type: "object"
+                          os:
+                            properties:
+                              name:
+                                type: "string"
+                            type: "object"
+                          overhead:
+                            additionalProperties:
+                              anyOf:
+                              - type: "integer"
+                              - type: "string"
+                              x-kubernetes-int-or-string: true
+                            type: "object"
+                          preemptionPolicy:
+                            type: "string"
+                          priority:
+                            type: "integer"
+                          priorityClassName:
+                            type: "string"
+                          readinessGates:
+                            items:
+                              properties:
+                                conditionType:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                          resourceClaims:
+                            items:
+                              properties:
+                                name:
+                                  type: "string"
+                                resourceClaimName:
+                                  type: "string"
+                                resourceClaimTemplateName:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                          resources:
+                            properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: "string"
+                                    request:
+                                      type: "string"
+                                  type: "object"
+                                type: "array"
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: "integer"
+                                  - type: "string"
+                                  x-kubernetes-int-or-string: true
+                                type: "object"
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: "integer"
+                                  - type: "string"
+                                  x-kubernetes-int-or-string: true
+                                type: "object"
+                            type: "object"
+                          restartPolicy:
+                            type: "string"
+                          runtimeClassName:
+                            type: "string"
+                          schedulerName:
+                            type: "string"
+                          schedulingGates:
+                            items:
+                              properties:
+                                name:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                          securityContext:
+                            properties:
+                              appArmorProfile:
+                                properties:
+                                  localhostProfile:
+                                    type: "string"
+                                  type:
+                                    type: "string"
+                                type: "object"
+                              fsGroup:
+                                type: "integer"
+                              fsGroupChangePolicy:
+                                type: "string"
+                              runAsGroup:
+                                type: "integer"
+                              runAsNonRoot:
+                                type: "boolean"
+                              runAsUser:
+                                type: "integer"
+                              seLinuxChangePolicy:
+                                type: "string"
+                              seLinuxOptions:
+                                properties:
+                                  level:
+                                    type: "string"
+                                  role:
+                                    type: "string"
+                                  type:
+                                    type: "string"
+                                  user:
+                                    type: "string"
+                                type: "object"
+                              seccompProfile:
+                                properties:
+                                  localhostProfile:
+                                    type: "string"
+                                  type:
+                                    type: "string"
+                                type: "object"
+                              supplementalGroups:
+                                items:
+                                  type: "integer"
+                                type: "array"
+                              supplementalGroupsPolicy:
+                                type: "string"
+                              sysctls:
+                                items:
+                                  properties:
+                                    name:
+                                      type: "string"
+                                    value:
+                                      type: "string"
+                                  type: "object"
+                                type: "array"
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: "string"
+                                  gmsaCredentialSpecName:
+                                    type: "string"
+                                  hostProcess:
+                                    type: "boolean"
+                                  runAsUserName:
+                                    type: "string"
+                                type: "object"
+                            type: "object"
+                          serviceAccount:
+                            type: "string"
+                          serviceAccountName:
+                            type: "string"
+                          setHostnameAsFQDN:
+                            type: "boolean"
+                          shareProcessNamespace:
+                            type: "boolean"
+                          subdomain:
+                            type: "string"
+                          terminationGracePeriodSeconds:
+                            type: "integer"
+                          tolerations:
+                            items:
+                              properties:
+                                effect:
+                                  type: "string"
+                                key:
+                                  type: "string"
+                                operator:
+                                  type: "string"
+                                tolerationSeconds:
+                                  type: "integer"
+                                value:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                          topologySpreadConstraints:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: "string"
+                                          operator:
+                                            type: "string"
+                                          values:
+                                            items:
+                                              type: "string"
+                                            type: "array"
+                                        type: "object"
+                                      type: "array"
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: "string"
+                                      type: "object"
+                                  type: "object"
+                                matchLabelKeys:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                maxSkew:
+                                  type: "integer"
+                                minDomains:
+                                  type: "integer"
+                                nodeAffinityPolicy:
+                                  type: "string"
+                                nodeTaintsPolicy:
+                                  type: "string"
+                                topologyKey:
+                                  type: "string"
+                                whenUnsatisfiable:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                          volumes:
+                            items:
+                              properties:
+                                awsElasticBlockStore:
+                                  properties:
+                                    fsType:
+                                      type: "string"
+                                    partition:
+                                      type: "integer"
+                                    readOnly:
+                                      type: "boolean"
+                                    volumeID:
+                                      type: "string"
+                                  type: "object"
+                                azureDisk:
+                                  properties:
+                                    cachingMode:
+                                      type: "string"
+                                    diskName:
+                                      type: "string"
+                                    diskURI:
+                                      type: "string"
+                                    fsType:
+                                      type: "string"
+                                    kind:
+                                      type: "string"
+                                    readOnly:
+                                      type: "boolean"
+                                  type: "object"
+                                azureFile:
+                                  properties:
+                                    readOnly:
+                                      type: "boolean"
+                                    secretName:
+                                      type: "string"
+                                    shareName:
+                                      type: "string"
+                                  type: "object"
+                                cephfs:
+                                  properties:
+                                    monitors:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    path:
+                                      type: "string"
+                                    readOnly:
+                                      type: "boolean"
+                                    secretFile:
+                                      type: "string"
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: "string"
+                                      type: "object"
+                                    user:
+                                      type: "string"
+                                  type: "object"
+                                cinder:
+                                  properties:
+                                    fsType:
+                                      type: "string"
+                                    readOnly:
+                                      type: "boolean"
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: "string"
+                                      type: "object"
+                                    volumeID:
+                                      type: "string"
+                                  type: "object"
+                                configMap:
+                                  properties:
+                                    defaultMode:
+                                      type: "integer"
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: "string"
+                                          mode:
+                                            type: "integer"
+                                          path:
+                                            type: "string"
+                                        type: "object"
+                                      type: "array"
+                                    name:
+                                      type: "string"
+                                    optional:
+                                      type: "boolean"
+                                  type: "object"
+                                csi:
+                                  properties:
+                                    driver:
+                                      type: "string"
+                                    fsType:
+                                      type: "string"
+                                    nodePublishSecretRef:
+                                      properties:
+                                        name:
+                                          type: "string"
+                                      type: "object"
+                                    readOnly:
+                                      type: "boolean"
+                                    volumeAttributes:
+                                      additionalProperties:
+                                        type: "string"
+                                      type: "object"
+                                  type: "object"
+                                downwardAPI:
+                                  properties:
+                                    defaultMode:
+                                      type: "integer"
+                                    items:
+                                      items:
+                                        properties:
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: "string"
+                                              fieldPath:
+                                                type: "string"
+                                            type: "object"
+                                          mode:
+                                            type: "integer"
+                                          path:
+                                            type: "string"
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: "string"
+                                              divisor:
+                                                anyOf:
+                                                - type: "integer"
+                                                - type: "string"
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: "string"
+                                            type: "object"
+                                        type: "object"
+                                      type: "array"
+                                  type: "object"
+                                emptyDir:
+                                  properties:
+                                    medium:
+                                      type: "string"
+                                    sizeLimit:
+                                      anyOf:
+                                      - type: "integer"
+                                      - type: "string"
+                                      x-kubernetes-int-or-string: true
+                                  type: "object"
+                                ephemeral:
+                                  properties:
+                                    volumeClaimTemplate:
+                                      properties:
+                                        metadata:
+                                          properties:
+                                            annotations:
+                                              additionalProperties:
+                                                type: "string"
+                                              type: "object"
+                                            creationTimestamp:
+                                              type: "string"
+                                            deletionGracePeriodSeconds:
+                                              type: "integer"
+                                            deletionTimestamp:
+                                              type: "string"
+                                            finalizers:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                            generateName:
+                                              type: "string"
+                                            generation:
+                                              type: "integer"
+                                            labels:
+                                              additionalProperties:
+                                                type: "string"
+                                              type: "object"
+                                            managedFields:
+                                              items:
+                                                properties:
+                                                  apiVersion:
+                                                    type: "string"
+                                                  fieldsType:
+                                                    type: "string"
+                                                  fieldsV1:
+                                                    type: "object"
+                                                  manager:
+                                                    type: "string"
+                                                  operation:
+                                                    type: "string"
+                                                  subresource:
+                                                    type: "string"
+                                                  time:
+                                                    type: "string"
+                                                type: "object"
+                                              type: "array"
+                                            name:
+                                              type: "string"
+                                            namespace:
+                                              type: "string"
+                                            ownerReferences:
+                                              items:
+                                                properties:
+                                                  apiVersion:
+                                                    type: "string"
+                                                  blockOwnerDeletion:
+                                                    type: "boolean"
+                                                  controller:
+                                                    type: "boolean"
+                                                  kind:
+                                                    type: "string"
+                                                  name:
+                                                    type: "string"
+                                                  uid:
+                                                    type: "string"
+                                                type: "object"
+                                              type: "array"
+                                            resourceVersion:
+                                              type: "string"
+                                            selfLink:
+                                              type: "string"
+                                            uid:
+                                              type: "string"
+                                          type: "object"
+                                        spec:
+                                          properties:
+                                            accessModes:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                            dataSource:
+                                              properties:
+                                                apiGroup:
+                                                  type: "string"
+                                                kind:
+                                                  type: "string"
+                                                name:
+                                                  type: "string"
+                                              type: "object"
+                                            dataSourceRef:
+                                              properties:
+                                                apiGroup:
+                                                  type: "string"
+                                                kind:
+                                                  type: "string"
+                                                name:
+                                                  type: "string"
+                                                namespace:
+                                                  type: "string"
+                                              type: "object"
+                                            resources:
+                                              properties:
+                                                limits:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                    - type: "integer"
+                                                    - type: "string"
+                                                    x-kubernetes-int-or-string: true
+                                                  type: "object"
+                                                requests:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                    - type: "integer"
+                                                    - type: "string"
+                                                    x-kubernetes-int-or-string: true
+                                                  type: "object"
+                                              type: "object"
+                                            selector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: "string"
+                                                      operator:
+                                                        type: "string"
+                                                      values:
+                                                        items:
+                                                          type: "string"
+                                                        type: "array"
+                                                    type: "object"
+                                                  type: "array"
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: "string"
+                                                  type: "object"
+                                              type: "object"
+                                            storageClassName:
+                                              type: "string"
+                                            volumeAttributesClassName:
+                                              type: "string"
+                                            volumeMode:
+                                              type: "string"
+                                            volumeName:
+                                              type: "string"
+                                          type: "object"
+                                      type: "object"
+                                  type: "object"
+                                fc:
+                                  properties:
+                                    fsType:
+                                      type: "string"
+                                    lun:
+                                      type: "integer"
+                                    readOnly:
+                                      type: "boolean"
+                                    targetWWNs:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    wwids:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                  type: "object"
+                                flexVolume:
+                                  properties:
+                                    driver:
+                                      type: "string"
+                                    fsType:
+                                      type: "string"
+                                    options:
+                                      additionalProperties:
+                                        type: "string"
+                                      type: "object"
+                                    readOnly:
+                                      type: "boolean"
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: "string"
+                                      type: "object"
+                                  type: "object"
+                                flocker:
+                                  properties:
+                                    datasetName:
+                                      type: "string"
+                                    datasetUUID:
+                                      type: "string"
+                                  type: "object"
+                                gcePersistentDisk:
+                                  properties:
+                                    fsType:
+                                      type: "string"
+                                    partition:
+                                      type: "integer"
+                                    pdName:
+                                      type: "string"
+                                    readOnly:
+                                      type: "boolean"
+                                  type: "object"
+                                gitRepo:
+                                  properties:
+                                    directory:
+                                      type: "string"
+                                    repository:
+                                      type: "string"
+                                    revision:
+                                      type: "string"
+                                  type: "object"
+                                glusterfs:
+                                  properties:
+                                    endpoints:
+                                      type: "string"
+                                    path:
+                                      type: "string"
+                                    readOnly:
+                                      type: "boolean"
+                                  type: "object"
+                                hostPath:
+                                  properties:
+                                    path:
+                                      type: "string"
+                                    type:
+                                      type: "string"
+                                  type: "object"
+                                image:
+                                  properties:
+                                    pullPolicy:
+                                      type: "string"
+                                    reference:
+                                      type: "string"
+                                  type: "object"
+                                iscsi:
+                                  properties:
+                                    chapAuthDiscovery:
+                                      type: "boolean"
+                                    chapAuthSession:
+                                      type: "boolean"
+                                    fsType:
+                                      type: "string"
+                                    initiatorName:
+                                      type: "string"
+                                    iqn:
+                                      type: "string"
+                                    iscsiInterface:
+                                      type: "string"
+                                    lun:
+                                      type: "integer"
+                                    portals:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    readOnly:
+                                      type: "boolean"
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: "string"
+                                      type: "object"
+                                    targetPortal:
+                                      type: "string"
+                                  type: "object"
+                                name:
+                                  type: "string"
+                                nfs:
+                                  properties:
+                                    path:
+                                      type: "string"
+                                    readOnly:
+                                      type: "boolean"
+                                    server:
+                                      type: "string"
+                                  type: "object"
+                                persistentVolumeClaim:
+                                  properties:
+                                    claimName:
+                                      type: "string"
+                                    readOnly:
+                                      type: "boolean"
+                                  type: "object"
+                                photonPersistentDisk:
+                                  properties:
+                                    fsType:
+                                      type: "string"
+                                    pdID:
+                                      type: "string"
+                                  type: "object"
+                                portworxVolume:
+                                  properties:
+                                    fsType:
+                                      type: "string"
+                                    readOnly:
+                                      type: "boolean"
+                                    volumeID:
+                                      type: "string"
+                                  type: "object"
+                                projected:
+                                  properties:
+                                    defaultMode:
+                                      type: "integer"
+                                    sources:
+                                      items:
+                                        properties:
+                                          clusterTrustBundle:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: "string"
+                                                        operator:
+                                                          type: "string"
+                                                        values:
+                                                          items:
+                                                            type: "string"
+                                                          type: "array"
+                                                      type: "object"
+                                                    type: "array"
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: "string"
+                                                    type: "object"
+                                                type: "object"
+                                              name:
+                                                type: "string"
+                                              optional:
+                                                type: "boolean"
+                                              path:
+                                                type: "string"
+                                              signerName:
+                                                type: "string"
+                                            type: "object"
+                                          configMap:
+                                            properties:
+                                              items:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: "string"
+                                                    mode:
+                                                      type: "integer"
+                                                    path:
+                                                      type: "string"
+                                                  type: "object"
+                                                type: "array"
+                                              name:
+                                                type: "string"
+                                              optional:
+                                                type: "boolean"
+                                            type: "object"
+                                          downwardAPI:
+                                            properties:
+                                              items:
+                                                items:
+                                                  properties:
+                                                    fieldRef:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: "string"
+                                                        fieldPath:
+                                                          type: "string"
+                                                      type: "object"
+                                                    mode:
+                                                      type: "integer"
+                                                    path:
+                                                      type: "string"
+                                                    resourceFieldRef:
+                                                      properties:
+                                                        containerName:
+                                                          type: "string"
+                                                        divisor:
+                                                          anyOf:
+                                                          - type: "integer"
+                                                          - type: "string"
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          type: "string"
+                                                      type: "object"
+                                                  type: "object"
+                                                type: "array"
+                                            type: "object"
+                                          podCertificate:
+                                            properties:
+                                              certificateChainPath:
+                                                type: "string"
+                                              credentialBundlePath:
+                                                type: "string"
+                                              keyPath:
+                                                type: "string"
+                                              keyType:
+                                                type: "string"
+                                              maxExpirationSeconds:
+                                                type: "integer"
+                                              signerName:
+                                                type: "string"
+                                            type: "object"
+                                          secret:
+                                            properties:
+                                              items:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: "string"
+                                                    mode:
+                                                      type: "integer"
+                                                    path:
+                                                      type: "string"
+                                                  type: "object"
+                                                type: "array"
+                                              name:
+                                                type: "string"
+                                              optional:
+                                                type: "boolean"
+                                            type: "object"
+                                          serviceAccountToken:
+                                            properties:
+                                              audience:
+                                                type: "string"
+                                              expirationSeconds:
+                                                type: "integer"
+                                              path:
+                                                type: "string"
+                                            type: "object"
+                                        type: "object"
+                                      type: "array"
+                                  type: "object"
+                                quobyte:
+                                  properties:
+                                    group:
+                                      type: "string"
+                                    readOnly:
+                                      type: "boolean"
+                                    registry:
+                                      type: "string"
+                                    tenant:
+                                      type: "string"
+                                    user:
+                                      type: "string"
+                                    volume:
+                                      type: "string"
+                                  type: "object"
+                                rbd:
+                                  properties:
+                                    fsType:
+                                      type: "string"
+                                    image:
+                                      type: "string"
+                                    keyring:
+                                      type: "string"
+                                    monitors:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    pool:
+                                      type: "string"
+                                    readOnly:
+                                      type: "boolean"
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: "string"
+                                      type: "object"
+                                    user:
+                                      type: "string"
+                                  type: "object"
+                                scaleIO:
+                                  properties:
+                                    fsType:
+                                      type: "string"
+                                    gateway:
+                                      type: "string"
+                                    protectionDomain:
+                                      type: "string"
+                                    readOnly:
+                                      type: "boolean"
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: "string"
+                                      type: "object"
+                                    sslEnabled:
+                                      type: "boolean"
+                                    storageMode:
+                                      type: "string"
+                                    storagePool:
+                                      type: "string"
+                                    system:
+                                      type: "string"
+                                    volumeName:
+                                      type: "string"
+                                  type: "object"
+                                secret:
+                                  properties:
+                                    defaultMode:
+                                      type: "integer"
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: "string"
+                                          mode:
+                                            type: "integer"
+                                          path:
+                                            type: "string"
+                                        type: "object"
+                                      type: "array"
+                                    optional:
+                                      type: "boolean"
+                                    secretName:
+                                      type: "string"
+                                  type: "object"
+                                storageos:
+                                  properties:
+                                    fsType:
+                                      type: "string"
+                                    readOnly:
+                                      type: "boolean"
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: "string"
+                                      type: "object"
+                                    volumeName:
+                                      type: "string"
+                                    volumeNamespace:
+                                      type: "string"
+                                  type: "object"
+                                vsphereVolume:
+                                  properties:
+                                    fsType:
+                                      type: "string"
+                                    storagePolicyID:
+                                      type: "string"
+                                    storagePolicyName:
+                                      type: "string"
+                                    volumePath:
+                                      type: "string"
+                                  type: "object"
+                              type: "object"
+                            type: "array"
+                        type: "object"
+                    type: "object"
+                type: "object"
+              update:
+                description: "Configuration related to Keycloak deployment updates."
+                properties:
+                  labels:
+                    additionalProperties:
+                      type: "string"
+                    description: "Optionally set to add additional labels to the Job\
+                      \ created for the update."
+                    type: "object"
+                  revision:
+                    description: "When use the Explicit strategy, the revision signals\
+                      \ if a rolling update can be used or not."
+                    type: "string"
+                  scheduling:
+                    description: "In this section you can configure the update job's\
+                      \ scheduling"
+                    properties:
+                      affinity:
+                        properties:
+                          nodeAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    preference:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                      type: "object"
+                                    weight:
+                                      type: "integer"
+                                  type: "object"
+                                type: "array"
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                properties:
+                                  nodeSelectorTerms:
+                                    items:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                        matchFields:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                      type: "object"
+                                    type: "array"
+                                type: "object"
+                            type: "object"
+                          podAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: "string"
+                                                  operator:
+                                                    type: "string"
+                                                  values:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                type: "object"
+                                              type: "array"
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: "string"
+                                              type: "object"
+                                          type: "object"
+                                        matchLabelKeys:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: "string"
+                                                  operator:
+                                                    type: "string"
+                                                  values:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                type: "object"
+                                              type: "array"
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: "string"
+                                              type: "object"
+                                          type: "object"
+                                        namespaces:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        topologyKey:
+                                          type: "string"
+                                      type: "object"
+                                    weight:
+                                      type: "integer"
+                                  type: "object"
+                                type: "array"
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: "string"
+                                          type: "object"
+                                      type: "object"
+                                    matchLabelKeys:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: "string"
+                                          type: "object"
+                                      type: "object"
+                                    namespaces:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    topologyKey:
+                                      type: "string"
+                                  type: "object"
+                                type: "array"
+                            type: "object"
+                          podAntiAffinity:
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    podAffinityTerm:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: "string"
+                                                  operator:
+                                                    type: "string"
+                                                  values:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                type: "object"
+                                              type: "array"
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: "string"
+                                              type: "object"
+                                          type: "object"
+                                        matchLabelKeys:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: "string"
+                                                  operator:
+                                                    type: "string"
+                                                  values:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                type: "object"
+                                              type: "array"
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: "string"
+                                              type: "object"
+                                          type: "object"
+                                        namespaces:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        topologyKey:
+                                          type: "string"
+                                      type: "object"
+                                    weight:
+                                      type: "integer"
+                                  type: "object"
+                                type: "array"
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: "string"
+                                          type: "object"
+                                      type: "object"
+                                    matchLabelKeys:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    mismatchLabelKeys:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: "string"
+                                              operator:
+                                                type: "string"
+                                              values:
+                                                items:
+                                                  type: "string"
+                                                type: "array"
+                                            type: "object"
+                                          type: "array"
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: "string"
+                                          type: "object"
+                                      type: "object"
+                                    namespaces:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    topologyKey:
+                                      type: "string"
+                                  type: "object"
+                                type: "array"
+                            type: "object"
+                        type: "object"
+                      priorityClassName:
+                        type: "string"
+                      tolerations:
+                        items:
+                          properties:
+                            effect:
+                              type: "string"
+                            key:
+                              type: "string"
+                            operator:
+                              type: "string"
+                            tolerationSeconds:
+                              type: "integer"
+                            value:
+                              type: "string"
+                          type: "object"
+                        type: "array"
+                      topologySpreadConstraints:
+                        items:
+                          properties:
+                            labelSelector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: "string"
+                                      operator:
+                                        type: "string"
+                                      values:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                    type: "object"
+                                  type: "array"
+                                matchLabels:
+                                  additionalProperties:
+                                    type: "string"
+                                  type: "object"
+                              type: "object"
+                            matchLabelKeys:
+                              items:
+                                type: "string"
+                              type: "array"
+                            maxSkew:
+                              type: "integer"
+                            minDomains:
+                              type: "integer"
+                            nodeAffinityPolicy:
+                              type: "string"
+                            nodeTaintsPolicy:
+                              type: "string"
+                            topologyKey:
+                              type: "string"
+                            whenUnsatisfiable:
+                              type: "string"
+                          type: "object"
+                        type: "array"
+                    type: "object"
+                  strategy:
+                    default: "RecreateOnImageChange"
+                    description: "Sets the update strategy to use."
+                    enum:
+                    - "Auto"
+                    - "Explicit"
+                    - "RecreateOnImageChange"
+                    type: "string"
+                type: "object"
+                x-kubernetes-validations:
+                - message: "The 'revision' field is required when 'Explicit' strategy\
+                    \ is used"
+                  rule: "self.strategy != 'Explicit' || has(self.revision)"
+            type: "object"
+          status:
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      type: "string"
+                    message:
+                      type: "string"
+                    observedGeneration:
+                      type: "integer"
+                    status:
+                      type: "string"
+                    type:
+                      type: "string"
+                  type: "object"
+                type: "array"
+              instances:
+                type: "integer"
+              observedGeneration:
+                type: "integer"
+              selector:
+                type: "string"
+            type: "object"
+        type: "object"
+    served: true
+    storage: false
     subresources:
       scale:
         labelSelectorPath: ".status.selector"

--- a/infrastructure/base/keycloak-operator/keycloakrealmimport-crd.yaml
+++ b/infrastructure/base/keycloak-operator/keycloakrealmimport-crd.yaml
@@ -11,7 +11,7 @@ spec:
     singular: "keycloakrealmimport"
   scope: "Namespaced"
   versions:
-  - name: "v2alpha1"
+  - name: "v2beta1"
     schema:
       openAPIV3Schema:
         properties:
@@ -21,6 +21,12 @@ spec:
                 description: "The name of the Keycloak CR to reference, in the same\
                   \ namespace."
                 type: "string"
+              labels:
+                additionalProperties:
+                  type: "string"
+                description: "Optionally set to add additional labels to the Job created\
+                  \ for the import."
+                type: "object"
               placeholders:
                 additionalProperties:
                   properties:
@@ -2306,6 +2312,10 @@ spec:
                           type: "boolean"
                         trustEmail:
                           type: "boolean"
+                        types:
+                          items:
+                            type: "string"
+                          type: "array"
                         updateProfileFirstLoginMode:
                           type: "string"
                       type: "object"
@@ -2327,6 +2337,8 @@ spec:
                   maxDeltaTimeSeconds:
                     type: "integer"
                   maxFailureWaitSeconds:
+                    type: "integer"
+                  maxSecondaryAuthFailures:
                     type: "integer"
                   maxTemporaryLockouts:
                     type: "integer"
@@ -2728,6 +2740,413 @@ spec:
                           type: "array"
                         enabled:
                           type: "boolean"
+                        groups:
+                          items:
+                            properties:
+                              access:
+                                additionalProperties:
+                                  type: "boolean"
+                                type: "object"
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                type: "object"
+                              clientRoles:
+                                additionalProperties:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                type: "object"
+                              description:
+                                type: "string"
+                              id:
+                                type: "string"
+                              name:
+                                type: "string"
+                              parentId:
+                                type: "string"
+                              path:
+                                type: "string"
+                              realmRoles:
+                                items:
+                                  type: "string"
+                                type: "array"
+                              subGroupCount:
+                                type: "integer"
+                              subGroups:
+                                items:
+                                  properties:
+                                    access:
+                                      additionalProperties:
+                                        type: "boolean"
+                                      type: "object"
+                                    attributes:
+                                      additionalProperties:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                      type: "object"
+                                    clientRoles:
+                                      additionalProperties:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                      type: "object"
+                                    description:
+                                      type: "string"
+                                    id:
+                                      type: "string"
+                                    name:
+                                      type: "string"
+                                    parentId:
+                                      type: "string"
+                                    path:
+                                      type: "string"
+                                    realmRoles:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    subGroupCount:
+                                      type: "integer"
+                                    subGroups:
+                                      items:
+                                        properties:
+                                          access:
+                                            additionalProperties:
+                                              type: "boolean"
+                                            type: "object"
+                                          attributes:
+                                            additionalProperties:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                            type: "object"
+                                          clientRoles:
+                                            additionalProperties:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                            type: "object"
+                                          description:
+                                            type: "string"
+                                          id:
+                                            type: "string"
+                                          name:
+                                            type: "string"
+                                          parentId:
+                                            type: "string"
+                                          path:
+                                            type: "string"
+                                          realmRoles:
+                                            items:
+                                              type: "string"
+                                            type: "array"
+                                          subGroupCount:
+                                            type: "integer"
+                                          subGroups:
+                                            items:
+                                              properties:
+                                                access:
+                                                  additionalProperties:
+                                                    type: "boolean"
+                                                  type: "object"
+                                                attributes:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                  type: "object"
+                                                clientRoles:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                  type: "object"
+                                                description:
+                                                  type: "string"
+                                                id:
+                                                  type: "string"
+                                                name:
+                                                  type: "string"
+                                                parentId:
+                                                  type: "string"
+                                                path:
+                                                  type: "string"
+                                                realmRoles:
+                                                  items:
+                                                    type: "string"
+                                                  type: "array"
+                                                subGroupCount:
+                                                  type: "integer"
+                                                subGroups:
+                                                  items:
+                                                    properties:
+                                                      access:
+                                                        additionalProperties:
+                                                          type: "boolean"
+                                                        type: "object"
+                                                      attributes:
+                                                        additionalProperties:
+                                                          items:
+                                                            type: "string"
+                                                          type: "array"
+                                                        type: "object"
+                                                      clientRoles:
+                                                        additionalProperties:
+                                                          items:
+                                                            type: "string"
+                                                          type: "array"
+                                                        type: "object"
+                                                      description:
+                                                        type: "string"
+                                                      id:
+                                                        type: "string"
+                                                      name:
+                                                        type: "string"
+                                                      parentId:
+                                                        type: "string"
+                                                      path:
+                                                        type: "string"
+                                                      realmRoles:
+                                                        items:
+                                                          type: "string"
+                                                        type: "array"
+                                                      subGroupCount:
+                                                        type: "integer"
+                                                      subGroups:
+                                                        items:
+                                                          properties:
+                                                            access:
+                                                              additionalProperties:
+                                                                type: "boolean"
+                                                              type: "object"
+                                                            attributes:
+                                                              additionalProperties:
+                                                                items:
+                                                                  type: "string"
+                                                                type: "array"
+                                                              type: "object"
+                                                            clientRoles:
+                                                              additionalProperties:
+                                                                items:
+                                                                  type: "string"
+                                                                type: "array"
+                                                              type: "object"
+                                                            description:
+                                                              type: "string"
+                                                            id:
+                                                              type: "string"
+                                                            name:
+                                                              type: "string"
+                                                            parentId:
+                                                              type: "string"
+                                                            path:
+                                                              type: "string"
+                                                            realmRoles:
+                                                              items:
+                                                                type: "string"
+                                                              type: "array"
+                                                            subGroupCount:
+                                                              type: "integer"
+                                                            subGroups:
+                                                              items:
+                                                                properties:
+                                                                  access:
+                                                                    additionalProperties:
+                                                                      type: "boolean"
+                                                                    type: "object"
+                                                                  attributes:
+                                                                    additionalProperties:
+                                                                      items:
+                                                                        type: "string"
+                                                                      type: "array"
+                                                                    type: "object"
+                                                                  clientRoles:
+                                                                    additionalProperties:
+                                                                      items:
+                                                                        type: "string"
+                                                                      type: "array"
+                                                                    type: "object"
+                                                                  description:
+                                                                    type: "string"
+                                                                  id:
+                                                                    type: "string"
+                                                                  name:
+                                                                    type: "string"
+                                                                  parentId:
+                                                                    type: "string"
+                                                                  path:
+                                                                    type: "string"
+                                                                  realmRoles:
+                                                                    items:
+                                                                      type: "string"
+                                                                    type: "array"
+                                                                  subGroupCount:
+                                                                    type: "integer"
+                                                                  subGroups:
+                                                                    items:
+                                                                      properties:
+                                                                        access:
+                                                                          additionalProperties:
+                                                                            type: "boolean"
+                                                                          type: "object"
+                                                                        attributes:
+                                                                          additionalProperties:
+                                                                            items:
+                                                                              type: "string"
+                                                                            type: "array"
+                                                                          type: "object"
+                                                                        clientRoles:
+                                                                          additionalProperties:
+                                                                            items:
+                                                                              type: "string"
+                                                                            type: "array"
+                                                                          type: "object"
+                                                                        description:
+                                                                          type: "string"
+                                                                        id:
+                                                                          type: "string"
+                                                                        name:
+                                                                          type: "string"
+                                                                        parentId:
+                                                                          type: "string"
+                                                                        path:
+                                                                          type: "string"
+                                                                        realmRoles:
+                                                                          items:
+                                                                            type: "string"
+                                                                          type: "array"
+                                                                        subGroupCount:
+                                                                          type: "integer"
+                                                                        subGroups:
+                                                                          items:
+                                                                            properties:
+                                                                              access:
+                                                                                additionalProperties:
+                                                                                  type: "boolean"
+                                                                                type: "object"
+                                                                              attributes:
+                                                                                additionalProperties:
+                                                                                  items:
+                                                                                    type: "string"
+                                                                                  type: "array"
+                                                                                type: "object"
+                                                                              clientRoles:
+                                                                                additionalProperties:
+                                                                                  items:
+                                                                                    type: "string"
+                                                                                  type: "array"
+                                                                                type: "object"
+                                                                              description:
+                                                                                type: "string"
+                                                                              id:
+                                                                                type: "string"
+                                                                              name:
+                                                                                type: "string"
+                                                                              parentId:
+                                                                                type: "string"
+                                                                              path:
+                                                                                type: "string"
+                                                                              realmRoles:
+                                                                                items:
+                                                                                  type: "string"
+                                                                                type: "array"
+                                                                              subGroupCount:
+                                                                                type: "integer"
+                                                                              subGroups:
+                                                                                items:
+                                                                                  properties:
+                                                                                    access:
+                                                                                      additionalProperties:
+                                                                                        type: "boolean"
+                                                                                      type: "object"
+                                                                                    attributes:
+                                                                                      additionalProperties:
+                                                                                        items:
+                                                                                          type: "string"
+                                                                                        type: "array"
+                                                                                      type: "object"
+                                                                                    clientRoles:
+                                                                                      additionalProperties:
+                                                                                        items:
+                                                                                          type: "string"
+                                                                                        type: "array"
+                                                                                      type: "object"
+                                                                                    description:
+                                                                                      type: "string"
+                                                                                    id:
+                                                                                      type: "string"
+                                                                                    name:
+                                                                                      type: "string"
+                                                                                    parentId:
+                                                                                      type: "string"
+                                                                                    path:
+                                                                                      type: "string"
+                                                                                    realmRoles:
+                                                                                      items:
+                                                                                        type: "string"
+                                                                                      type: "array"
+                                                                                    subGroupCount:
+                                                                                      type: "integer"
+                                                                                    subGroups:
+                                                                                      items:
+                                                                                        properties:
+                                                                                          access:
+                                                                                            additionalProperties:
+                                                                                              type: "boolean"
+                                                                                            type: "object"
+                                                                                          attributes:
+                                                                                            additionalProperties:
+                                                                                              items:
+                                                                                                type: "string"
+                                                                                              type: "array"
+                                                                                            type: "object"
+                                                                                          clientRoles:
+                                                                                            additionalProperties:
+                                                                                              items:
+                                                                                                type: "string"
+                                                                                              type: "array"
+                                                                                            type: "object"
+                                                                                          description:
+                                                                                            type: "string"
+                                                                                          id:
+                                                                                            type: "string"
+                                                                                          name:
+                                                                                            type: "string"
+                                                                                          parentId:
+                                                                                            type: "string"
+                                                                                          path:
+                                                                                            type: "string"
+                                                                                          realmRoles:
+                                                                                            items:
+                                                                                              type: "string"
+                                                                                            type: "array"
+                                                                                          subGroupCount:
+                                                                                            type: "integer"
+                                                                                        type: "object"
+                                                                                      type: "array"
+                                                                                  type: "object"
+                                                                                type: "array"
+                                                                            type: "object"
+                                                                          type: "array"
+                                                                      type: "object"
+                                                                    type: "array"
+                                                                type: "object"
+                                                              type: "array"
+                                                          type: "object"
+                                                        type: "array"
+                                                    type: "object"
+                                                  type: "array"
+                                              type: "object"
+                                            type: "array"
+                                        type: "object"
+                                      type: "array"
+                                  type: "object"
+                                type: "array"
+                            type: "object"
+                          type: "array"
                         id:
                           type: "string"
                         identityProviders:
@@ -2765,6 +3184,10 @@ spec:
                                 type: "boolean"
                               trustEmail:
                                 type: "boolean"
+                              types:
+                                items:
+                                  type: "string"
+                                type: "array"
                               updateProfileFirstLoginMode:
                                 type: "string"
                             type: "object"
@@ -3221,6 +3644,8 @@ spec:
                           type: "object"
                         type: "array"
                     type: "object"
+                  scimApiEnabled:
+                    type: "boolean"
                   scopeMappings:
                     items:
                       properties:
@@ -3630,5 +4055,4053 @@ spec:
         type: "object"
     served: true
     storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    deprecationWarning: "Please migrate to v2beta1"
+    name: "v2alpha1"
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              keycloakCRName:
+                description: "The name of the Keycloak CR to reference, in the same\
+                  \ namespace."
+                type: "string"
+              labels:
+                additionalProperties:
+                  type: "string"
+                description: "Optionally set to add additional labels to the Job created\
+                  \ for the import."
+                type: "object"
+              placeholders:
+                additionalProperties:
+                  properties:
+                    secret:
+                      properties:
+                        key:
+                          type: "string"
+                        name:
+                          type: "string"
+                        optional:
+                          type: "boolean"
+                      type: "object"
+                  type: "object"
+                description: "Optionally set to replace ENV variable placeholders\
+                  \ in the realm import."
+                type: "object"
+              realm:
+                description: "The RealmRepresentation to import into Keycloak."
+                properties:
+                  accessCodeLifespan:
+                    type: "integer"
+                  accessCodeLifespanLogin:
+                    type: "integer"
+                  accessCodeLifespanUserAction:
+                    type: "integer"
+                  accessTokenLifespan:
+                    type: "integer"
+                  accessTokenLifespanForImplicitFlow:
+                    type: "integer"
+                  accountTheme:
+                    type: "string"
+                  actionTokenGeneratedByAdminLifespan:
+                    type: "integer"
+                  actionTokenGeneratedByUserLifespan:
+                    type: "integer"
+                  adminEventsDetailsEnabled:
+                    type: "boolean"
+                  adminEventsEnabled:
+                    type: "boolean"
+                  adminPermissionsClient:
+                    properties:
+                      access:
+                        additionalProperties:
+                          type: "boolean"
+                        type: "object"
+                      adminUrl:
+                        type: "string"
+                      alwaysDisplayInConsole:
+                        type: "boolean"
+                      attributes:
+                        additionalProperties:
+                          type: "string"
+                        type: "object"
+                      authenticationFlowBindingOverrides:
+                        additionalProperties:
+                          type: "string"
+                        type: "object"
+                      authorizationServicesEnabled:
+                        type: "boolean"
+                      authorizationSettings:
+                        properties:
+                          allowRemoteResourceManagement:
+                            type: "boolean"
+                          authorizationSchema:
+                            properties:
+                              resourceTypes:
+                                additionalProperties:
+                                  properties:
+                                    groupType:
+                                      type: "string"
+                                    scopeAliases:
+                                      additionalProperties:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                      type: "object"
+                                    scopes:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    type:
+                                      type: "string"
+                                  type: "object"
+                                type: "object"
+                            type: "object"
+                          clientId:
+                            type: "string"
+                          decisionStrategy:
+                            enum:
+                            - "AFFIRMATIVE"
+                            - "CONSENSUS"
+                            - "UNANIMOUS"
+                            type: "string"
+                          id:
+                            type: "string"
+                          name:
+                            type: "string"
+                          policies:
+                            items:
+                              properties:
+                                config:
+                                  additionalProperties:
+                                    type: "string"
+                                  type: "object"
+                                decisionStrategy:
+                                  enum:
+                                  - "AFFIRMATIVE"
+                                  - "CONSENSUS"
+                                  - "UNANIMOUS"
+                                  type: "string"
+                                description:
+                                  type: "string"
+                                id:
+                                  type: "string"
+                                logic:
+                                  enum:
+                                  - "NEGATIVE"
+                                  - "POSITIVE"
+                                  type: "string"
+                                name:
+                                  type: "string"
+                                owner:
+                                  type: "string"
+                                policies:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                resourceType:
+                                  type: "string"
+                                resources:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                resourcesData:
+                                  items:
+                                    properties:
+                                      _id:
+                                        type: "string"
+                                      attributes:
+                                        additionalProperties:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        type: "object"
+                                      displayName:
+                                        type: "string"
+                                      icon_uri:
+                                        type: "string"
+                                      name:
+                                        type: "string"
+                                      owner:
+                                        properties:
+                                          id:
+                                            type: "string"
+                                          name:
+                                            type: "string"
+                                        type: "object"
+                                      ownerManagedAccess:
+                                        type: "boolean"
+                                      scopes:
+                                        items:
+                                          properties:
+                                            displayName:
+                                              type: "string"
+                                            iconUri:
+                                              type: "string"
+                                            id:
+                                              type: "string"
+                                            name:
+                                              type: "string"
+                                          type: "object"
+                                        type: "array"
+                                      type:
+                                        type: "string"
+                                      uris:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                    type: "object"
+                                  type: "array"
+                                scopes:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                scopesData:
+                                  items:
+                                    properties:
+                                      displayName:
+                                        type: "string"
+                                      iconUri:
+                                        type: "string"
+                                      id:
+                                        type: "string"
+                                      name:
+                                        type: "string"
+                                    type: "object"
+                                  type: "array"
+                                type:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                          policyEnforcementMode:
+                            enum:
+                            - "DISABLED"
+                            - "ENFORCING"
+                            - "PERMISSIVE"
+                            type: "string"
+                          resources:
+                            items:
+                              properties:
+                                _id:
+                                  type: "string"
+                                attributes:
+                                  additionalProperties:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                  type: "object"
+                                displayName:
+                                  type: "string"
+                                icon_uri:
+                                  type: "string"
+                                name:
+                                  type: "string"
+                                owner:
+                                  properties:
+                                    id:
+                                      type: "string"
+                                    name:
+                                      type: "string"
+                                  type: "object"
+                                ownerManagedAccess:
+                                  type: "boolean"
+                                scopes:
+                                  items:
+                                    properties:
+                                      displayName:
+                                        type: "string"
+                                      iconUri:
+                                        type: "string"
+                                      id:
+                                        type: "string"
+                                      name:
+                                        type: "string"
+                                    type: "object"
+                                  type: "array"
+                                type:
+                                  type: "string"
+                                uris:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                              type: "object"
+                            type: "array"
+                          scopes:
+                            items:
+                              properties:
+                                displayName:
+                                  type: "string"
+                                iconUri:
+                                  type: "string"
+                                id:
+                                  type: "string"
+                                name:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                        type: "object"
+                      baseUrl:
+                        type: "string"
+                      bearerOnly:
+                        type: "boolean"
+                      clientAuthenticatorType:
+                        type: "string"
+                      clientId:
+                        type: "string"
+                      clientTemplate:
+                        type: "string"
+                      consentRequired:
+                        type: "boolean"
+                      defaultClientScopes:
+                        items:
+                          type: "string"
+                        type: "array"
+                      defaultRoles:
+                        items:
+                          type: "string"
+                        type: "array"
+                      description:
+                        type: "string"
+                      directAccessGrantsEnabled:
+                        type: "boolean"
+                      directGrantsOnly:
+                        type: "boolean"
+                      enabled:
+                        type: "boolean"
+                      frontchannelLogout:
+                        type: "boolean"
+                      fullScopeAllowed:
+                        type: "boolean"
+                      id:
+                        type: "string"
+                      implicitFlowEnabled:
+                        type: "boolean"
+                      name:
+                        type: "string"
+                      nodeReRegistrationTimeout:
+                        type: "integer"
+                      notBefore:
+                        type: "integer"
+                      optionalClientScopes:
+                        items:
+                          type: "string"
+                        type: "array"
+                      origin:
+                        type: "string"
+                      protocol:
+                        type: "string"
+                      protocolMappers:
+                        items:
+                          properties:
+                            config:
+                              additionalProperties:
+                                type: "string"
+                              type: "object"
+                            consentRequired:
+                              type: "boolean"
+                            consentText:
+                              type: "string"
+                            id:
+                              type: "string"
+                            name:
+                              type: "string"
+                            protocol:
+                              type: "string"
+                            protocolMapper:
+                              type: "string"
+                          type: "object"
+                        type: "array"
+                      publicClient:
+                        type: "boolean"
+                      redirectUris:
+                        items:
+                          type: "string"
+                        type: "array"
+                      registeredNodes:
+                        additionalProperties:
+                          type: "integer"
+                        type: "object"
+                      registrationAccessToken:
+                        type: "string"
+                      rootUrl:
+                        type: "string"
+                      secret:
+                        type: "string"
+                      serviceAccountsEnabled:
+                        type: "boolean"
+                      standardFlowEnabled:
+                        type: "boolean"
+                      surrogateAuthRequired:
+                        type: "boolean"
+                      type:
+                        type: "string"
+                      useTemplateConfig:
+                        type: "boolean"
+                      useTemplateMappers:
+                        type: "boolean"
+                      useTemplateScope:
+                        type: "boolean"
+                      webOrigins:
+                        items:
+                          type: "string"
+                        type: "array"
+                    type: "object"
+                  adminPermissionsEnabled:
+                    type: "boolean"
+                  adminTheme:
+                    type: "string"
+                  applicationScopeMappings:
+                    additionalProperties:
+                      items:
+                        properties:
+                          client:
+                            type: "string"
+                          clientScope:
+                            type: "string"
+                          clientTemplate:
+                            type: "string"
+                          roles:
+                            items:
+                              type: "string"
+                            type: "array"
+                          self:
+                            type: "string"
+                        type: "object"
+                      type: "array"
+                    type: "object"
+                  applications:
+                    items:
+                      properties:
+                        access:
+                          additionalProperties:
+                            type: "boolean"
+                          type: "object"
+                        adminUrl:
+                          type: "string"
+                        alwaysDisplayInConsole:
+                          type: "boolean"
+                        attributes:
+                          additionalProperties:
+                            type: "string"
+                          type: "object"
+                        authenticationFlowBindingOverrides:
+                          additionalProperties:
+                            type: "string"
+                          type: "object"
+                        authorizationServicesEnabled:
+                          type: "boolean"
+                        authorizationSettings:
+                          properties:
+                            allowRemoteResourceManagement:
+                              type: "boolean"
+                            authorizationSchema:
+                              properties:
+                                resourceTypes:
+                                  additionalProperties:
+                                    properties:
+                                      groupType:
+                                        type: "string"
+                                      scopeAliases:
+                                        additionalProperties:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        type: "object"
+                                      scopes:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                      type:
+                                        type: "string"
+                                    type: "object"
+                                  type: "object"
+                              type: "object"
+                            clientId:
+                              type: "string"
+                            decisionStrategy:
+                              enum:
+                              - "AFFIRMATIVE"
+                              - "CONSENSUS"
+                              - "UNANIMOUS"
+                              type: "string"
+                            id:
+                              type: "string"
+                            name:
+                              type: "string"
+                            policies:
+                              items:
+                                properties:
+                                  config:
+                                    additionalProperties:
+                                      type: "string"
+                                    type: "object"
+                                  decisionStrategy:
+                                    enum:
+                                    - "AFFIRMATIVE"
+                                    - "CONSENSUS"
+                                    - "UNANIMOUS"
+                                    type: "string"
+                                  description:
+                                    type: "string"
+                                  id:
+                                    type: "string"
+                                  logic:
+                                    enum:
+                                    - "NEGATIVE"
+                                    - "POSITIVE"
+                                    type: "string"
+                                  name:
+                                    type: "string"
+                                  owner:
+                                    type: "string"
+                                  policies:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                  resourceType:
+                                    type: "string"
+                                  resources:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                  resourcesData:
+                                    items:
+                                      properties:
+                                        _id:
+                                          type: "string"
+                                        attributes:
+                                          additionalProperties:
+                                            items:
+                                              type: "string"
+                                            type: "array"
+                                          type: "object"
+                                        displayName:
+                                          type: "string"
+                                        icon_uri:
+                                          type: "string"
+                                        name:
+                                          type: "string"
+                                        owner:
+                                          properties:
+                                            id:
+                                              type: "string"
+                                            name:
+                                              type: "string"
+                                          type: "object"
+                                        ownerManagedAccess:
+                                          type: "boolean"
+                                        scopes:
+                                          items:
+                                            properties:
+                                              displayName:
+                                                type: "string"
+                                              iconUri:
+                                                type: "string"
+                                              id:
+                                                type: "string"
+                                              name:
+                                                type: "string"
+                                            type: "object"
+                                          type: "array"
+                                        type:
+                                          type: "string"
+                                        uris:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                      type: "object"
+                                    type: "array"
+                                  scopes:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                  scopesData:
+                                    items:
+                                      properties:
+                                        displayName:
+                                          type: "string"
+                                        iconUri:
+                                          type: "string"
+                                        id:
+                                          type: "string"
+                                        name:
+                                          type: "string"
+                                      type: "object"
+                                    type: "array"
+                                  type:
+                                    type: "string"
+                                type: "object"
+                              type: "array"
+                            policyEnforcementMode:
+                              enum:
+                              - "DISABLED"
+                              - "ENFORCING"
+                              - "PERMISSIVE"
+                              type: "string"
+                            resources:
+                              items:
+                                properties:
+                                  _id:
+                                    type: "string"
+                                  attributes:
+                                    additionalProperties:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    type: "object"
+                                  displayName:
+                                    type: "string"
+                                  icon_uri:
+                                    type: "string"
+                                  name:
+                                    type: "string"
+                                  owner:
+                                    properties:
+                                      id:
+                                        type: "string"
+                                      name:
+                                        type: "string"
+                                    type: "object"
+                                  ownerManagedAccess:
+                                    type: "boolean"
+                                  scopes:
+                                    items:
+                                      properties:
+                                        displayName:
+                                          type: "string"
+                                        iconUri:
+                                          type: "string"
+                                        id:
+                                          type: "string"
+                                        name:
+                                          type: "string"
+                                      type: "object"
+                                    type: "array"
+                                  type:
+                                    type: "string"
+                                  uris:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              type: "array"
+                            scopes:
+                              items:
+                                properties:
+                                  displayName:
+                                    type: "string"
+                                  iconUri:
+                                    type: "string"
+                                  id:
+                                    type: "string"
+                                  name:
+                                    type: "string"
+                                type: "object"
+                              type: "array"
+                          type: "object"
+                        baseUrl:
+                          type: "string"
+                        bearerOnly:
+                          type: "boolean"
+                        claims:
+                          properties:
+                            address:
+                              type: "boolean"
+                            email:
+                              type: "boolean"
+                            gender:
+                              type: "boolean"
+                            locale:
+                              type: "boolean"
+                            name:
+                              type: "boolean"
+                            phone:
+                              type: "boolean"
+                            picture:
+                              type: "boolean"
+                            profile:
+                              type: "boolean"
+                            username:
+                              type: "boolean"
+                            website:
+                              type: "boolean"
+                          type: "object"
+                        clientAuthenticatorType:
+                          type: "string"
+                        clientId:
+                          type: "string"
+                        clientTemplate:
+                          type: "string"
+                        consentRequired:
+                          type: "boolean"
+                        defaultClientScopes:
+                          items:
+                            type: "string"
+                          type: "array"
+                        defaultRoles:
+                          items:
+                            type: "string"
+                          type: "array"
+                        description:
+                          type: "string"
+                        directAccessGrantsEnabled:
+                          type: "boolean"
+                        directGrantsOnly:
+                          type: "boolean"
+                        enabled:
+                          type: "boolean"
+                        frontchannelLogout:
+                          type: "boolean"
+                        fullScopeAllowed:
+                          type: "boolean"
+                        id:
+                          type: "string"
+                        implicitFlowEnabled:
+                          type: "boolean"
+                        name:
+                          type: "string"
+                        nodeReRegistrationTimeout:
+                          type: "integer"
+                        notBefore:
+                          type: "integer"
+                        optionalClientScopes:
+                          items:
+                            type: "string"
+                          type: "array"
+                        origin:
+                          type: "string"
+                        protocol:
+                          type: "string"
+                        protocolMappers:
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: "string"
+                                type: "object"
+                              consentRequired:
+                                type: "boolean"
+                              consentText:
+                                type: "string"
+                              id:
+                                type: "string"
+                              name:
+                                type: "string"
+                              protocol:
+                                type: "string"
+                              protocolMapper:
+                                type: "string"
+                            type: "object"
+                          type: "array"
+                        publicClient:
+                          type: "boolean"
+                        redirectUris:
+                          items:
+                            type: "string"
+                          type: "array"
+                        registeredNodes:
+                          additionalProperties:
+                            type: "integer"
+                          type: "object"
+                        registrationAccessToken:
+                          type: "string"
+                        rootUrl:
+                          type: "string"
+                        secret:
+                          type: "string"
+                        serviceAccountsEnabled:
+                          type: "boolean"
+                        standardFlowEnabled:
+                          type: "boolean"
+                        surrogateAuthRequired:
+                          type: "boolean"
+                        type:
+                          type: "string"
+                        useTemplateConfig:
+                          type: "boolean"
+                        useTemplateMappers:
+                          type: "boolean"
+                        useTemplateScope:
+                          type: "boolean"
+                        webOrigins:
+                          items:
+                            type: "string"
+                          type: "array"
+                      type: "object"
+                    type: "array"
+                  attributes:
+                    additionalProperties:
+                      type: "string"
+                    type: "object"
+                  authenticationFlows:
+                    items:
+                      properties:
+                        alias:
+                          type: "string"
+                        authenticationExecutions:
+                          items:
+                            properties:
+                              authenticator:
+                                type: "string"
+                              authenticatorConfig:
+                                type: "string"
+                              authenticatorFlow:
+                                type: "boolean"
+                              autheticatorFlow:
+                                type: "boolean"
+                              flowAlias:
+                                type: "string"
+                              priority:
+                                type: "integer"
+                              requirement:
+                                type: "string"
+                              userSetupAllowed:
+                                type: "boolean"
+                            type: "object"
+                          type: "array"
+                        builtIn:
+                          type: "boolean"
+                        description:
+                          type: "string"
+                        id:
+                          type: "string"
+                        providerId:
+                          type: "string"
+                        topLevel:
+                          type: "boolean"
+                      type: "object"
+                    type: "array"
+                  authenticatorConfig:
+                    items:
+                      properties:
+                        alias:
+                          type: "string"
+                        config:
+                          additionalProperties:
+                            type: "string"
+                          type: "object"
+                        id:
+                          type: "string"
+                      type: "object"
+                    type: "array"
+                  browserFlow:
+                    type: "string"
+                  browserSecurityHeaders:
+                    additionalProperties:
+                      type: "string"
+                    type: "object"
+                  bruteForceProtected:
+                    type: "boolean"
+                  bruteForceStrategy:
+                    enum:
+                    - "LINEAR"
+                    - "MULTIPLE"
+                    type: "string"
+                  certificate:
+                    type: "string"
+                  clientAuthenticationFlow:
+                    type: "string"
+                  clientOfflineSessionIdleTimeout:
+                    type: "integer"
+                  clientOfflineSessionMaxLifespan:
+                    type: "integer"
+                  clientPolicies:
+                    x-kubernetes-preserve-unknown-fields: true
+                  clientProfiles:
+                    x-kubernetes-preserve-unknown-fields: true
+                  clientScopeMappings:
+                    additionalProperties:
+                      items:
+                        properties:
+                          client:
+                            type: "string"
+                          clientScope:
+                            type: "string"
+                          clientTemplate:
+                            type: "string"
+                          roles:
+                            items:
+                              type: "string"
+                            type: "array"
+                          self:
+                            type: "string"
+                        type: "object"
+                      type: "array"
+                    type: "object"
+                  clientScopes:
+                    items:
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            type: "string"
+                          type: "object"
+                        description:
+                          type: "string"
+                        id:
+                          type: "string"
+                        name:
+                          type: "string"
+                        protocol:
+                          type: "string"
+                        protocolMappers:
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: "string"
+                                type: "object"
+                              consentRequired:
+                                type: "boolean"
+                              consentText:
+                                type: "string"
+                              id:
+                                type: "string"
+                              name:
+                                type: "string"
+                              protocol:
+                                type: "string"
+                              protocolMapper:
+                                type: "string"
+                            type: "object"
+                          type: "array"
+                      type: "object"
+                    type: "array"
+                  clientSessionIdleTimeout:
+                    type: "integer"
+                  clientSessionMaxLifespan:
+                    type: "integer"
+                  clientTemplates:
+                    items:
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            type: "string"
+                          type: "object"
+                        bearerOnly:
+                          type: "boolean"
+                        consentRequired:
+                          type: "boolean"
+                        description:
+                          type: "string"
+                        directAccessGrantsEnabled:
+                          type: "boolean"
+                        frontchannelLogout:
+                          type: "boolean"
+                        fullScopeAllowed:
+                          type: "boolean"
+                        id:
+                          type: "string"
+                        implicitFlowEnabled:
+                          type: "boolean"
+                        name:
+                          type: "string"
+                        protocol:
+                          type: "string"
+                        protocolMappers:
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: "string"
+                                type: "object"
+                              consentRequired:
+                                type: "boolean"
+                              consentText:
+                                type: "string"
+                              id:
+                                type: "string"
+                              name:
+                                type: "string"
+                              protocol:
+                                type: "string"
+                              protocolMapper:
+                                type: "string"
+                            type: "object"
+                          type: "array"
+                        publicClient:
+                          type: "boolean"
+                        serviceAccountsEnabled:
+                          type: "boolean"
+                        standardFlowEnabled:
+                          type: "boolean"
+                      type: "object"
+                    type: "array"
+                  clients:
+                    items:
+                      properties:
+                        access:
+                          additionalProperties:
+                            type: "boolean"
+                          type: "object"
+                        adminUrl:
+                          type: "string"
+                        alwaysDisplayInConsole:
+                          type: "boolean"
+                        attributes:
+                          additionalProperties:
+                            type: "string"
+                          type: "object"
+                        authenticationFlowBindingOverrides:
+                          additionalProperties:
+                            type: "string"
+                          type: "object"
+                        authorizationServicesEnabled:
+                          type: "boolean"
+                        authorizationSettings:
+                          properties:
+                            allowRemoteResourceManagement:
+                              type: "boolean"
+                            authorizationSchema:
+                              properties:
+                                resourceTypes:
+                                  additionalProperties:
+                                    properties:
+                                      groupType:
+                                        type: "string"
+                                      scopeAliases:
+                                        additionalProperties:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        type: "object"
+                                      scopes:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                      type:
+                                        type: "string"
+                                    type: "object"
+                                  type: "object"
+                              type: "object"
+                            clientId:
+                              type: "string"
+                            decisionStrategy:
+                              enum:
+                              - "AFFIRMATIVE"
+                              - "CONSENSUS"
+                              - "UNANIMOUS"
+                              type: "string"
+                            id:
+                              type: "string"
+                            name:
+                              type: "string"
+                            policies:
+                              items:
+                                properties:
+                                  config:
+                                    additionalProperties:
+                                      type: "string"
+                                    type: "object"
+                                  decisionStrategy:
+                                    enum:
+                                    - "AFFIRMATIVE"
+                                    - "CONSENSUS"
+                                    - "UNANIMOUS"
+                                    type: "string"
+                                  description:
+                                    type: "string"
+                                  id:
+                                    type: "string"
+                                  logic:
+                                    enum:
+                                    - "NEGATIVE"
+                                    - "POSITIVE"
+                                    type: "string"
+                                  name:
+                                    type: "string"
+                                  owner:
+                                    type: "string"
+                                  policies:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                  resourceType:
+                                    type: "string"
+                                  resources:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                  resourcesData:
+                                    items:
+                                      properties:
+                                        _id:
+                                          type: "string"
+                                        attributes:
+                                          additionalProperties:
+                                            items:
+                                              type: "string"
+                                            type: "array"
+                                          type: "object"
+                                        displayName:
+                                          type: "string"
+                                        icon_uri:
+                                          type: "string"
+                                        name:
+                                          type: "string"
+                                        owner:
+                                          properties:
+                                            id:
+                                              type: "string"
+                                            name:
+                                              type: "string"
+                                          type: "object"
+                                        ownerManagedAccess:
+                                          type: "boolean"
+                                        scopes:
+                                          items:
+                                            properties:
+                                              displayName:
+                                                type: "string"
+                                              iconUri:
+                                                type: "string"
+                                              id:
+                                                type: "string"
+                                              name:
+                                                type: "string"
+                                            type: "object"
+                                          type: "array"
+                                        type:
+                                          type: "string"
+                                        uris:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                      type: "object"
+                                    type: "array"
+                                  scopes:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                  scopesData:
+                                    items:
+                                      properties:
+                                        displayName:
+                                          type: "string"
+                                        iconUri:
+                                          type: "string"
+                                        id:
+                                          type: "string"
+                                        name:
+                                          type: "string"
+                                      type: "object"
+                                    type: "array"
+                                  type:
+                                    type: "string"
+                                type: "object"
+                              type: "array"
+                            policyEnforcementMode:
+                              enum:
+                              - "DISABLED"
+                              - "ENFORCING"
+                              - "PERMISSIVE"
+                              type: "string"
+                            resources:
+                              items:
+                                properties:
+                                  _id:
+                                    type: "string"
+                                  attributes:
+                                    additionalProperties:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    type: "object"
+                                  displayName:
+                                    type: "string"
+                                  icon_uri:
+                                    type: "string"
+                                  name:
+                                    type: "string"
+                                  owner:
+                                    properties:
+                                      id:
+                                        type: "string"
+                                      name:
+                                        type: "string"
+                                    type: "object"
+                                  ownerManagedAccess:
+                                    type: "boolean"
+                                  scopes:
+                                    items:
+                                      properties:
+                                        displayName:
+                                          type: "string"
+                                        iconUri:
+                                          type: "string"
+                                        id:
+                                          type: "string"
+                                        name:
+                                          type: "string"
+                                      type: "object"
+                                    type: "array"
+                                  type:
+                                    type: "string"
+                                  uris:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              type: "array"
+                            scopes:
+                              items:
+                                properties:
+                                  displayName:
+                                    type: "string"
+                                  iconUri:
+                                    type: "string"
+                                  id:
+                                    type: "string"
+                                  name:
+                                    type: "string"
+                                type: "object"
+                              type: "array"
+                          type: "object"
+                        baseUrl:
+                          type: "string"
+                        bearerOnly:
+                          type: "boolean"
+                        clientAuthenticatorType:
+                          type: "string"
+                        clientId:
+                          type: "string"
+                        clientTemplate:
+                          type: "string"
+                        consentRequired:
+                          type: "boolean"
+                        defaultClientScopes:
+                          items:
+                            type: "string"
+                          type: "array"
+                        defaultRoles:
+                          items:
+                            type: "string"
+                          type: "array"
+                        description:
+                          type: "string"
+                        directAccessGrantsEnabled:
+                          type: "boolean"
+                        directGrantsOnly:
+                          type: "boolean"
+                        enabled:
+                          type: "boolean"
+                        frontchannelLogout:
+                          type: "boolean"
+                        fullScopeAllowed:
+                          type: "boolean"
+                        id:
+                          type: "string"
+                        implicitFlowEnabled:
+                          type: "boolean"
+                        name:
+                          type: "string"
+                        nodeReRegistrationTimeout:
+                          type: "integer"
+                        notBefore:
+                          type: "integer"
+                        optionalClientScopes:
+                          items:
+                            type: "string"
+                          type: "array"
+                        origin:
+                          type: "string"
+                        protocol:
+                          type: "string"
+                        protocolMappers:
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: "string"
+                                type: "object"
+                              consentRequired:
+                                type: "boolean"
+                              consentText:
+                                type: "string"
+                              id:
+                                type: "string"
+                              name:
+                                type: "string"
+                              protocol:
+                                type: "string"
+                              protocolMapper:
+                                type: "string"
+                            type: "object"
+                          type: "array"
+                        publicClient:
+                          type: "boolean"
+                        redirectUris:
+                          items:
+                            type: "string"
+                          type: "array"
+                        registeredNodes:
+                          additionalProperties:
+                            type: "integer"
+                          type: "object"
+                        registrationAccessToken:
+                          type: "string"
+                        rootUrl:
+                          type: "string"
+                        secret:
+                          type: "string"
+                        serviceAccountsEnabled:
+                          type: "boolean"
+                        standardFlowEnabled:
+                          type: "boolean"
+                        surrogateAuthRequired:
+                          type: "boolean"
+                        type:
+                          type: "string"
+                        useTemplateConfig:
+                          type: "boolean"
+                        useTemplateMappers:
+                          type: "boolean"
+                        useTemplateScope:
+                          type: "boolean"
+                        webOrigins:
+                          items:
+                            type: "string"
+                          type: "array"
+                      type: "object"
+                    type: "array"
+                  codeSecret:
+                    type: "string"
+                  components:
+                    additionalProperties:
+                      items:
+                        properties:
+                          config:
+                            additionalProperties:
+                              items:
+                                type: "string"
+                              type: "array"
+                            type: "object"
+                          id:
+                            type: "string"
+                          name:
+                            type: "string"
+                          providerId:
+                            type: "string"
+                          subComponents:
+                            additionalProperties:
+                              items:
+                                properties:
+                                  config:
+                                    additionalProperties:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    type: "object"
+                                  id:
+                                    type: "string"
+                                  name:
+                                    type: "string"
+                                  providerId:
+                                    type: "string"
+                                  subComponents:
+                                    additionalProperties:
+                                      items:
+                                        properties:
+                                          config:
+                                            additionalProperties:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                            type: "object"
+                                          id:
+                                            type: "string"
+                                          name:
+                                            type: "string"
+                                          providerId:
+                                            type: "string"
+                                          subComponents:
+                                            additionalProperties:
+                                              items:
+                                                properties:
+                                                  config:
+                                                    additionalProperties:
+                                                      items:
+                                                        type: "string"
+                                                      type: "array"
+                                                    type: "object"
+                                                  id:
+                                                    type: "string"
+                                                  name:
+                                                    type: "string"
+                                                  providerId:
+                                                    type: "string"
+                                                  subComponents:
+                                                    additionalProperties:
+                                                      items:
+                                                        properties:
+                                                          config:
+                                                            additionalProperties:
+                                                              items:
+                                                                type: "string"
+                                                              type: "array"
+                                                            type: "object"
+                                                          id:
+                                                            type: "string"
+                                                          name:
+                                                            type: "string"
+                                                          providerId:
+                                                            type: "string"
+                                                          subComponents:
+                                                            additionalProperties:
+                                                              items:
+                                                                properties:
+                                                                  config:
+                                                                    additionalProperties:
+                                                                      items:
+                                                                        type: "string"
+                                                                      type: "array"
+                                                                    type: "object"
+                                                                  id:
+                                                                    type: "string"
+                                                                  name:
+                                                                    type: "string"
+                                                                  providerId:
+                                                                    type: "string"
+                                                                  subComponents:
+                                                                    additionalProperties:
+                                                                      items:
+                                                                        properties:
+                                                                          config:
+                                                                            additionalProperties:
+                                                                              items:
+                                                                                type: "string"
+                                                                              type: "array"
+                                                                            type: "object"
+                                                                          id:
+                                                                            type: "string"
+                                                                          name:
+                                                                            type: "string"
+                                                                          providerId:
+                                                                            type: "string"
+                                                                          subComponents:
+                                                                            additionalProperties:
+                                                                              items:
+                                                                                properties:
+                                                                                  config:
+                                                                                    additionalProperties:
+                                                                                      items:
+                                                                                        type: "string"
+                                                                                      type: "array"
+                                                                                    type: "object"
+                                                                                  id:
+                                                                                    type: "string"
+                                                                                  name:
+                                                                                    type: "string"
+                                                                                  providerId:
+                                                                                    type: "string"
+                                                                                  subComponents:
+                                                                                    additionalProperties:
+                                                                                      items:
+                                                                                        properties:
+                                                                                          config:
+                                                                                            additionalProperties:
+                                                                                              items:
+                                                                                                type: "string"
+                                                                                              type: "array"
+                                                                                            type: "object"
+                                                                                          id:
+                                                                                            type: "string"
+                                                                                          name:
+                                                                                            type: "string"
+                                                                                          providerId:
+                                                                                            type: "string"
+                                                                                          subComponents:
+                                                                                            additionalProperties:
+                                                                                              items:
+                                                                                                properties:
+                                                                                                  config:
+                                                                                                    additionalProperties:
+                                                                                                      items:
+                                                                                                        type: "string"
+                                                                                                      type: "array"
+                                                                                                    type: "object"
+                                                                                                  id:
+                                                                                                    type: "string"
+                                                                                                  name:
+                                                                                                    type: "string"
+                                                                                                  providerId:
+                                                                                                    type: "string"
+                                                                                                  subComponents:
+                                                                                                    additionalProperties:
+                                                                                                      items:
+                                                                                                        properties:
+                                                                                                          config:
+                                                                                                            additionalProperties:
+                                                                                                              items:
+                                                                                                                type: "string"
+                                                                                                              type: "array"
+                                                                                                            type: "object"
+                                                                                                          id:
+                                                                                                            type: "string"
+                                                                                                          name:
+                                                                                                            type: "string"
+                                                                                                          providerId:
+                                                                                                            type: "string"
+                                                                                                          subType:
+                                                                                                            type: "string"
+                                                                                                        type: "object"
+                                                                                                      type: "array"
+                                                                                                    type: "object"
+                                                                                                  subType:
+                                                                                                    type: "string"
+                                                                                                type: "object"
+                                                                                              type: "array"
+                                                                                            type: "object"
+                                                                                          subType:
+                                                                                            type: "string"
+                                                                                        type: "object"
+                                                                                      type: "array"
+                                                                                    type: "object"
+                                                                                  subType:
+                                                                                    type: "string"
+                                                                                type: "object"
+                                                                              type: "array"
+                                                                            type: "object"
+                                                                          subType:
+                                                                            type: "string"
+                                                                        type: "object"
+                                                                      type: "array"
+                                                                    type: "object"
+                                                                  subType:
+                                                                    type: "string"
+                                                                type: "object"
+                                                              type: "array"
+                                                            type: "object"
+                                                          subType:
+                                                            type: "string"
+                                                        type: "object"
+                                                      type: "array"
+                                                    type: "object"
+                                                  subType:
+                                                    type: "string"
+                                                type: "object"
+                                              type: "array"
+                                            type: "object"
+                                          subType:
+                                            type: "string"
+                                        type: "object"
+                                      type: "array"
+                                    type: "object"
+                                  subType:
+                                    type: "string"
+                                type: "object"
+                              type: "array"
+                            type: "object"
+                          subType:
+                            type: "string"
+                        type: "object"
+                      type: "array"
+                    type: "object"
+                  defaultDefaultClientScopes:
+                    items:
+                      type: "string"
+                    type: "array"
+                  defaultGroups:
+                    items:
+                      type: "string"
+                    type: "array"
+                  defaultLocale:
+                    type: "string"
+                  defaultOptionalClientScopes:
+                    items:
+                      type: "string"
+                    type: "array"
+                  defaultRole:
+                    properties:
+                      attributes:
+                        additionalProperties:
+                          items:
+                            type: "string"
+                          type: "array"
+                        type: "object"
+                      clientRole:
+                        type: "boolean"
+                      composite:
+                        type: "boolean"
+                      composites:
+                        properties:
+                          application:
+                            additionalProperties:
+                              items:
+                                type: "string"
+                              type: "array"
+                            type: "object"
+                          client:
+                            additionalProperties:
+                              items:
+                                type: "string"
+                              type: "array"
+                            type: "object"
+                          realm:
+                            items:
+                              type: "string"
+                            type: "array"
+                        type: "object"
+                      containerId:
+                        type: "string"
+                      description:
+                        type: "string"
+                      id:
+                        type: "string"
+                      name:
+                        type: "string"
+                      scopeParamRequired:
+                        type: "boolean"
+                    type: "object"
+                  defaultRoles:
+                    items:
+                      type: "string"
+                    type: "array"
+                  defaultSignatureAlgorithm:
+                    type: "string"
+                  directGrantFlow:
+                    type: "string"
+                  displayName:
+                    type: "string"
+                  displayNameHtml:
+                    type: "string"
+                  dockerAuthenticationFlow:
+                    type: "string"
+                  duplicateEmailsAllowed:
+                    type: "boolean"
+                  editUsernameAllowed:
+                    type: "boolean"
+                  emailTheme:
+                    type: "string"
+                  enabled:
+                    type: "boolean"
+                  enabledEventTypes:
+                    items:
+                      type: "string"
+                    type: "array"
+                  eventsEnabled:
+                    type: "boolean"
+                  eventsExpiration:
+                    type: "integer"
+                  eventsListeners:
+                    items:
+                      type: "string"
+                    type: "array"
+                  failureFactor:
+                    type: "integer"
+                  federatedUsers:
+                    items:
+                      properties:
+                        access:
+                          additionalProperties:
+                            type: "boolean"
+                          type: "object"
+                        applicationRoles:
+                          additionalProperties:
+                            items:
+                              type: "string"
+                            type: "array"
+                          type: "object"
+                        attributes:
+                          additionalProperties:
+                            items:
+                              type: "string"
+                            type: "array"
+                          type: "object"
+                        clientConsents:
+                          items:
+                            properties:
+                              clientId:
+                                type: "string"
+                              createdDate:
+                                type: "integer"
+                              grantedClientScopes:
+                                items:
+                                  type: "string"
+                                type: "array"
+                              grantedRealmRoles:
+                                items:
+                                  type: "string"
+                                type: "array"
+                              lastUpdatedDate:
+                                type: "integer"
+                            type: "object"
+                          type: "array"
+                        clientRoles:
+                          additionalProperties:
+                            items:
+                              type: "string"
+                            type: "array"
+                          type: "object"
+                        createdTimestamp:
+                          type: "integer"
+                        credentials:
+                          items:
+                            properties:
+                              algorithm:
+                                type: "string"
+                              config:
+                                additionalProperties:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                type: "object"
+                              counter:
+                                type: "integer"
+                              createdDate:
+                                type: "integer"
+                              credentialData:
+                                type: "string"
+                              device:
+                                type: "string"
+                              digits:
+                                type: "integer"
+                              federationLink:
+                                type: "string"
+                              hashIterations:
+                                type: "integer"
+                              hashedSaltedValue:
+                                type: "string"
+                              id:
+                                type: "string"
+                              period:
+                                type: "integer"
+                              priority:
+                                type: "integer"
+                              salt:
+                                type: "string"
+                              secretData:
+                                type: "string"
+                              temporary:
+                                type: "boolean"
+                              type:
+                                type: "string"
+                              userLabel:
+                                type: "string"
+                              value:
+                                type: "string"
+                            type: "object"
+                          type: "array"
+                        disableableCredentialTypes:
+                          items:
+                            type: "string"
+                          type: "array"
+                        email:
+                          type: "string"
+                        emailVerified:
+                          type: "boolean"
+                        enabled:
+                          type: "boolean"
+                        federatedIdentities:
+                          items:
+                            properties:
+                              identityProvider:
+                                type: "string"
+                              userId:
+                                type: "string"
+                              userName:
+                                type: "string"
+                            type: "object"
+                          type: "array"
+                        federationLink:
+                          type: "string"
+                        firstName:
+                          type: "string"
+                        groups:
+                          items:
+                            type: "string"
+                          type: "array"
+                        id:
+                          type: "string"
+                        lastName:
+                          type: "string"
+                        notBefore:
+                          type: "integer"
+                        origin:
+                          type: "string"
+                        realmRoles:
+                          items:
+                            type: "string"
+                          type: "array"
+                        requiredActions:
+                          items:
+                            type: "string"
+                          type: "array"
+                        self:
+                          type: "string"
+                        serviceAccountClientId:
+                          type: "string"
+                        socialLinks:
+                          items:
+                            properties:
+                              socialProvider:
+                                type: "string"
+                              socialUserId:
+                                type: "string"
+                              socialUsername:
+                                type: "string"
+                            type: "object"
+                          type: "array"
+                        totp:
+                          type: "boolean"
+                        userProfileMetadata:
+                          properties:
+                            attributes:
+                              items:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: "object"
+                                    type: "object"
+                                  defaultValue:
+                                    type: "string"
+                                  displayName:
+                                    type: "string"
+                                  group:
+                                    type: "string"
+                                  multivalued:
+                                    type: "boolean"
+                                  name:
+                                    type: "string"
+                                  readOnly:
+                                    type: "boolean"
+                                  required:
+                                    type: "boolean"
+                                  validators:
+                                    additionalProperties:
+                                      additionalProperties:
+                                        type: "object"
+                                      type: "object"
+                                    type: "object"
+                                type: "object"
+                              type: "array"
+                            groups:
+                              items:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: "object"
+                                    type: "object"
+                                  displayDescription:
+                                    type: "string"
+                                  displayHeader:
+                                    type: "string"
+                                  name:
+                                    type: "string"
+                                type: "object"
+                              type: "array"
+                          type: "object"
+                        username:
+                          type: "string"
+                      type: "object"
+                    type: "array"
+                  firstBrokerLoginFlow:
+                    type: "string"
+                  groups:
+                    items:
+                      properties:
+                        access:
+                          additionalProperties:
+                            type: "boolean"
+                          type: "object"
+                        attributes:
+                          additionalProperties:
+                            items:
+                              type: "string"
+                            type: "array"
+                          type: "object"
+                        clientRoles:
+                          additionalProperties:
+                            items:
+                              type: "string"
+                            type: "array"
+                          type: "object"
+                        description:
+                          type: "string"
+                        id:
+                          type: "string"
+                        name:
+                          type: "string"
+                        parentId:
+                          type: "string"
+                        path:
+                          type: "string"
+                        realmRoles:
+                          items:
+                            type: "string"
+                          type: "array"
+                        subGroupCount:
+                          type: "integer"
+                        subGroups:
+                          items:
+                            properties:
+                              access:
+                                additionalProperties:
+                                  type: "boolean"
+                                type: "object"
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                type: "object"
+                              clientRoles:
+                                additionalProperties:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                type: "object"
+                              description:
+                                type: "string"
+                              id:
+                                type: "string"
+                              name:
+                                type: "string"
+                              parentId:
+                                type: "string"
+                              path:
+                                type: "string"
+                              realmRoles:
+                                items:
+                                  type: "string"
+                                type: "array"
+                              subGroupCount:
+                                type: "integer"
+                              subGroups:
+                                items:
+                                  properties:
+                                    access:
+                                      additionalProperties:
+                                        type: "boolean"
+                                      type: "object"
+                                    attributes:
+                                      additionalProperties:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                      type: "object"
+                                    clientRoles:
+                                      additionalProperties:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                      type: "object"
+                                    description:
+                                      type: "string"
+                                    id:
+                                      type: "string"
+                                    name:
+                                      type: "string"
+                                    parentId:
+                                      type: "string"
+                                    path:
+                                      type: "string"
+                                    realmRoles:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    subGroupCount:
+                                      type: "integer"
+                                    subGroups:
+                                      items:
+                                        properties:
+                                          access:
+                                            additionalProperties:
+                                              type: "boolean"
+                                            type: "object"
+                                          attributes:
+                                            additionalProperties:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                            type: "object"
+                                          clientRoles:
+                                            additionalProperties:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                            type: "object"
+                                          description:
+                                            type: "string"
+                                          id:
+                                            type: "string"
+                                          name:
+                                            type: "string"
+                                          parentId:
+                                            type: "string"
+                                          path:
+                                            type: "string"
+                                          realmRoles:
+                                            items:
+                                              type: "string"
+                                            type: "array"
+                                          subGroupCount:
+                                            type: "integer"
+                                          subGroups:
+                                            items:
+                                              properties:
+                                                access:
+                                                  additionalProperties:
+                                                    type: "boolean"
+                                                  type: "object"
+                                                attributes:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                  type: "object"
+                                                clientRoles:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                  type: "object"
+                                                description:
+                                                  type: "string"
+                                                id:
+                                                  type: "string"
+                                                name:
+                                                  type: "string"
+                                                parentId:
+                                                  type: "string"
+                                                path:
+                                                  type: "string"
+                                                realmRoles:
+                                                  items:
+                                                    type: "string"
+                                                  type: "array"
+                                                subGroupCount:
+                                                  type: "integer"
+                                                subGroups:
+                                                  items:
+                                                    properties:
+                                                      access:
+                                                        additionalProperties:
+                                                          type: "boolean"
+                                                        type: "object"
+                                                      attributes:
+                                                        additionalProperties:
+                                                          items:
+                                                            type: "string"
+                                                          type: "array"
+                                                        type: "object"
+                                                      clientRoles:
+                                                        additionalProperties:
+                                                          items:
+                                                            type: "string"
+                                                          type: "array"
+                                                        type: "object"
+                                                      description:
+                                                        type: "string"
+                                                      id:
+                                                        type: "string"
+                                                      name:
+                                                        type: "string"
+                                                      parentId:
+                                                        type: "string"
+                                                      path:
+                                                        type: "string"
+                                                      realmRoles:
+                                                        items:
+                                                          type: "string"
+                                                        type: "array"
+                                                      subGroupCount:
+                                                        type: "integer"
+                                                      subGroups:
+                                                        items:
+                                                          properties:
+                                                            access:
+                                                              additionalProperties:
+                                                                type: "boolean"
+                                                              type: "object"
+                                                            attributes:
+                                                              additionalProperties:
+                                                                items:
+                                                                  type: "string"
+                                                                type: "array"
+                                                              type: "object"
+                                                            clientRoles:
+                                                              additionalProperties:
+                                                                items:
+                                                                  type: "string"
+                                                                type: "array"
+                                                              type: "object"
+                                                            description:
+                                                              type: "string"
+                                                            id:
+                                                              type: "string"
+                                                            name:
+                                                              type: "string"
+                                                            parentId:
+                                                              type: "string"
+                                                            path:
+                                                              type: "string"
+                                                            realmRoles:
+                                                              items:
+                                                                type: "string"
+                                                              type: "array"
+                                                            subGroupCount:
+                                                              type: "integer"
+                                                            subGroups:
+                                                              items:
+                                                                properties:
+                                                                  access:
+                                                                    additionalProperties:
+                                                                      type: "boolean"
+                                                                    type: "object"
+                                                                  attributes:
+                                                                    additionalProperties:
+                                                                      items:
+                                                                        type: "string"
+                                                                      type: "array"
+                                                                    type: "object"
+                                                                  clientRoles:
+                                                                    additionalProperties:
+                                                                      items:
+                                                                        type: "string"
+                                                                      type: "array"
+                                                                    type: "object"
+                                                                  description:
+                                                                    type: "string"
+                                                                  id:
+                                                                    type: "string"
+                                                                  name:
+                                                                    type: "string"
+                                                                  parentId:
+                                                                    type: "string"
+                                                                  path:
+                                                                    type: "string"
+                                                                  realmRoles:
+                                                                    items:
+                                                                      type: "string"
+                                                                    type: "array"
+                                                                  subGroupCount:
+                                                                    type: "integer"
+                                                                  subGroups:
+                                                                    items:
+                                                                      properties:
+                                                                        access:
+                                                                          additionalProperties:
+                                                                            type: "boolean"
+                                                                          type: "object"
+                                                                        attributes:
+                                                                          additionalProperties:
+                                                                            items:
+                                                                              type: "string"
+                                                                            type: "array"
+                                                                          type: "object"
+                                                                        clientRoles:
+                                                                          additionalProperties:
+                                                                            items:
+                                                                              type: "string"
+                                                                            type: "array"
+                                                                          type: "object"
+                                                                        description:
+                                                                          type: "string"
+                                                                        id:
+                                                                          type: "string"
+                                                                        name:
+                                                                          type: "string"
+                                                                        parentId:
+                                                                          type: "string"
+                                                                        path:
+                                                                          type: "string"
+                                                                        realmRoles:
+                                                                          items:
+                                                                            type: "string"
+                                                                          type: "array"
+                                                                        subGroupCount:
+                                                                          type: "integer"
+                                                                        subGroups:
+                                                                          items:
+                                                                            properties:
+                                                                              access:
+                                                                                additionalProperties:
+                                                                                  type: "boolean"
+                                                                                type: "object"
+                                                                              attributes:
+                                                                                additionalProperties:
+                                                                                  items:
+                                                                                    type: "string"
+                                                                                  type: "array"
+                                                                                type: "object"
+                                                                              clientRoles:
+                                                                                additionalProperties:
+                                                                                  items:
+                                                                                    type: "string"
+                                                                                  type: "array"
+                                                                                type: "object"
+                                                                              description:
+                                                                                type: "string"
+                                                                              id:
+                                                                                type: "string"
+                                                                              name:
+                                                                                type: "string"
+                                                                              parentId:
+                                                                                type: "string"
+                                                                              path:
+                                                                                type: "string"
+                                                                              realmRoles:
+                                                                                items:
+                                                                                  type: "string"
+                                                                                type: "array"
+                                                                              subGroupCount:
+                                                                                type: "integer"
+                                                                              subGroups:
+                                                                                items:
+                                                                                  properties:
+                                                                                    access:
+                                                                                      additionalProperties:
+                                                                                        type: "boolean"
+                                                                                      type: "object"
+                                                                                    attributes:
+                                                                                      additionalProperties:
+                                                                                        items:
+                                                                                          type: "string"
+                                                                                        type: "array"
+                                                                                      type: "object"
+                                                                                    clientRoles:
+                                                                                      additionalProperties:
+                                                                                        items:
+                                                                                          type: "string"
+                                                                                        type: "array"
+                                                                                      type: "object"
+                                                                                    description:
+                                                                                      type: "string"
+                                                                                    id:
+                                                                                      type: "string"
+                                                                                    name:
+                                                                                      type: "string"
+                                                                                    parentId:
+                                                                                      type: "string"
+                                                                                    path:
+                                                                                      type: "string"
+                                                                                    realmRoles:
+                                                                                      items:
+                                                                                        type: "string"
+                                                                                      type: "array"
+                                                                                    subGroupCount:
+                                                                                      type: "integer"
+                                                                                  type: "object"
+                                                                                type: "array"
+                                                                            type: "object"
+                                                                          type: "array"
+                                                                      type: "object"
+                                                                    type: "array"
+                                                                type: "object"
+                                                              type: "array"
+                                                          type: "object"
+                                                        type: "array"
+                                                    type: "object"
+                                                  type: "array"
+                                              type: "object"
+                                            type: "array"
+                                        type: "object"
+                                      type: "array"
+                                  type: "object"
+                                type: "array"
+                            type: "object"
+                          type: "array"
+                      type: "object"
+                    type: "array"
+                  id:
+                    type: "string"
+                  identityProviderMappers:
+                    items:
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: "string"
+                          type: "object"
+                        id:
+                          type: "string"
+                        identityProviderAlias:
+                          type: "string"
+                        identityProviderMapper:
+                          type: "string"
+                        name:
+                          type: "string"
+                      type: "object"
+                    type: "array"
+                  identityProviders:
+                    items:
+                      properties:
+                        addReadTokenRoleOnCreate:
+                          type: "boolean"
+                        alias:
+                          type: "string"
+                        authenticateByDefault:
+                          type: "boolean"
+                        config:
+                          additionalProperties:
+                            type: "string"
+                          type: "object"
+                        displayName:
+                          type: "string"
+                        enabled:
+                          type: "boolean"
+                        firstBrokerLoginFlowAlias:
+                          type: "string"
+                        hideOnLogin:
+                          type: "boolean"
+                        internalId:
+                          type: "string"
+                        linkOnly:
+                          type: "boolean"
+                        organizationId:
+                          type: "string"
+                        postBrokerLoginFlowAlias:
+                          type: "string"
+                        providerId:
+                          type: "string"
+                        storeToken:
+                          type: "boolean"
+                        trustEmail:
+                          type: "boolean"
+                        types:
+                          items:
+                            type: "string"
+                          type: "array"
+                        updateProfileFirstLoginMode:
+                          type: "string"
+                      type: "object"
+                    type: "array"
+                  internationalizationEnabled:
+                    type: "boolean"
+                  keycloakVersion:
+                    type: "string"
+                  localizationTexts:
+                    additionalProperties:
+                      additionalProperties:
+                        type: "string"
+                      type: "object"
+                    type: "object"
+                  loginTheme:
+                    type: "string"
+                  loginWithEmailAllowed:
+                    type: "boolean"
+                  maxDeltaTimeSeconds:
+                    type: "integer"
+                  maxFailureWaitSeconds:
+                    type: "integer"
+                  maxSecondaryAuthFailures:
+                    type: "integer"
+                  maxTemporaryLockouts:
+                    type: "integer"
+                  minimumQuickLoginWaitSeconds:
+                    type: "integer"
+                  notBefore:
+                    type: "integer"
+                  oauth2DeviceCodeLifespan:
+                    type: "integer"
+                  oauth2DevicePollingInterval:
+                    type: "integer"
+                  oauthClients:
+                    items:
+                      properties:
+                        access:
+                          additionalProperties:
+                            type: "boolean"
+                          type: "object"
+                        adminUrl:
+                          type: "string"
+                        alwaysDisplayInConsole:
+                          type: "boolean"
+                        attributes:
+                          additionalProperties:
+                            type: "string"
+                          type: "object"
+                        authenticationFlowBindingOverrides:
+                          additionalProperties:
+                            type: "string"
+                          type: "object"
+                        authorizationServicesEnabled:
+                          type: "boolean"
+                        authorizationSettings:
+                          properties:
+                            allowRemoteResourceManagement:
+                              type: "boolean"
+                            authorizationSchema:
+                              properties:
+                                resourceTypes:
+                                  additionalProperties:
+                                    properties:
+                                      groupType:
+                                        type: "string"
+                                      scopeAliases:
+                                        additionalProperties:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        type: "object"
+                                      scopes:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                      type:
+                                        type: "string"
+                                    type: "object"
+                                  type: "object"
+                              type: "object"
+                            clientId:
+                              type: "string"
+                            decisionStrategy:
+                              enum:
+                              - "AFFIRMATIVE"
+                              - "CONSENSUS"
+                              - "UNANIMOUS"
+                              type: "string"
+                            id:
+                              type: "string"
+                            name:
+                              type: "string"
+                            policies:
+                              items:
+                                properties:
+                                  config:
+                                    additionalProperties:
+                                      type: "string"
+                                    type: "object"
+                                  decisionStrategy:
+                                    enum:
+                                    - "AFFIRMATIVE"
+                                    - "CONSENSUS"
+                                    - "UNANIMOUS"
+                                    type: "string"
+                                  description:
+                                    type: "string"
+                                  id:
+                                    type: "string"
+                                  logic:
+                                    enum:
+                                    - "NEGATIVE"
+                                    - "POSITIVE"
+                                    type: "string"
+                                  name:
+                                    type: "string"
+                                  owner:
+                                    type: "string"
+                                  policies:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                  resourceType:
+                                    type: "string"
+                                  resources:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                  resourcesData:
+                                    items:
+                                      properties:
+                                        _id:
+                                          type: "string"
+                                        attributes:
+                                          additionalProperties:
+                                            items:
+                                              type: "string"
+                                            type: "array"
+                                          type: "object"
+                                        displayName:
+                                          type: "string"
+                                        icon_uri:
+                                          type: "string"
+                                        name:
+                                          type: "string"
+                                        owner:
+                                          properties:
+                                            id:
+                                              type: "string"
+                                            name:
+                                              type: "string"
+                                          type: "object"
+                                        ownerManagedAccess:
+                                          type: "boolean"
+                                        scopes:
+                                          items:
+                                            properties:
+                                              displayName:
+                                                type: "string"
+                                              iconUri:
+                                                type: "string"
+                                              id:
+                                                type: "string"
+                                              name:
+                                                type: "string"
+                                            type: "object"
+                                          type: "array"
+                                        type:
+                                          type: "string"
+                                        uris:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                      type: "object"
+                                    type: "array"
+                                  scopes:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                  scopesData:
+                                    items:
+                                      properties:
+                                        displayName:
+                                          type: "string"
+                                        iconUri:
+                                          type: "string"
+                                        id:
+                                          type: "string"
+                                        name:
+                                          type: "string"
+                                      type: "object"
+                                    type: "array"
+                                  type:
+                                    type: "string"
+                                type: "object"
+                              type: "array"
+                            policyEnforcementMode:
+                              enum:
+                              - "DISABLED"
+                              - "ENFORCING"
+                              - "PERMISSIVE"
+                              type: "string"
+                            resources:
+                              items:
+                                properties:
+                                  _id:
+                                    type: "string"
+                                  attributes:
+                                    additionalProperties:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    type: "object"
+                                  displayName:
+                                    type: "string"
+                                  icon_uri:
+                                    type: "string"
+                                  name:
+                                    type: "string"
+                                  owner:
+                                    properties:
+                                      id:
+                                        type: "string"
+                                      name:
+                                        type: "string"
+                                    type: "object"
+                                  ownerManagedAccess:
+                                    type: "boolean"
+                                  scopes:
+                                    items:
+                                      properties:
+                                        displayName:
+                                          type: "string"
+                                        iconUri:
+                                          type: "string"
+                                        id:
+                                          type: "string"
+                                        name:
+                                          type: "string"
+                                      type: "object"
+                                    type: "array"
+                                  type:
+                                    type: "string"
+                                  uris:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              type: "array"
+                            scopes:
+                              items:
+                                properties:
+                                  displayName:
+                                    type: "string"
+                                  iconUri:
+                                    type: "string"
+                                  id:
+                                    type: "string"
+                                  name:
+                                    type: "string"
+                                type: "object"
+                              type: "array"
+                          type: "object"
+                        baseUrl:
+                          type: "string"
+                        bearerOnly:
+                          type: "boolean"
+                        claims:
+                          properties:
+                            address:
+                              type: "boolean"
+                            email:
+                              type: "boolean"
+                            gender:
+                              type: "boolean"
+                            locale:
+                              type: "boolean"
+                            name:
+                              type: "boolean"
+                            phone:
+                              type: "boolean"
+                            picture:
+                              type: "boolean"
+                            profile:
+                              type: "boolean"
+                            username:
+                              type: "boolean"
+                            website:
+                              type: "boolean"
+                          type: "object"
+                        clientAuthenticatorType:
+                          type: "string"
+                        clientId:
+                          type: "string"
+                        clientTemplate:
+                          type: "string"
+                        consentRequired:
+                          type: "boolean"
+                        defaultClientScopes:
+                          items:
+                            type: "string"
+                          type: "array"
+                        defaultRoles:
+                          items:
+                            type: "string"
+                          type: "array"
+                        description:
+                          type: "string"
+                        directAccessGrantsEnabled:
+                          type: "boolean"
+                        directGrantsOnly:
+                          type: "boolean"
+                        enabled:
+                          type: "boolean"
+                        frontchannelLogout:
+                          type: "boolean"
+                        fullScopeAllowed:
+                          type: "boolean"
+                        id:
+                          type: "string"
+                        implicitFlowEnabled:
+                          type: "boolean"
+                        name:
+                          type: "string"
+                        nodeReRegistrationTimeout:
+                          type: "integer"
+                        notBefore:
+                          type: "integer"
+                        optionalClientScopes:
+                          items:
+                            type: "string"
+                          type: "array"
+                        origin:
+                          type: "string"
+                        protocol:
+                          type: "string"
+                        protocolMappers:
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: "string"
+                                type: "object"
+                              consentRequired:
+                                type: "boolean"
+                              consentText:
+                                type: "string"
+                              id:
+                                type: "string"
+                              name:
+                                type: "string"
+                              protocol:
+                                type: "string"
+                              protocolMapper:
+                                type: "string"
+                            type: "object"
+                          type: "array"
+                        publicClient:
+                          type: "boolean"
+                        redirectUris:
+                          items:
+                            type: "string"
+                          type: "array"
+                        registeredNodes:
+                          additionalProperties:
+                            type: "integer"
+                          type: "object"
+                        registrationAccessToken:
+                          type: "string"
+                        rootUrl:
+                          type: "string"
+                        secret:
+                          type: "string"
+                        serviceAccountsEnabled:
+                          type: "boolean"
+                        standardFlowEnabled:
+                          type: "boolean"
+                        surrogateAuthRequired:
+                          type: "boolean"
+                        type:
+                          type: "string"
+                        useTemplateConfig:
+                          type: "boolean"
+                        useTemplateMappers:
+                          type: "boolean"
+                        useTemplateScope:
+                          type: "boolean"
+                        webOrigins:
+                          items:
+                            type: "string"
+                          type: "array"
+                      type: "object"
+                    type: "array"
+                  offlineSessionIdleTimeout:
+                    type: "integer"
+                  offlineSessionMaxLifespan:
+                    type: "integer"
+                  offlineSessionMaxLifespanEnabled:
+                    type: "boolean"
+                  organizations:
+                    items:
+                      properties:
+                        alias:
+                          type: "string"
+                        attributes:
+                          additionalProperties:
+                            items:
+                              type: "string"
+                            type: "array"
+                          type: "object"
+                        description:
+                          type: "string"
+                        domains:
+                          items:
+                            properties:
+                              name:
+                                type: "string"
+                              verified:
+                                type: "boolean"
+                            type: "object"
+                          type: "array"
+                        enabled:
+                          type: "boolean"
+                        groups:
+                          items:
+                            properties:
+                              access:
+                                additionalProperties:
+                                  type: "boolean"
+                                type: "object"
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                type: "object"
+                              clientRoles:
+                                additionalProperties:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                type: "object"
+                              description:
+                                type: "string"
+                              id:
+                                type: "string"
+                              name:
+                                type: "string"
+                              parentId:
+                                type: "string"
+                              path:
+                                type: "string"
+                              realmRoles:
+                                items:
+                                  type: "string"
+                                type: "array"
+                              subGroupCount:
+                                type: "integer"
+                              subGroups:
+                                items:
+                                  properties:
+                                    access:
+                                      additionalProperties:
+                                        type: "boolean"
+                                      type: "object"
+                                    attributes:
+                                      additionalProperties:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                      type: "object"
+                                    clientRoles:
+                                      additionalProperties:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                      type: "object"
+                                    description:
+                                      type: "string"
+                                    id:
+                                      type: "string"
+                                    name:
+                                      type: "string"
+                                    parentId:
+                                      type: "string"
+                                    path:
+                                      type: "string"
+                                    realmRoles:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    subGroupCount:
+                                      type: "integer"
+                                    subGroups:
+                                      items:
+                                        properties:
+                                          access:
+                                            additionalProperties:
+                                              type: "boolean"
+                                            type: "object"
+                                          attributes:
+                                            additionalProperties:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                            type: "object"
+                                          clientRoles:
+                                            additionalProperties:
+                                              items:
+                                                type: "string"
+                                              type: "array"
+                                            type: "object"
+                                          description:
+                                            type: "string"
+                                          id:
+                                            type: "string"
+                                          name:
+                                            type: "string"
+                                          parentId:
+                                            type: "string"
+                                          path:
+                                            type: "string"
+                                          realmRoles:
+                                            items:
+                                              type: "string"
+                                            type: "array"
+                                          subGroupCount:
+                                            type: "integer"
+                                          subGroups:
+                                            items:
+                                              properties:
+                                                access:
+                                                  additionalProperties:
+                                                    type: "boolean"
+                                                  type: "object"
+                                                attributes:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                  type: "object"
+                                                clientRoles:
+                                                  additionalProperties:
+                                                    items:
+                                                      type: "string"
+                                                    type: "array"
+                                                  type: "object"
+                                                description:
+                                                  type: "string"
+                                                id:
+                                                  type: "string"
+                                                name:
+                                                  type: "string"
+                                                parentId:
+                                                  type: "string"
+                                                path:
+                                                  type: "string"
+                                                realmRoles:
+                                                  items:
+                                                    type: "string"
+                                                  type: "array"
+                                                subGroupCount:
+                                                  type: "integer"
+                                                subGroups:
+                                                  items:
+                                                    properties:
+                                                      access:
+                                                        additionalProperties:
+                                                          type: "boolean"
+                                                        type: "object"
+                                                      attributes:
+                                                        additionalProperties:
+                                                          items:
+                                                            type: "string"
+                                                          type: "array"
+                                                        type: "object"
+                                                      clientRoles:
+                                                        additionalProperties:
+                                                          items:
+                                                            type: "string"
+                                                          type: "array"
+                                                        type: "object"
+                                                      description:
+                                                        type: "string"
+                                                      id:
+                                                        type: "string"
+                                                      name:
+                                                        type: "string"
+                                                      parentId:
+                                                        type: "string"
+                                                      path:
+                                                        type: "string"
+                                                      realmRoles:
+                                                        items:
+                                                          type: "string"
+                                                        type: "array"
+                                                      subGroupCount:
+                                                        type: "integer"
+                                                      subGroups:
+                                                        items:
+                                                          properties:
+                                                            access:
+                                                              additionalProperties:
+                                                                type: "boolean"
+                                                              type: "object"
+                                                            attributes:
+                                                              additionalProperties:
+                                                                items:
+                                                                  type: "string"
+                                                                type: "array"
+                                                              type: "object"
+                                                            clientRoles:
+                                                              additionalProperties:
+                                                                items:
+                                                                  type: "string"
+                                                                type: "array"
+                                                              type: "object"
+                                                            description:
+                                                              type: "string"
+                                                            id:
+                                                              type: "string"
+                                                            name:
+                                                              type: "string"
+                                                            parentId:
+                                                              type: "string"
+                                                            path:
+                                                              type: "string"
+                                                            realmRoles:
+                                                              items:
+                                                                type: "string"
+                                                              type: "array"
+                                                            subGroupCount:
+                                                              type: "integer"
+                                                            subGroups:
+                                                              items:
+                                                                properties:
+                                                                  access:
+                                                                    additionalProperties:
+                                                                      type: "boolean"
+                                                                    type: "object"
+                                                                  attributes:
+                                                                    additionalProperties:
+                                                                      items:
+                                                                        type: "string"
+                                                                      type: "array"
+                                                                    type: "object"
+                                                                  clientRoles:
+                                                                    additionalProperties:
+                                                                      items:
+                                                                        type: "string"
+                                                                      type: "array"
+                                                                    type: "object"
+                                                                  description:
+                                                                    type: "string"
+                                                                  id:
+                                                                    type: "string"
+                                                                  name:
+                                                                    type: "string"
+                                                                  parentId:
+                                                                    type: "string"
+                                                                  path:
+                                                                    type: "string"
+                                                                  realmRoles:
+                                                                    items:
+                                                                      type: "string"
+                                                                    type: "array"
+                                                                  subGroupCount:
+                                                                    type: "integer"
+                                                                  subGroups:
+                                                                    items:
+                                                                      properties:
+                                                                        access:
+                                                                          additionalProperties:
+                                                                            type: "boolean"
+                                                                          type: "object"
+                                                                        attributes:
+                                                                          additionalProperties:
+                                                                            items:
+                                                                              type: "string"
+                                                                            type: "array"
+                                                                          type: "object"
+                                                                        clientRoles:
+                                                                          additionalProperties:
+                                                                            items:
+                                                                              type: "string"
+                                                                            type: "array"
+                                                                          type: "object"
+                                                                        description:
+                                                                          type: "string"
+                                                                        id:
+                                                                          type: "string"
+                                                                        name:
+                                                                          type: "string"
+                                                                        parentId:
+                                                                          type: "string"
+                                                                        path:
+                                                                          type: "string"
+                                                                        realmRoles:
+                                                                          items:
+                                                                            type: "string"
+                                                                          type: "array"
+                                                                        subGroupCount:
+                                                                          type: "integer"
+                                                                        subGroups:
+                                                                          items:
+                                                                            properties:
+                                                                              access:
+                                                                                additionalProperties:
+                                                                                  type: "boolean"
+                                                                                type: "object"
+                                                                              attributes:
+                                                                                additionalProperties:
+                                                                                  items:
+                                                                                    type: "string"
+                                                                                  type: "array"
+                                                                                type: "object"
+                                                                              clientRoles:
+                                                                                additionalProperties:
+                                                                                  items:
+                                                                                    type: "string"
+                                                                                  type: "array"
+                                                                                type: "object"
+                                                                              description:
+                                                                                type: "string"
+                                                                              id:
+                                                                                type: "string"
+                                                                              name:
+                                                                                type: "string"
+                                                                              parentId:
+                                                                                type: "string"
+                                                                              path:
+                                                                                type: "string"
+                                                                              realmRoles:
+                                                                                items:
+                                                                                  type: "string"
+                                                                                type: "array"
+                                                                              subGroupCount:
+                                                                                type: "integer"
+                                                                              subGroups:
+                                                                                items:
+                                                                                  properties:
+                                                                                    access:
+                                                                                      additionalProperties:
+                                                                                        type: "boolean"
+                                                                                      type: "object"
+                                                                                    attributes:
+                                                                                      additionalProperties:
+                                                                                        items:
+                                                                                          type: "string"
+                                                                                        type: "array"
+                                                                                      type: "object"
+                                                                                    clientRoles:
+                                                                                      additionalProperties:
+                                                                                        items:
+                                                                                          type: "string"
+                                                                                        type: "array"
+                                                                                      type: "object"
+                                                                                    description:
+                                                                                      type: "string"
+                                                                                    id:
+                                                                                      type: "string"
+                                                                                    name:
+                                                                                      type: "string"
+                                                                                    parentId:
+                                                                                      type: "string"
+                                                                                    path:
+                                                                                      type: "string"
+                                                                                    realmRoles:
+                                                                                      items:
+                                                                                        type: "string"
+                                                                                      type: "array"
+                                                                                    subGroupCount:
+                                                                                      type: "integer"
+                                                                                    subGroups:
+                                                                                      items:
+                                                                                        properties:
+                                                                                          access:
+                                                                                            additionalProperties:
+                                                                                              type: "boolean"
+                                                                                            type: "object"
+                                                                                          attributes:
+                                                                                            additionalProperties:
+                                                                                              items:
+                                                                                                type: "string"
+                                                                                              type: "array"
+                                                                                            type: "object"
+                                                                                          clientRoles:
+                                                                                            additionalProperties:
+                                                                                              items:
+                                                                                                type: "string"
+                                                                                              type: "array"
+                                                                                            type: "object"
+                                                                                          description:
+                                                                                            type: "string"
+                                                                                          id:
+                                                                                            type: "string"
+                                                                                          name:
+                                                                                            type: "string"
+                                                                                          parentId:
+                                                                                            type: "string"
+                                                                                          path:
+                                                                                            type: "string"
+                                                                                          realmRoles:
+                                                                                            items:
+                                                                                              type: "string"
+                                                                                            type: "array"
+                                                                                          subGroupCount:
+                                                                                            type: "integer"
+                                                                                        type: "object"
+                                                                                      type: "array"
+                                                                                  type: "object"
+                                                                                type: "array"
+                                                                            type: "object"
+                                                                          type: "array"
+                                                                      type: "object"
+                                                                    type: "array"
+                                                                type: "object"
+                                                              type: "array"
+                                                          type: "object"
+                                                        type: "array"
+                                                    type: "object"
+                                                  type: "array"
+                                              type: "object"
+                                            type: "array"
+                                        type: "object"
+                                      type: "array"
+                                  type: "object"
+                                type: "array"
+                            type: "object"
+                          type: "array"
+                        id:
+                          type: "string"
+                        identityProviders:
+                          items:
+                            properties:
+                              addReadTokenRoleOnCreate:
+                                type: "boolean"
+                              alias:
+                                type: "string"
+                              authenticateByDefault:
+                                type: "boolean"
+                              config:
+                                additionalProperties:
+                                  type: "string"
+                                type: "object"
+                              displayName:
+                                type: "string"
+                              enabled:
+                                type: "boolean"
+                              firstBrokerLoginFlowAlias:
+                                type: "string"
+                              hideOnLogin:
+                                type: "boolean"
+                              internalId:
+                                type: "string"
+                              linkOnly:
+                                type: "boolean"
+                              organizationId:
+                                type: "string"
+                              postBrokerLoginFlowAlias:
+                                type: "string"
+                              providerId:
+                                type: "string"
+                              storeToken:
+                                type: "boolean"
+                              trustEmail:
+                                type: "boolean"
+                              types:
+                                items:
+                                  type: "string"
+                                type: "array"
+                              updateProfileFirstLoginMode:
+                                type: "string"
+                            type: "object"
+                          type: "array"
+                        members:
+                          items:
+                            properties:
+                              access:
+                                additionalProperties:
+                                  type: "boolean"
+                                type: "object"
+                              applicationRoles:
+                                additionalProperties:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                type: "object"
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                type: "object"
+                              clientConsents:
+                                items:
+                                  properties:
+                                    clientId:
+                                      type: "string"
+                                    createdDate:
+                                      type: "integer"
+                                    grantedClientScopes:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    grantedRealmRoles:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    lastUpdatedDate:
+                                      type: "integer"
+                                  type: "object"
+                                type: "array"
+                              clientRoles:
+                                additionalProperties:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                type: "object"
+                              createdTimestamp:
+                                type: "integer"
+                              credentials:
+                                items:
+                                  properties:
+                                    algorithm:
+                                      type: "string"
+                                    config:
+                                      additionalProperties:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                      type: "object"
+                                    counter:
+                                      type: "integer"
+                                    createdDate:
+                                      type: "integer"
+                                    credentialData:
+                                      type: "string"
+                                    device:
+                                      type: "string"
+                                    digits:
+                                      type: "integer"
+                                    federationLink:
+                                      type: "string"
+                                    hashIterations:
+                                      type: "integer"
+                                    hashedSaltedValue:
+                                      type: "string"
+                                    id:
+                                      type: "string"
+                                    period:
+                                      type: "integer"
+                                    priority:
+                                      type: "integer"
+                                    salt:
+                                      type: "string"
+                                    secretData:
+                                      type: "string"
+                                    temporary:
+                                      type: "boolean"
+                                    type:
+                                      type: "string"
+                                    userLabel:
+                                      type: "string"
+                                    value:
+                                      type: "string"
+                                  type: "object"
+                                type: "array"
+                              disableableCredentialTypes:
+                                items:
+                                  type: "string"
+                                type: "array"
+                              email:
+                                type: "string"
+                              emailVerified:
+                                type: "boolean"
+                              enabled:
+                                type: "boolean"
+                              federatedIdentities:
+                                items:
+                                  properties:
+                                    identityProvider:
+                                      type: "string"
+                                    userId:
+                                      type: "string"
+                                    userName:
+                                      type: "string"
+                                  type: "object"
+                                type: "array"
+                              federationLink:
+                                type: "string"
+                              firstName:
+                                type: "string"
+                              groups:
+                                items:
+                                  type: "string"
+                                type: "array"
+                              id:
+                                type: "string"
+                              lastName:
+                                type: "string"
+                              membershipType:
+                                enum:
+                                - "MANAGED"
+                                - "UNMANAGED"
+                                type: "string"
+                              notBefore:
+                                type: "integer"
+                              origin:
+                                type: "string"
+                              realmRoles:
+                                items:
+                                  type: "string"
+                                type: "array"
+                              requiredActions:
+                                items:
+                                  type: "string"
+                                type: "array"
+                              self:
+                                type: "string"
+                              serviceAccountClientId:
+                                type: "string"
+                              socialLinks:
+                                items:
+                                  properties:
+                                    socialProvider:
+                                      type: "string"
+                                    socialUserId:
+                                      type: "string"
+                                    socialUsername:
+                                      type: "string"
+                                  type: "object"
+                                type: "array"
+                              totp:
+                                type: "boolean"
+                              userProfileMetadata:
+                                properties:
+                                  attributes:
+                                    items:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: "object"
+                                          type: "object"
+                                        defaultValue:
+                                          type: "string"
+                                        displayName:
+                                          type: "string"
+                                        group:
+                                          type: "string"
+                                        multivalued:
+                                          type: "boolean"
+                                        name:
+                                          type: "string"
+                                        readOnly:
+                                          type: "boolean"
+                                        required:
+                                          type: "boolean"
+                                        validators:
+                                          additionalProperties:
+                                            additionalProperties:
+                                              type: "object"
+                                            type: "object"
+                                          type: "object"
+                                      type: "object"
+                                    type: "array"
+                                  groups:
+                                    items:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: "object"
+                                          type: "object"
+                                        displayDescription:
+                                          type: "string"
+                                        displayHeader:
+                                          type: "string"
+                                        name:
+                                          type: "string"
+                                      type: "object"
+                                    type: "array"
+                                type: "object"
+                              username:
+                                type: "string"
+                            type: "object"
+                          type: "array"
+                        name:
+                          type: "string"
+                        redirectUrl:
+                          type: "string"
+                      type: "object"
+                    type: "array"
+                  organizationsEnabled:
+                    type: "boolean"
+                  otpPolicyAlgorithm:
+                    type: "string"
+                  otpPolicyCodeReusable:
+                    type: "boolean"
+                  otpPolicyDigits:
+                    type: "integer"
+                  otpPolicyInitialCounter:
+                    type: "integer"
+                  otpPolicyLookAheadWindow:
+                    type: "integer"
+                  otpPolicyPeriod:
+                    type: "integer"
+                  otpPolicyType:
+                    type: "string"
+                  otpSupportedApplications:
+                    items:
+                      type: "string"
+                    type: "array"
+                  passwordCredentialGrantAllowed:
+                    type: "boolean"
+                  passwordPolicy:
+                    type: "string"
+                  permanentLockout:
+                    type: "boolean"
+                  privateKey:
+                    type: "string"
+                  protocolMappers:
+                    items:
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: "string"
+                          type: "object"
+                        consentRequired:
+                          type: "boolean"
+                        consentText:
+                          type: "string"
+                        id:
+                          type: "string"
+                        name:
+                          type: "string"
+                        protocol:
+                          type: "string"
+                        protocolMapper:
+                          type: "string"
+                      type: "object"
+                    type: "array"
+                  publicKey:
+                    type: "string"
+                  quickLoginCheckMilliSeconds:
+                    type: "integer"
+                  realm:
+                    type: "string"
+                  refreshTokenMaxReuse:
+                    type: "integer"
+                  registrationAllowed:
+                    type: "boolean"
+                  registrationEmailAsUsername:
+                    type: "boolean"
+                  registrationFlow:
+                    type: "string"
+                  rememberMe:
+                    type: "boolean"
+                  requiredActions:
+                    items:
+                      properties:
+                        alias:
+                          type: "string"
+                        config:
+                          additionalProperties:
+                            type: "string"
+                          type: "object"
+                        defaultAction:
+                          type: "boolean"
+                        enabled:
+                          type: "boolean"
+                        name:
+                          type: "string"
+                        priority:
+                          type: "integer"
+                        providerId:
+                          type: "string"
+                      type: "object"
+                    type: "array"
+                  requiredCredentials:
+                    items:
+                      type: "string"
+                    type: "array"
+                  resetCredentialsFlow:
+                    type: "string"
+                  resetPasswordAllowed:
+                    type: "boolean"
+                  revokeRefreshToken:
+                    type: "boolean"
+                  roles:
+                    properties:
+                      application:
+                        additionalProperties:
+                          items:
+                            properties:
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                type: "object"
+                              clientRole:
+                                type: "boolean"
+                              composite:
+                                type: "boolean"
+                              composites:
+                                properties:
+                                  application:
+                                    additionalProperties:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    type: "object"
+                                  client:
+                                    additionalProperties:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    type: "object"
+                                  realm:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              containerId:
+                                type: "string"
+                              description:
+                                type: "string"
+                              id:
+                                type: "string"
+                              name:
+                                type: "string"
+                              scopeParamRequired:
+                                type: "boolean"
+                            type: "object"
+                          type: "array"
+                        type: "object"
+                      client:
+                        additionalProperties:
+                          items:
+                            properties:
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                type: "object"
+                              clientRole:
+                                type: "boolean"
+                              composite:
+                                type: "boolean"
+                              composites:
+                                properties:
+                                  application:
+                                    additionalProperties:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    type: "object"
+                                  client:
+                                    additionalProperties:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    type: "object"
+                                  realm:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              containerId:
+                                type: "string"
+                              description:
+                                type: "string"
+                              id:
+                                type: "string"
+                              name:
+                                type: "string"
+                              scopeParamRequired:
+                                type: "boolean"
+                            type: "object"
+                          type: "array"
+                        type: "object"
+                      realm:
+                        items:
+                          properties:
+                            attributes:
+                              additionalProperties:
+                                items:
+                                  type: "string"
+                                type: "array"
+                              type: "object"
+                            clientRole:
+                              type: "boolean"
+                            composite:
+                              type: "boolean"
+                            composites:
+                              properties:
+                                application:
+                                  additionalProperties:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                  type: "object"
+                                client:
+                                  additionalProperties:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                  type: "object"
+                                realm:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                              type: "object"
+                            containerId:
+                              type: "string"
+                            description:
+                              type: "string"
+                            id:
+                              type: "string"
+                            name:
+                              type: "string"
+                            scopeParamRequired:
+                              type: "boolean"
+                          type: "object"
+                        type: "array"
+                    type: "object"
+                  scimApiEnabled:
+                    type: "boolean"
+                  scopeMappings:
+                    items:
+                      properties:
+                        client:
+                          type: "string"
+                        clientScope:
+                          type: "string"
+                        clientTemplate:
+                          type: "string"
+                        roles:
+                          items:
+                            type: "string"
+                          type: "array"
+                        self:
+                          type: "string"
+                      type: "object"
+                    type: "array"
+                  smtpServer:
+                    additionalProperties:
+                      type: "string"
+                    type: "object"
+                  social:
+                    type: "boolean"
+                  socialProviders:
+                    additionalProperties:
+                      type: "string"
+                    type: "object"
+                  sslRequired:
+                    type: "string"
+                  ssoSessionIdleTimeout:
+                    type: "integer"
+                  ssoSessionIdleTimeoutRememberMe:
+                    type: "integer"
+                  ssoSessionMaxLifespan:
+                    type: "integer"
+                  ssoSessionMaxLifespanRememberMe:
+                    type: "integer"
+                  supportedLocales:
+                    items:
+                      type: "string"
+                    type: "array"
+                  updateProfileOnInitialSocialLogin:
+                    type: "boolean"
+                  userFederationMappers:
+                    items:
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: "string"
+                          type: "object"
+                        federationMapperType:
+                          type: "string"
+                        federationProviderDisplayName:
+                          type: "string"
+                        id:
+                          type: "string"
+                        name:
+                          type: "string"
+                      type: "object"
+                    type: "array"
+                  userFederationProviders:
+                    items:
+                      properties:
+                        changedSyncPeriod:
+                          type: "integer"
+                        config:
+                          additionalProperties:
+                            type: "string"
+                          type: "object"
+                        displayName:
+                          type: "string"
+                        fullSyncPeriod:
+                          type: "integer"
+                        id:
+                          type: "string"
+                        lastSync:
+                          type: "integer"
+                        priority:
+                          type: "integer"
+                        providerName:
+                          type: "string"
+                      type: "object"
+                    type: "array"
+                  userManagedAccessAllowed:
+                    type: "boolean"
+                  users:
+                    items:
+                      properties:
+                        access:
+                          additionalProperties:
+                            type: "boolean"
+                          type: "object"
+                        applicationRoles:
+                          additionalProperties:
+                            items:
+                              type: "string"
+                            type: "array"
+                          type: "object"
+                        attributes:
+                          additionalProperties:
+                            items:
+                              type: "string"
+                            type: "array"
+                          type: "object"
+                        clientConsents:
+                          items:
+                            properties:
+                              clientId:
+                                type: "string"
+                              createdDate:
+                                type: "integer"
+                              grantedClientScopes:
+                                items:
+                                  type: "string"
+                                type: "array"
+                              grantedRealmRoles:
+                                items:
+                                  type: "string"
+                                type: "array"
+                              lastUpdatedDate:
+                                type: "integer"
+                            type: "object"
+                          type: "array"
+                        clientRoles:
+                          additionalProperties:
+                            items:
+                              type: "string"
+                            type: "array"
+                          type: "object"
+                        createdTimestamp:
+                          type: "integer"
+                        credentials:
+                          items:
+                            properties:
+                              algorithm:
+                                type: "string"
+                              config:
+                                additionalProperties:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                type: "object"
+                              counter:
+                                type: "integer"
+                              createdDate:
+                                type: "integer"
+                              credentialData:
+                                type: "string"
+                              device:
+                                type: "string"
+                              digits:
+                                type: "integer"
+                              federationLink:
+                                type: "string"
+                              hashIterations:
+                                type: "integer"
+                              hashedSaltedValue:
+                                type: "string"
+                              id:
+                                type: "string"
+                              period:
+                                type: "integer"
+                              priority:
+                                type: "integer"
+                              salt:
+                                type: "string"
+                              secretData:
+                                type: "string"
+                              temporary:
+                                type: "boolean"
+                              type:
+                                type: "string"
+                              userLabel:
+                                type: "string"
+                              value:
+                                type: "string"
+                            type: "object"
+                          type: "array"
+                        disableableCredentialTypes:
+                          items:
+                            type: "string"
+                          type: "array"
+                        email:
+                          type: "string"
+                        emailVerified:
+                          type: "boolean"
+                        enabled:
+                          type: "boolean"
+                        federatedIdentities:
+                          items:
+                            properties:
+                              identityProvider:
+                                type: "string"
+                              userId:
+                                type: "string"
+                              userName:
+                                type: "string"
+                            type: "object"
+                          type: "array"
+                        federationLink:
+                          type: "string"
+                        firstName:
+                          type: "string"
+                        groups:
+                          items:
+                            type: "string"
+                          type: "array"
+                        id:
+                          type: "string"
+                        lastName:
+                          type: "string"
+                        notBefore:
+                          type: "integer"
+                        origin:
+                          type: "string"
+                        realmRoles:
+                          items:
+                            type: "string"
+                          type: "array"
+                        requiredActions:
+                          items:
+                            type: "string"
+                          type: "array"
+                        self:
+                          type: "string"
+                        serviceAccountClientId:
+                          type: "string"
+                        socialLinks:
+                          items:
+                            properties:
+                              socialProvider:
+                                type: "string"
+                              socialUserId:
+                                type: "string"
+                              socialUsername:
+                                type: "string"
+                            type: "object"
+                          type: "array"
+                        totp:
+                          type: "boolean"
+                        userProfileMetadata:
+                          properties:
+                            attributes:
+                              items:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: "object"
+                                    type: "object"
+                                  defaultValue:
+                                    type: "string"
+                                  displayName:
+                                    type: "string"
+                                  group:
+                                    type: "string"
+                                  multivalued:
+                                    type: "boolean"
+                                  name:
+                                    type: "string"
+                                  readOnly:
+                                    type: "boolean"
+                                  required:
+                                    type: "boolean"
+                                  validators:
+                                    additionalProperties:
+                                      additionalProperties:
+                                        type: "object"
+                                      type: "object"
+                                    type: "object"
+                                type: "object"
+                              type: "array"
+                            groups:
+                              items:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: "object"
+                                    type: "object"
+                                  displayDescription:
+                                    type: "string"
+                                  displayHeader:
+                                    type: "string"
+                                  name:
+                                    type: "string"
+                                type: "object"
+                              type: "array"
+                          type: "object"
+                        username:
+                          type: "string"
+                      type: "object"
+                    type: "array"
+                  verifiableCredentialsEnabled:
+                    type: "boolean"
+                  verifyEmail:
+                    type: "boolean"
+                  waitIncrementSeconds:
+                    type: "integer"
+                  webAuthnPolicyAcceptableAaguids:
+                    items:
+                      type: "string"
+                    type: "array"
+                  webAuthnPolicyAttestationConveyancePreference:
+                    type: "string"
+                  webAuthnPolicyAuthenticatorAttachment:
+                    type: "string"
+                  webAuthnPolicyAvoidSameAuthenticatorRegister:
+                    type: "boolean"
+                  webAuthnPolicyCreateTimeout:
+                    type: "integer"
+                  webAuthnPolicyExtraOrigins:
+                    items:
+                      type: "string"
+                    type: "array"
+                  webAuthnPolicyPasswordlessAcceptableAaguids:
+                    items:
+                      type: "string"
+                    type: "array"
+                  webAuthnPolicyPasswordlessAttestationConveyancePreference:
+                    type: "string"
+                  webAuthnPolicyPasswordlessAuthenticatorAttachment:
+                    type: "string"
+                  webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister:
+                    type: "boolean"
+                  webAuthnPolicyPasswordlessCreateTimeout:
+                    type: "integer"
+                  webAuthnPolicyPasswordlessExtraOrigins:
+                    items:
+                      type: "string"
+                    type: "array"
+                  webAuthnPolicyPasswordlessPasskeysEnabled:
+                    type: "boolean"
+                  webAuthnPolicyPasswordlessRequireResidentKey:
+                    type: "string"
+                  webAuthnPolicyPasswordlessRpEntityName:
+                    type: "string"
+                  webAuthnPolicyPasswordlessRpId:
+                    type: "string"
+                  webAuthnPolicyPasswordlessSignatureAlgorithms:
+                    items:
+                      type: "string"
+                    type: "array"
+                  webAuthnPolicyPasswordlessUserVerificationRequirement:
+                    type: "string"
+                  webAuthnPolicyRequireResidentKey:
+                    type: "string"
+                  webAuthnPolicyRpEntityName:
+                    type: "string"
+                  webAuthnPolicyRpId:
+                    type: "string"
+                  webAuthnPolicySignatureAlgorithms:
+                    items:
+                      type: "string"
+                    type: "array"
+                  webAuthnPolicyUserVerificationRequirement:
+                    type: "string"
+                type: "object"
+              resources:
+                description: "Compute Resources required by Keycloak container. If\
+                  \ not specified, the value is inherited from the Keycloak CR."
+                properties:
+                  claims:
+                    items:
+                      properties:
+                        name:
+                          type: "string"
+                        request:
+                          type: "string"
+                      type: "object"
+                    type: "array"
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: "integer"
+                      - type: "string"
+                      x-kubernetes-int-or-string: true
+                    type: "object"
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: "integer"
+                      - type: "string"
+                      x-kubernetes-int-or-string: true
+                    type: "object"
+                type: "object"
+            required:
+            - "keycloakCRName"
+            - "realm"
+            type: "object"
+          status:
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      type: "string"
+                    message:
+                      type: "string"
+                    observedGeneration:
+                      type: "integer"
+                    status:
+                      type: "string"
+                    type:
+                      type: "string"
+                  type: "object"
+                type: "array"
+            type: "object"
+        type: "object"
+    served: true
+    storage: false
     subresources:
       status: {}

--- a/infrastructure/base/keycloak-operator/operator-resources.yaml
+++ b/infrastructure/base/keycloak-operator/operator-resources.yaml
@@ -3,12 +3,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    app.quarkus.io/quarkus-version: 3.33.1
+    app.quarkus.io/quarkus-version: 3.33.2
     app.quarkus.io/vcs-uri: https://github.com/keycloak/keycloak.git
-    app.quarkus.io/build-timestamp: 2026-04-15 - 14:07:19 +0000
+    app.quarkus.io/build-timestamp: 2026-06-25 - 08:27:10 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.1
+    app.kubernetes.io/version: 26.6.3
     app.kubernetes.io/managed-by: quarkus
   name: keycloak-operator
 ---
@@ -39,7 +39,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.1
+    app.kubernetes.io/version: 26.6.3
   name: keycloakrealmimportcontroller-cluster-role
 rules:
   - apiGroups:
@@ -85,7 +85,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.1
+    app.kubernetes.io/version: 26.6.3
   name: keycloakcontroller-cluster-role
 rules:
   - apiGroups:
@@ -281,7 +281,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.1
+    app.kubernetes.io/version: 26.6.3
   name: keycloakrealmimportcontroller-role-binding
 roleRef:
   kind: ClusterRole
@@ -296,7 +296,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.1
+    app.kubernetes.io/version: 26.6.3
   name: keycloakcontroller-role-binding
 roleRef:
   kind: ClusterRole
@@ -311,7 +311,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.1
+    app.kubernetes.io/version: 26.6.3
   name: keycloak-operator-view
 roleRef:
   kind: ClusterRole
@@ -325,12 +325,12 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    app.quarkus.io/quarkus-version: 3.33.1
+    app.quarkus.io/quarkus-version: 3.33.2
     app.quarkus.io/vcs-uri: https://github.com/keycloak/keycloak.git
-    app.quarkus.io/build-timestamp: 2026-04-15 - 14:07:19 +0000
+    app.quarkus.io/build-timestamp: 2026-06-25 - 08:27:10 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.1
+    app.kubernetes.io/version: 26.6.3
     app.kubernetes.io/managed-by: quarkus
   name: keycloak-operator
 spec:
@@ -347,12 +347,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    app.quarkus.io/quarkus-version: 3.33.1
+    app.quarkus.io/quarkus-version: 3.33.2
     app.quarkus.io/vcs-uri: https://github.com/keycloak/keycloak.git
-    app.quarkus.io/build-timestamp: 2026-04-15 - 14:07:19 +0000
+    app.quarkus.io/build-timestamp: 2026-06-25 - 08:27:10 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.1
+    app.kubernetes.io/version: 26.6.3
     app.kubernetes.io/managed-by: quarkus
   name: keycloak-operator
 spec:
@@ -363,12 +363,12 @@ spec:
   template:
     metadata:
       annotations:
-        app.quarkus.io/quarkus-version: 3.33.1
+        app.quarkus.io/quarkus-version: 3.33.2
         app.quarkus.io/vcs-uri: https://github.com/keycloak/keycloak.git
-        app.quarkus.io/build-timestamp: 2026-04-15 - 14:07:19 +0000
+        app.quarkus.io/build-timestamp: 2026-06-25 - 08:27:10 +0000
       labels:
         app.kubernetes.io/managed-by: quarkus
-        app.kubernetes.io/version: 26.6.1
+        app.kubernetes.io/version: 26.6.3
         app.kubernetes.io/name: keycloak-operator
     spec:
       containers:
@@ -378,8 +378,8 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: RELATED_IMAGE_KEYCLOAK
-              value: ghcr.io/informasjonsforvaltning/sso:26.6.1 # Custom Keycloak image from GitHub Container Registry
-          image: quay.io/keycloak/keycloak-operator:26.6.1
+              value: ghcr.io/informasjonsforvaltning/sso:26.6.3 # Custom Keycloak image from GitHub Container Registry
+          image: quay.io/keycloak/keycloak-operator:26.6.3
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3

--- a/infrastructure/base/keycloak-operator/operator-resources.yaml
+++ b/infrastructure/base/keycloak-operator/operator-resources.yaml
@@ -3,12 +3,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    app.quarkus.io/quarkus-version: 3.27.0
+    app.quarkus.io/quarkus-version: 3.33.1
     app.quarkus.io/vcs-uri: https://github.com/keycloak/keycloak.git
-    app.quarkus.io/build-timestamp: 2025-09-30 - 11:54:50 +0000
+    app.quarkus.io/build-timestamp: 2026-04-15 - 14:07:19 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.5.5
+    app.kubernetes.io/version: 26.6.1
     app.kubernetes.io/managed-by: quarkus
   name: keycloak-operator
 ---
@@ -39,7 +39,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.5.5
+    app.kubernetes.io/version: 26.6.1
   name: keycloakrealmimportcontroller-cluster-role
 rules:
   - apiGroups:
@@ -85,7 +85,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.5.5
+    app.kubernetes.io/version: 26.6.1
   name: keycloakcontroller-cluster-role
 rules:
   - apiGroups:
@@ -260,6 +260,7 @@ rules:
       - list
       - update
       - watch
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -280,7 +281,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.5.5
+    app.kubernetes.io/version: 26.6.1
   name: keycloakrealmimportcontroller-role-binding
 roleRef:
   kind: ClusterRole
@@ -295,7 +296,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.5.5
+    app.kubernetes.io/version: 26.6.1
   name: keycloakcontroller-role-binding
 roleRef:
   kind: ClusterRole
@@ -310,7 +311,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.5.5
+    app.kubernetes.io/version: 26.6.1
   name: keycloak-operator-view
 roleRef:
   kind: ClusterRole
@@ -324,12 +325,12 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    app.quarkus.io/quarkus-version: 3.27.0
+    app.quarkus.io/quarkus-version: 3.33.1
     app.quarkus.io/vcs-uri: https://github.com/keycloak/keycloak.git
-    app.quarkus.io/build-timestamp: 2025-09-30 - 11:54:50 +0000
+    app.quarkus.io/build-timestamp: 2026-04-15 - 14:07:19 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.5.5
+    app.kubernetes.io/version: 26.6.1
     app.kubernetes.io/managed-by: quarkus
   name: keycloak-operator
 spec:
@@ -346,12 +347,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    app.quarkus.io/quarkus-version: 3.27.0
+    app.quarkus.io/quarkus-version: 3.33.1
     app.quarkus.io/vcs-uri: https://github.com/keycloak/keycloak.git
-    app.quarkus.io/build-timestamp: 2025-09-30 - 11:54:50 +0000
+    app.quarkus.io/build-timestamp: 2026-04-15 - 14:07:19 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.5.5
+    app.kubernetes.io/version: 26.6.1
     app.kubernetes.io/managed-by: quarkus
   name: keycloak-operator
 spec:
@@ -362,12 +363,12 @@ spec:
   template:
     metadata:
       annotations:
-        app.quarkus.io/quarkus-version: 3.27.0
+        app.quarkus.io/quarkus-version: 3.33.1
         app.quarkus.io/vcs-uri: https://github.com/keycloak/keycloak.git
-        app.quarkus.io/build-timestamp: 2025-09-30 - 11:54:50 +0000
+        app.quarkus.io/build-timestamp: 2026-04-15 - 14:07:19 +0000
       labels:
         app.kubernetes.io/managed-by: quarkus
-        app.kubernetes.io/version: 26.5.5
+        app.kubernetes.io/version: 26.6.1
         app.kubernetes.io/name: keycloak-operator
     spec:
       containers:
@@ -377,8 +378,8 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: RELATED_IMAGE_KEYCLOAK
-              value: ghcr.io/informasjonsforvaltning/sso:26.5.5 # Custom Keycloak image from GitHub Container Registry
-          image: quay.io/keycloak/keycloak-operator:26.5.5
+              value: ghcr.io/informasjonsforvaltning/sso:26.6.1 # Custom Keycloak image from GitHub Container Registry
+          image: quay.io/keycloak/keycloak-operator:26.6.1
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3

--- a/infrastructure/dev/keycloak-operator/keycloak-operator-demo/rbac.yaml
+++ b/infrastructure/dev/keycloak-operator/keycloak-operator-demo/rbac.yaml
@@ -20,7 +20,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.5.5
+    app.kubernetes.io/version: 26.6.1
   name: keycloakrealmimportcontroller-cluster-role-binding-demo
 roleRef:
   kind: ClusterRole
@@ -36,7 +36,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.5.5
+    app.kubernetes.io/version: 26.6.1
   name: keycloakcontroller-cluster-role-binding-demo
 roleRef:
   kind: ClusterRole

--- a/infrastructure/dev/keycloak-operator/keycloak-operator-demo/rbac.yaml
+++ b/infrastructure/dev/keycloak-operator/keycloak-operator-demo/rbac.yaml
@@ -20,7 +20,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.1
+    app.kubernetes.io/version: 26.6.3
   name: keycloakrealmimportcontroller-cluster-role-binding-demo
 roleRef:
   kind: ClusterRole
@@ -36,7 +36,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.1
+    app.kubernetes.io/version: 26.6.3
   name: keycloakcontroller-cluster-role-binding-demo
 roleRef:
   kind: ClusterRole

--- a/infrastructure/dev/keycloak-operator/keycloak-operator-staging/rbac.yaml
+++ b/infrastructure/dev/keycloak-operator/keycloak-operator-staging/rbac.yaml
@@ -20,7 +20,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.5.5
+    app.kubernetes.io/version: 26.6.1
   name: keycloakrealmimportcontroller-cluster-role-binding-staging
 roleRef:
   kind: ClusterRole
@@ -36,7 +36,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.5.5
+    app.kubernetes.io/version: 26.6.1
   name: keycloakcontroller-cluster-role-binding-staging
 roleRef:
   kind: ClusterRole

--- a/infrastructure/dev/keycloak-operator/keycloak-operator-staging/rbac.yaml
+++ b/infrastructure/dev/keycloak-operator/keycloak-operator-staging/rbac.yaml
@@ -20,7 +20,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.1
+    app.kubernetes.io/version: 26.6.3
   name: keycloakrealmimportcontroller-cluster-role-binding-staging
 roleRef:
   kind: ClusterRole
@@ -36,7 +36,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.1
+    app.kubernetes.io/version: 26.6.3
   name: keycloakcontroller-cluster-role-binding-staging
 roleRef:
   kind: ClusterRole

--- a/infrastructure/prod/keycloak-operator/rbac.yaml
+++ b/infrastructure/prod/keycloak-operator/rbac.yaml
@@ -20,7 +20,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.1
+    app.kubernetes.io/version: 26.6.3
   name: keycloakrealmimportcontroller-cluster-role-binding-prod
 roleRef:
   kind: ClusterRole
@@ -36,7 +36,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.1
+    app.kubernetes.io/version: 26.6.3
   name: keycloakcontroller-cluster-role-binding-prod
 roleRef:
   kind: ClusterRole

--- a/infrastructure/prod/keycloak-operator/rbac.yaml
+++ b/infrastructure/prod/keycloak-operator/rbac.yaml
@@ -20,7 +20,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.5.5
+    app.kubernetes.io/version: 26.6.1
   name: keycloakrealmimportcontroller-cluster-role-binding-prod
 roleRef:
   kind: ClusterRole
@@ -36,7 +36,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.5.5
+    app.kubernetes.io/version: 26.6.1
   name: keycloakcontroller-cluster-role-binding-prod
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
# Summary

- Bump Keycloak operator and SSO server image to 26.6.3 (operator-resources + demo/staging/prod RBAC)
- Update operator CRDs to the 26.6.x set with `v2beta1` as the storage version
- Migrate Keycloak CRs (demo/staging/prod) to `apiVersion: k8s.keycloak.org/v2beta1` and bump `update.revision` to roll the StatefulSets
- Verified live in dev: operators on 26.6.3, all keycloak Kustomizations green, all 3 replicas rolled to `sso:26.6.3` in demo + staging

Replaces the auto-closed #307 (branch was renamed).