### PR TITLE
chore: bump prometheus exporter charts

### DIFF
--- a/infrastructure/base/monitoring/helm-release-blackbox-exporter.yaml
+++ b/infrastructure/base/monitoring/helm-release-blackbox-exporter.yaml
@@ -9,7 +9,7 @@ spec:
   targetNamespace: monitoring
   chart:
     spec:
-      version: 9.x
+      version: 11.x
       chart: prometheus-blackbox-exporter
       sourceRef:
         kind: HelmRepository

--- a/infrastructure/base/monitoring/helm-release-kafka-exporter.yaml
+++ b/infrastructure/base/monitoring/helm-release-kafka-exporter.yaml
@@ -9,7 +9,7 @@ spec:
   targetNamespace: monitoring
   chart:
     spec:
-      version: 2.x
+      version: 3.x
       chart: prometheus-kafka-exporter
       sourceRef:
         kind: HelmRepository

--- a/infrastructure/base/monitoring/helm-release-postgres-exporter.yaml
+++ b/infrastructure/base/monitoring/helm-release-postgres-exporter.yaml
@@ -9,7 +9,7 @@ spec:
   targetNamespace: monitoring
   chart:
     spec:
-      version: 7.x
+      version: 8.x
       chart: prometheus-postgres-exporter
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
## What

Three prometheus-community exporter charts, each one major behind or more:

| chart | from | to | appVersion |
|---|---|---|---|
| prometheus-blackbox-exporter | 9.8.0 | 11.16.0 | v0.26.0 → v0.28.0 |
| prometheus-kafka-exporter | 2.18.0 | 3.1.0 | v1.9.0 (unchanged) |
| prometheus-postgres-exporter | 7.5.2 | 8.2.0 | v0.19.1 → v0.20.1 |

Version pins only — no values changes needed.

## Why the majors were safe to cross

Each chart's breaking changes were cross-referenced against the values we actually set:

- **blackbox 10.0.0** renamed `extraEnvFromSecret` → `extraEnvFrom` and changed `extraEnv` to a list; **11.0.0** dropped v1beta1 API support. We set neither `extraEnv*` nor any `config`/`modules`/`prober` — only `serviceMonitor`.
- **kafka 3.0.0** removed PodSecurityPolicy (`rbac.pspEnabled`) and raised min k8s to 1.25. We never set `pspEnabled`, and we're on 1.35. Image is still `danielqsj/kafka-exporter` at the same appVersion — the exporter binary is literally unchanged.
- **postgres 8.0.0** removed the hardcoded fallback password and now hard-`required`s `config.datasource.password`. **We're exempt** — that template is gated on `config.datasourceSecret`, which we set.

## Verification

- All three render clean via `helm template` against our exact values (base + overlays).
- **Deployment `spec.selector.matchLabels` compared old vs new for all three — identical.** This is the failure mode that stalls a HelmRelease (immutable field), and it does not occur here.
- Nothing in `infrastructure/base/alerts/` references any `probe_*` metric.

## Known follow-up, NOT fixed here

`helm-release-postgres-exporter.yaml` carries ~110 lines of dead config: `config.queries` and `config.autoDiscoverDatabases` **were removed from this chart back in 5.0.0** and have been silently discarded ever since (no `values.schema.json`, so Helm ignores them without error).

Consequence: every `pg_stat_activity_connections_*` metric in `alerts/postgres-connection-alerts.yaml` has never existed, so **5 of its 8 alerts can never fire**. This predates and is unaffected by this bump — filed separately to keep this PR to version pins.



---

## ✅ Dev-validert 2026-08-06

| chart | før | etter | pod |
|---|---|---|---|
| blackbox | 9.8.0 | **11.16.0** | restartet, Running |
| kafka | 2.18.0 | **3.1.0** | ikke restartet (forventet) |
| postgres | 7.5.2 | **8.2.0** | restartet, Running |

Kafka-poden ble stående (4d+ uptime) — korrekt, siden appVersion er uendret og eneste chart-endring over major-en var PSP-fjerning. Ingenting i pod-specen flyttet seg.

**Service-navn overlevde**, inkludert `monitoring-blackbox-exporter-prometheus-blackbox-exporter` som er hardkodet i Prometheus' `additionalScrapeConfigs`. Det var den ene tingen her som kunne knekt probing i stillhet.

Alle tre er `up` i Prometheus etter oppgradering. Ingen regresjoner.

### Bekrefter en antakelse i #347

Servicen heter `monitoring-prometheus-postgres-exporter`, ikke `postgres-exporter` — så `up{job="postgres-exporter"}` på linje 100 i `postgres-connection-alerts.yaml` matcher faktisk ingenting, som mistenkt.
