### PR TITLE
fix: rename dynamic-scopes to parameterized-scopes

### DIFF
--- a/apps/dev/keycloak-demo/keycloak.yaml
+++ b/apps/dev/keycloak-demo/keycloak.yaml
@@ -54,8 +54,8 @@ spec:
       - admin-fine-grained-authz
       - ciba
       - client-auth-federated
-      - dynamic-scopes
       - organization
+      - parameterized-scopes
       - recovery-codes
       - scripts
   additionalOptions:

--- a/apps/dev/keycloak-staging/keycloak.yaml
+++ b/apps/dev/keycloak-staging/keycloak.yaml
@@ -54,8 +54,8 @@ spec:
       - admin-fine-grained-authz
       - ciba
       - client-auth-federated
-      - dynamic-scopes
       - organization
+      - parameterized-scopes
       - recovery-codes
       - scripts
   additionalOptions:

--- a/apps/prod/keycloak/keycloak.yaml
+++ b/apps/prod/keycloak/keycloak.yaml
@@ -54,8 +54,8 @@ spec:
       - admin-fine-grained-authz
       - ciba
       - client-auth-federated
-      - dynamic-scopes
       - organization
+      - parameterized-scopes
       - recovery-codes
       - scripts
   additionalOptions:


### PR DESCRIPTION
# Summary

Keycloak 26.7.0 renamed the dynamic-scopes feature to
parameterized-scopes. The Keycloak CRs still declare the old name, so
the 26.7.0 server exits at startup with "'dynamic-scopes' is an
unrecognized feature", leaving keycloak-2 in CrashLoopBackOff and the
StatefulSet rollout stalled in staging, demo and prod.

- Rename dynamic-scopes to parameterized-scopes in the prod, staging and demo Keycloak CRs

Per the Keycloak upgrading guide this is a rename only; existing scopes
are migrated automatically and no manual data work is required. Neither
realm currently advertises any parameterized scopes, so no behaviour
change is expected.
