### PR TITLE
chore: update keycloak to 26.7.0

### DIFF
--- a/apps/dev/keycloak-demo/keycloak.yaml
+++ b/apps/dev/keycloak-demo/keycloak.yaml
@@ -10,7 +10,7 @@ spec:
   instances: 3
   update:
     strategy: Explicit
-    revision: "7"
+    revision: "8"
   http:
     httpEnabled: false
     httpsPort: 8443

--- a/apps/dev/keycloak-staging/keycloak.yaml
+++ b/apps/dev/keycloak-staging/keycloak.yaml
@@ -10,7 +10,7 @@ spec:
   instances: 3
   update:
     strategy: Explicit
-    revision: "19"
+    revision: "20"
   http:
     httpEnabled: false
     httpsPort: 8443

--- a/apps/prod/keycloak/keycloak.yaml
+++ b/apps/prod/keycloak/keycloak.yaml
@@ -10,7 +10,7 @@ spec:
   instances: 3
   update:
     strategy: Explicit
-    revision: "6"
+    revision: "7"
   http:
     httpEnabled: false
     httpsPort: 8443

--- a/infrastructure/base/keycloak-operator/operator-resources.yaml
+++ b/infrastructure/base/keycloak-operator/operator-resources.yaml
@@ -8,7 +8,7 @@ metadata:
     app.quarkus.io/build-timestamp: 2026-06-25 - 08:27:10 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.3
+    app.kubernetes.io/version: 26.7.0
     app.kubernetes.io/managed-by: quarkus
   name: keycloak-operator
 ---
@@ -39,7 +39,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.3
+    app.kubernetes.io/version: 26.7.0
   name: keycloakrealmimportcontroller-cluster-role
 rules:
   - apiGroups:
@@ -85,7 +85,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.3
+    app.kubernetes.io/version: 26.7.0
   name: keycloakcontroller-cluster-role
 rules:
   - apiGroups:
@@ -281,7 +281,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.3
+    app.kubernetes.io/version: 26.7.0
   name: keycloakrealmimportcontroller-role-binding
 roleRef:
   kind: ClusterRole
@@ -296,7 +296,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.3
+    app.kubernetes.io/version: 26.7.0
   name: keycloakcontroller-role-binding
 roleRef:
   kind: ClusterRole
@@ -311,7 +311,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.3
+    app.kubernetes.io/version: 26.7.0
   name: keycloak-operator-view
 roleRef:
   kind: ClusterRole
@@ -330,7 +330,7 @@ metadata:
     app.quarkus.io/build-timestamp: 2026-06-25 - 08:27:10 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.3
+    app.kubernetes.io/version: 26.7.0
     app.kubernetes.io/managed-by: quarkus
   name: keycloak-operator
 spec:
@@ -352,7 +352,7 @@ metadata:
     app.quarkus.io/build-timestamp: 2026-06-25 - 08:27:10 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.3
+    app.kubernetes.io/version: 26.7.0
     app.kubernetes.io/managed-by: quarkus
   name: keycloak-operator
 spec:
@@ -368,7 +368,7 @@ spec:
         app.quarkus.io/build-timestamp: 2026-06-25 - 08:27:10 +0000
       labels:
         app.kubernetes.io/managed-by: quarkus
-        app.kubernetes.io/version: 26.6.3
+        app.kubernetes.io/version: 26.7.0
         app.kubernetes.io/name: keycloak-operator
     spec:
       containers:
@@ -378,8 +378,8 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: RELATED_IMAGE_KEYCLOAK
-              value: ghcr.io/informasjonsforvaltning/sso:26.6.3 # Custom Keycloak image from GitHub Container Registry
-          image: quay.io/keycloak/keycloak-operator:26.6.3
+              value: ghcr.io/informasjonsforvaltning/sso:26.7.0 # Custom Keycloak image from GitHub Container Registry
+          image: quay.io/keycloak/keycloak-operator:26.7.0
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3

--- a/infrastructure/dev/keycloak-operator/keycloak-operator-demo/rbac.yaml
+++ b/infrastructure/dev/keycloak-operator/keycloak-operator-demo/rbac.yaml
@@ -20,7 +20,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.3
+    app.kubernetes.io/version: 26.7.0
   name: keycloakrealmimportcontroller-cluster-role-binding-demo
 roleRef:
   kind: ClusterRole
@@ -36,7 +36,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.3
+    app.kubernetes.io/version: 26.7.0
   name: keycloakcontroller-cluster-role-binding-demo
 roleRef:
   kind: ClusterRole

--- a/infrastructure/dev/keycloak-operator/keycloak-operator-staging/rbac.yaml
+++ b/infrastructure/dev/keycloak-operator/keycloak-operator-staging/rbac.yaml
@@ -20,7 +20,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.3
+    app.kubernetes.io/version: 26.7.0
   name: keycloakrealmimportcontroller-cluster-role-binding-staging
 roleRef:
   kind: ClusterRole
@@ -36,7 +36,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.3
+    app.kubernetes.io/version: 26.7.0
   name: keycloakcontroller-cluster-role-binding-staging
 roleRef:
   kind: ClusterRole

--- a/infrastructure/prod/keycloak-operator/rbac.yaml
+++ b/infrastructure/prod/keycloak-operator/rbac.yaml
@@ -20,7 +20,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.3
+    app.kubernetes.io/version: 26.7.0
   name: keycloakrealmimportcontroller-cluster-role-binding-prod
 roleRef:
   kind: ClusterRole
@@ -36,7 +36,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.6.3
+    app.kubernetes.io/version: 26.7.0
   name: keycloakcontroller-cluster-role-binding-prod
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
# Summary

- Bump keycloak operator image and version labels 26.6.3 → 26.7.0 (operator-resources.yaml + demo/staging/prod rbac.yaml)
- Increment Keycloak CR revision in each env to trigger the rolling update (demo 7→8, staging 19→20, prod 6→7)
- Companion to sso#176 (rest-user-mapper keycloak-version → 26.7.0); resolves keycloak-services advisory
- Mirrors the earlier keycloak-update pattern (commit 1c50515)