### PR TITLE
chore: bump ingress-nginx to final 4.15.1

### DIFF
--- a/infrastructure/base/nginx/helm-release.yaml
+++ b/infrastructure/base/nginx/helm-release.yaml
@@ -9,7 +9,10 @@ spec:
   targetNamespace: nginx
   chart:
     spec:
-      version: 4.14.x
+      # ingress-nginx was retired upstream (repo archived 2026-03-24); 4.15.1
+      # is the final release and the only one supporting k8s 1.35. Pinned
+      # exactly because the range can never advance again.
+      version: 4.15.1
       chart: ingress-nginx
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
## What

`ingress-nginx` 4.14.x → **4.15.1**, pinned exactly rather than as a range.

## Why now

We are running controller **1.14.5, which supports Kubernetes up to 1.34**. Our cluster is **1.35**. 4.15.1 (controller 1.15.1) is the only version whose support matrix covers us.

## Why an exact pin instead of `4.15.x`

**ingress-nginx is retired.** The repo was archived read-only on 2026-03-24 and moved to `kubernetes-retired`. Controller 1.15.1 / chart 4.15.1 (2026-03-19) is the final release that will ever exist — the Helm index confirms nothing has been published since across any release line.

A wildcard is now permanently frozen anyway; the exact pin makes that fact visible in the file instead of implying future movement.

## Verification

- `templates/` is **byte-identical** between charts 4.14.5 and 4.15.1 — zero files differ.
- Rendered against our values, the diff is empty apart from the controller image and version labels.
- Both overlays are unaffected (`dev` is an empty `values: {}` patch; `prod` only sets `interval`/`targetNamespace`).

**Risk: very low.** This is an image bump.

## Security posture (context, not blocking)

- We already carry the Feb/Mar 2026 config-injection RCE fixes (CVE-2026-24512/-24513/-24514) — they landed in 1.14.5, which we run. 4.15.1 keeps them.
- **CVE-2026-42533** (CVSS 9.2, disclosed 2026-07-15) affects 1.15.1 and everything earlier with **no OSS fix, ever**. We are almost certainly not exposed: it requires a `map` directive reachable only via `http-snippet`/`main-snippet`, and all our snippets are `server-snippet`/`configuration-snippet`.
- The point is the steady state, not this CVE: every future NGINX/controller CVE now lands on us permanently.

## Follow-up: plan the migration

Official path forward is Gateway API. Our surface is **6 Ingress resources / 8 files with nginx annotations** — weeks-scale, not months. The hard parts are the `server-snippet` blocks (all simple `deny all` / `return 404` guards on `/metrics` and Keycloak `userinfo`, expressible as HTTPRoute rules) and basic auth (needs an extension or external authz hop).

Since we already run GKE `BackendConfig`/`FrontendConfig` in front of nginx, **GKE Gateway** would let us delete a layer. Worth scoping this quarter; shouldn't drift past ~12 months.



---

## ✅ Dev-validert 2026-08-06

- Controller **4.14.5 → 4.15.1**, image `registry.k8s.io/ingress-nginx/controller:v1.15.1`
- **Alle 53 nginx-klasse Ingresses har adresse tildelt**
- Admission controller validerer en 232 kB konfigurasjon uten feil
- Ingen andre HelmReleases regredierte

**Merk for prod:** dev kjører kun **én** controller-replica, så rollouten er et kort ingress-avbrudd, ikke en rullerende oppdatering. Sjekk replica-antallet i prod før merge.

### Ikke en regresjon: "Ignoring ingress" ved oppstart

Loggen viser `Ignoring ingress because of error while validating ingress class` rett etter oppstart. Det er rekkefølge-støy: poden startet 10:28:50, linjene kom 10:28:58 før IngressClass-ene var lastet, og de samme Ingressene ble akseptert 10:29:47.

### Urelatert funn

Controlleren logger jevnlig `Error obtaining Endpoints for Service "staging/fdk-harvest-admin"` (og tilsvarende i `demo`) — en Ingress som peker på en Service som ikke finnes. Harmløst (den ruta 503-er), men det er dinglende config verdt en opprydding.
