### PR TITLE
fix: run clamd as clamav user, keep startup caps

### DIFF
--- a/infrastructure/base/clamav/configmap.yaml
+++ b/infrastructure/base/clamav/configmap.yaml
@@ -13,6 +13,9 @@ data:
     LogClean no
     LogVerbose no
     Foreground yes
+    # clamd starts as root (the entrypoint needs it to fix up permissions) and
+    # drops to this unprivileged user once running.
+    User clamav
     DatabaseDirectory /var/lib/clamav
     TemporaryDirectory /tmp
 

--- a/infrastructure/base/clamav/deployment.yaml
+++ b/infrastructure/base/clamav/deployment.yaml
@@ -24,14 +24,6 @@ spec:
       labels:
         app: clamav
     spec:
-      # The official image starts as root to fix up permissions, then clamd/
-      # freshclam run as the built-in clamav user (uid 100). Pinning the pod to
-      # that user keeps it non-root from the start; fsGroup makes the emptyDir
-      # volumes group-writable so freshclam can populate the signature DB.
-      securityContext:
-        runAsUser: 100
-        runAsGroup: 100
-        fsGroup: 100
       containers:
         - name: clamav
           # Official ClamAV image; runs both clamd and freshclam. Pinned to the
@@ -77,12 +69,23 @@ spec:
               mountPath: /var/lib/clamav
             - name: tmp
               mountPath: /tmp
+          # The image's entrypoint must start as root to create and chown
+          # /run/clamav and the signature DB dir; clamd then drops to the
+          # unprivileged clamav user (uid 100) via the "User clamav" directive in
+          # clamd.conf, so the long-running scanner is non-root. Only the caps
+          # startup needs are kept: CHOWN/FOWNER/DAC_OVERRIDE to fix ownership,
+          # SETUID/SETGID to drop privileges.
           securityContext:
-            runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL
+              add:
+                - CHOWN
+                - DAC_OVERRIDE
+                - FOWNER
+                - SETUID
+                - SETGID
             seccompProfile:
               type: RuntimeDefault
       volumes:


### PR DESCRIPTION
# Summary

- clamd now drops to the unprivileged clamav user (uid 100) via a `User clamav` directive in clamd.conf
- Let the image entrypoint start as root (needed to create/chown /run/clamav and the signature DB dir) instead of pinning the pod to uid 100, which caused CreateContainerConfigError / CrashLoopBackOff after #330
- Narrow capabilities to drop [ALL] + add only what startup needs: CHOWN, DAC_OVERRIDE, FOWNER (fix ownership), SETUID, SETGID (drop privileges)
- Verified in dev: clamd runs as uid 100, health check passes, EICAR test signature detected