### PR TITLE
fix: drop keycloak rolebindings missing namespace

### DIFF
--- a/infrastructure/base/keycloak-operator/operator-resources.yaml
+++ b/infrastructure/base/keycloak-operator/operator-resources.yaml
@@ -358,36 +358,6 @@ metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
     app.kubernetes.io/version: 26.7.0
-  name: keycloakoidcclientcontroller-role-binding
-roleRef:
-  kind: ClusterRole
-  apiGroup: rbac.authorization.k8s.io
-  name: keycloakoidcclientcontroller-cluster-role
-subjects:
-  - kind: ServiceAccount
-    name: keycloak-operator
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.7.0
-  name: keycloaksamlclientcontroller-role-binding
-roleRef:
-  kind: ClusterRole
-  apiGroup: rbac.authorization.k8s.io
-  name: keycloaksamlclientcontroller-cluster-role
-subjects:
-  - kind: ServiceAccount
-    name: keycloak-operator
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.7.0
   name: keycloak-operator-view
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
# Summary

PR #331 added two namespaced RoleBindings for the new client
controllers, but the environment kustomizations assign namespaces via
explicit per-resource patches and no patch was added for them. They
render without a namespace, so Flux rejects them and the whole
keycloak-operator kustomization fails — which also blocked the
ClusterRoles and ClusterRoleBindings that actually fix the crash loop.

- Remove keycloakoidcclientcontroller-role-binding and keycloaksamlclientcontroller-role-binding from the operator base

The per-environment ClusterRoleBindings already grant these permissions
cluster-wide, so the namespaced RoleBindings were redundant.
