### PR TITLE
fix: point nginx-catalog at data-service-catalog

### DIFF
--- a/apps/dev/nginx-catalog-demo/config-map.yaml
+++ b/apps/dev/nginx-catalog-demo/config-map.yaml
@@ -83,11 +83,11 @@ data:
           add_header 'Content-Length' 0;
           return 204;
         }
-        proxy_pass http://dataservice-catalog:8080;
+        proxy_pass http://data-service-catalog:8080;
       }
     
       location / {
-        proxy_pass http://dataservice-catalog-gui:8080;
+        proxy_pass http://data-service-catalog-frontend:8080;
       }
     }
   server.concept.conf: |

--- a/apps/dev/nginx-catalog-staging/config-map.yaml
+++ b/apps/dev/nginx-catalog-staging/config-map.yaml
@@ -83,11 +83,11 @@ data:
           add_header 'Content-Length' 0;
           return 204;
         }
-        proxy_pass http://dataservice-catalog:8080;
+        proxy_pass http://data-service-catalog:8080;
       }
     
       location / {
-        proxy_pass http://dataservice-catalog-gui:8080;
+        proxy_pass http://data-service-catalog-frontend:8080;
       }
     }
   server.concept.conf: |

--- a/apps/prod/nginx-catalog/config-map.yaml
+++ b/apps/prod/nginx-catalog/config-map.yaml
@@ -83,11 +83,11 @@ data:
           add_header 'Content-Length' 0;
           return 204;
         }
-        proxy_pass http://dataservice-catalog:8080;
+        proxy_pass http://data-service-catalog:8080;
       }
     
       location / {
-        proxy_pass http://dataservice-catalog-gui:8080;
+        proxy_pass http://data-service-catalog-frontend:8080;
       }
     }
   server.concept.conf: |


### PR DESCRIPTION
# Summary

- Update nginx-catalog `proxy_pass` upstreams from the refactored-away `dataservice-catalog` / `dataservice-catalog-gui` to the current `data-service-catalog` / `data-service-catalog-frontend` services (staging, demo, prod)
- Fixes staging + demo nginx-catalog CrashLoopBackOff (`host not found in upstream "dataservice-catalog"`)
- Also fixes prod's latent dead-upstream 502s: the old prod services still exist but have no endpoints; the new services are healthy in all envs
- `server_name` aliases for the old hostnames kept for backward compatibility

Note: prod needs `kubectl rollout restart deploy/nginx-catalog -n prod` after merge (no configmap reloader); staging/demo self-heal via their crashloop restarts.