### PR TITLE
fix: track trivy chart on live helm repo

### DIFF
--- a/infrastructure/base/trivy/helm-release.yaml
+++ b/infrastructure/base/trivy/helm-release.yaml
@@ -9,7 +9,7 @@ spec:
   targetNamespace: trivy
   chart:
     spec:
-      version: 0.x
+      version: 0.34.x
       chart: trivy-operator
       sourceRef:
         kind: HelmRepository

--- a/infrastructure/base/trivy/helm-repo.yaml
+++ b/infrastructure/base/trivy/helm-repo.yaml
@@ -5,6 +5,9 @@ metadata:
   name: aquasecurity
   namespace: flux-system
 spec:
-  type: "oci"
+  # NOTE: Aqua stopped publishing to the ghcr.io OCI registry after chart
+  # 0.32.1 (2026-03-13). Releases continue on the traditional Helm repo only,
+  # so the OCI source silently froze the `version:` range in the HelmRelease.
+  type: "default"
   interval: 120m
-  url: oci://ghcr.io/aquasecurity/helm-charts
+  url: https://aquasecurity.github.io/helm-charts/


### PR DESCRIPTION
## What

Points the `aquasecurity` HelmRepository at the traditional Helm repo instead of the ghcr.io OCI registry, and pins the chart to `0.34.x`.

## Why

Aqua **stopped publishing trivy-operator to `oci://ghcr.io/aquasecurity/helm-charts` after chart 0.32.1** (2026-03-13). Releases have continued on `https://aquasecurity.github.io/helm-charts/` only.

Because our source was the OCI registry, the `version: 0.x` range had silently frozen — it resolved to 0.32.1 and **would never have advanced again**, with no error anywhere. Same class of silent GitOps dead-end as the flux-alerts no-ops (#221).

| | chart | operator | trivy scanner |
|---|---|---|---|
| before | 0.32.1 | 0.30.1 | 0.69.3 |
| after | 0.34.0 | 0.32.0 | 0.72.0 |

## Verification

- Confirmed both channels directly: ghcr's highest tag is 0.32.1; the HTTP repo has 0.33.1, 0.33.2, 0.34.0.
- `helm template` against our exact values renders clean on 0.34.0.
- All 8 values keys we set survive unchanged — including `trivy.configFile.cache.backend: memory` from the recent in-memory cache change, which renders through correctly.
- `trivy_image_vulnerabilities` (used by `alerts/image-critical-vulnerabilities.yaml`) is unchanged.
- CRDs move between operator minors but `install.crds: Create` / `upgrade.crds: CreateReplace` are already set.

## Watch after merge

Crossing two operator minors and three scanner minors can surface **new** findings as the scanner learns new package ecosystems. Worth eyeballing `ImageCriticalVulnerabilities` alert volume in dev before this reaches prod — a jump to trivy 0.72.0 could push some images over the `>= 10 Critical` threshold.

Vulnerability DB is unaffected (`aquasec/trivy-db` unchanged, pulled fresh at scan time).



---

## ✅ Dev-validert 2026-08-06

Testet via akkumulerende integrasjonsbranch (`test/hos/chart-bump-integration`) bootstrappet mot dev. Prod var urørt hele veien.

- HelmRepository flippet til `type: default` / `https://aquasecurity.github.io/helm-charts/`
- Chart **0.32.1 → 0.34.0**, operator-image `trivy-operator:0.32.0`, pod Running
- Scanner-image gikk **0.69.3 → 0.72.0** som forventet
- `trivy-trivy-operator` er `up` i Prometheus etter oppgraderingen
- Ingen andre HelmReleases regredierte

### Funn: OOMKilled scan-jobber — men de er IKKE fra denne bumpen

Under testen dukket det opp en haug `OOMKilled` scan-jobber. De kjørte alle **`aquasec/trivy:0.69.3`**, altså den *gamle* scanneren, og var opprettet av den forrige operatoren før oppgraderingen. Årsaken er sannsynligvis in-memory cache (`e81f7d2`) mot `256Mi`-grensa.

De nye **0.72.0-jobbene reproduserte ikke OOM-ene** — de kom opp `Completed`/`Running`. Merk også at OOMKilled-poder ikke ryddes av `scanJobTTL` (den gjelder bare fullførte), så de gamle blir liggende og se verre ut enn de er.

Dette blokkerer altså ikke bumpen. #336 adresserer det videre.
