### PR TITLE
chore: bump cert-manager to v1.19.6 (hop 1/3)

### DIFF
--- a/infrastructure/base/cert-manager/cert-manager.yaml
+++ b/infrastructure/base/cert-manager/cert-manager.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: cert-manager
-      version: v1.18.2
+      version: v1.19.6
       sourceRef:
         kind: HelmRepository
         name: jetstack

--- a/infrastructure/base/cert-manager/crds.yaml
+++ b/infrastructure/base/cert-manager/crds.yaml
@@ -12,1151 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Source: cert-manager/templates/crds.yaml
-#
-# START crd
+# Source: cert-manager/templates/crd-acme.cert-manager.io_challenges.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: certificaterequests.cert-manager.io
-  # START annotations
+  name: "challenges.acme.cert-manager.io"
   annotations:
     helm.sh/resource-policy: keep
-  # END annotations
   labels:
-    app: 'cert-manager'
-    app.kubernetes.io/name: 'cert-manager'
-    app.kubernetes.io/instance: 'cert-manager'
-    # Generated labels
-    app.kubernetes.io/version: "v1.18.2"
-spec:
-  group: cert-manager.io
-  names:
-    kind: CertificateRequest
-    listKind: CertificateRequestList
-    plural: certificaterequests
-    shortNames:
-      - cr
-      - crs
-    singular: certificaterequest
-    categories:
-      - cert-manager
-  scope: Namespaced
-  versions:
-    - name: v1
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=="Approved")].status
-          name: Approved
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Denied")].status
-          name: Denied
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .spec.issuerRef.name
-          name: Issuer
-          type: string
-        - jsonPath: .spec.username
-          name: Requester
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          priority: 1
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-          name: Age
-          type: date
-      schema:
-        openAPIV3Schema:
-          description: |-
-            A CertificateRequest is used to request a signed certificate from one of the
-            configured issuers.
-
-            All fields within the CertificateRequest's `spec` are immutable after creation.
-            A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
-            condition and its `status.failureTime` field.
-
-            A CertificateRequest is a one-shot resource, meaning it represents a single
-            point in time request for a certificate and cannot be re-used.
-          type: object
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: |-
-                Specification of the desired state of the CertificateRequest resource.
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-              type: object
-              required:
-                - issuerRef
-                - request
-              properties:
-                duration:
-                  description: |-
-                    Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
-                    issuer may choose to ignore the requested duration, just like any other
-                    requested attribute.
-                  type: string
-                extra:
-                  description: |-
-                    Extra contains extra attributes of the user that created the CertificateRequest.
-                    Populated by the cert-manager webhook on creation and immutable.
-                  type: object
-                  additionalProperties:
-                    type: array
-                    items:
-                      type: string
-                groups:
-                  description: |-
-                    Groups contains group membership of the user that created the CertificateRequest.
-                    Populated by the cert-manager webhook on creation and immutable.
-                  type: array
-                  items:
-                    type: string
-                  x-kubernetes-list-type: atomic
-                isCA:
-                  description: |-
-                    Requested basic constraints isCA value. Note that the issuer may choose
-                    to ignore the requested isCA value, just like any other requested attribute.
-
-                    NOTE: If the CSR in the `Request` field has a BasicConstraints extension,
-                    it must have the same isCA value as specified here.
-
-                    If true, this will automatically add the `cert sign` usage to the list
-                    of requested `usages`.
-                  type: boolean
-                issuerRef:
-                  description: |-
-                    Reference to the issuer responsible for issuing the certificate.
-                    If the issuer is namespace-scoped, it must be in the same namespace
-                    as the Certificate. If the issuer is cluster-scoped, it can be used
-                    from any namespace.
-
-                    The `name` field of the reference must always be specified.
-                  type: object
-                  required:
-                    - name
-                  properties:
-                    group:
-                      description: Group of the resource being referred to.
-                      type: string
-                    kind:
-                      description: Kind of the resource being referred to.
-                      type: string
-                    name:
-                      description: Name of the resource being referred to.
-                      type: string
-                request:
-                  description: |-
-                    The PEM-encoded X.509 certificate signing request to be submitted to the
-                    issuer for signing.
-
-                    If the CSR has a BasicConstraints extension, its isCA attribute must
-                    match the `isCA` value of this CertificateRequest.
-                    If the CSR has a KeyUsage extension, its key usages must match the
-                    key usages in the `usages` field of this CertificateRequest.
-                    If the CSR has a ExtKeyUsage extension, its extended key usages
-                    must match the extended key usages in the `usages` field of this
-                    CertificateRequest.
-                  type: string
-                  format: byte
-                uid:
-                  description: |-
-                    UID contains the uid of the user that created the CertificateRequest.
-                    Populated by the cert-manager webhook on creation and immutable.
-                  type: string
-                usages:
-                  description: |-
-                    Requested key usages and extended key usages.
-
-                    NOTE: If the CSR in the `Request` field has uses the KeyUsage or
-                    ExtKeyUsage extension, these extensions must have the same values
-                    as specified here without any additional values.
-
-                    If unset, defaults to `digital signature` and `key encipherment`.
-                  type: array
-                  items:
-                    description: |-
-                      KeyUsage specifies valid usage contexts for keys.
-                      See:
-                      https://tools.ietf.org/html/rfc5280#section-4.2.1.3
-                      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
-
-                      Valid KeyUsage values are as follows:
-                      "signing",
-                      "digital signature",
-                      "content commitment",
-                      "key encipherment",
-                      "key agreement",
-                      "data encipherment",
-                      "cert sign",
-                      "crl sign",
-                      "encipher only",
-                      "decipher only",
-                      "any",
-                      "server auth",
-                      "client auth",
-                      "code signing",
-                      "email protection",
-                      "s/mime",
-                      "ipsec end system",
-                      "ipsec tunnel",
-                      "ipsec user",
-                      "timestamping",
-                      "ocsp signing",
-                      "microsoft sgc",
-                      "netscape sgc"
-                    type: string
-                    enum:
-                      - signing
-                      - digital signature
-                      - content commitment
-                      - key encipherment
-                      - key agreement
-                      - data encipherment
-                      - cert sign
-                      - crl sign
-                      - encipher only
-                      - decipher only
-                      - any
-                      - server auth
-                      - client auth
-                      - code signing
-                      - email protection
-                      - s/mime
-                      - ipsec end system
-                      - ipsec tunnel
-                      - ipsec user
-                      - timestamping
-                      - ocsp signing
-                      - microsoft sgc
-                      - netscape sgc
-                username:
-                  description: |-
-                    Username contains the name of the user that created the CertificateRequest.
-                    Populated by the cert-manager webhook on creation and immutable.
-                  type: string
-            status:
-              description: |-
-                Status of the CertificateRequest.
-                This is set and managed automatically.
-                Read-only.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-              type: object
-              properties:
-                ca:
-                  description: |-
-                    The PEM encoded X.509 certificate of the signer, also known as the CA
-                    (Certificate Authority).
-                    This is set on a best-effort basis by different issuers.
-                    If not set, the CA is assumed to be unknown/not available.
-                  type: string
-                  format: byte
-                certificate:
-                  description: |-
-                    The PEM encoded X.509 certificate resulting from the certificate
-                    signing request.
-                    If not set, the CertificateRequest has either not been completed or has
-                    failed. More information on failure can be found by checking the
-                    `conditions` field.
-                  type: string
-                  format: byte
-                conditions:
-                  description: |-
-                    List of status conditions to indicate the status of a CertificateRequest.
-                    Known condition types are `Ready`, `InvalidRequest`, `Approved` and `Denied`.
-                  type: array
-                  items:
-                    description: CertificateRequestCondition contains condition information for a CertificateRequest.
-                    type: object
-                    required:
-                      - status
-                      - type
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          LastTransitionTime is the timestamp corresponding to the last status
-                          change of this condition.
-                        type: string
-                        format: date-time
-                      message:
-                        description: |-
-                          Message is a human readable description of the details of the last
-                          transition, complementing reason.
-                        type: string
-                      reason:
-                        description: |-
-                          Reason is a brief machine readable explanation for the condition's last
-                          transition.
-                        type: string
-                      status:
-                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
-                        type: string
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                      type:
-                        description: |-
-                          Type of the condition, known values are (`Ready`, `InvalidRequest`,
-                          `Approved`, `Denied`).
-                        type: string
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-                failureTime:
-                  description: |-
-                    FailureTime stores the time that this CertificateRequest failed. This is
-                    used to influence garbage collection and back-off.
-                  type: string
-                  format: date-time
-      served: true
-      storage: true
-
-# END crd
----
-# Source: cert-manager/templates/crds.yaml
-# START crd
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: certificates.cert-manager.io
-  # START annotations
-  annotations:
-    helm.sh/resource-policy: keep
-  # END annotations
-  labels:
-    app: 'cert-manager'
-    app.kubernetes.io/name: 'cert-manager'
-    app.kubernetes.io/instance: 'cert-manager'
-    # Generated labels
-    app.kubernetes.io/version: "v1.18.2"
-spec:
-  group: cert-manager.io
-  names:
-    kind: Certificate
-    listKind: CertificateList
-    plural: certificates
-    shortNames:
-      - cert
-      - certs
-    singular: certificate
-    categories:
-      - cert-manager
-  scope: Namespaced
-  versions:
-    - name: v1
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .spec.secretName
-          name: Secret
-          type: string
-        - jsonPath: .spec.issuerRef.name
-          name: Issuer
-          priority: 1
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          priority: 1
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-          name: Age
-          type: date
-      schema:
-        openAPIV3Schema:
-          description: |-
-            A Certificate resource should be created to ensure an up to date and signed
-            X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
-
-            The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
-          type: object
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: |-
-                Specification of the desired state of the Certificate resource.
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-              type: object
-              required:
-                - issuerRef
-                - secretName
-              properties:
-                additionalOutputFormats:
-                  description: |-
-                    Defines extra output formats of the private key and signed certificate chain
-                    to be written to this Certificate's target Secret.
-                  type: array
-                  items:
-                    description: |-
-                      CertificateAdditionalOutputFormat defines an additional output format of a
-                      Certificate resource. These contain supplementary data formats of the signed
-                      certificate chain and paired private key.
-                    type: object
-                    required:
-                      - type
-                    properties:
-                      type:
-                        description: |-
-                          Type is the name of the format type that should be written to the
-                          Certificate's target Secret.
-                        type: string
-                        enum:
-                          - DER
-                          - CombinedPEM
-                commonName:
-                  description: |-
-                    Requested common name X509 certificate subject attribute.
-                    More info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
-                    NOTE: TLS clients will ignore this value when any subject alternative name is
-                    set (see https://tools.ietf.org/html/rfc6125#section-6.4.4).
-
-                    Should have a length of 64 characters or fewer to avoid generating invalid CSRs.
-                    Cannot be set if the `literalSubject` field is set.
-                  type: string
-                dnsNames:
-                  description: Requested DNS subject alternative names.
-                  type: array
-                  items:
-                    type: string
-                duration:
-                  description: |-
-                    Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
-                    issuer may choose to ignore the requested duration, just like any other
-                    requested attribute.
-
-                    If unset, this defaults to 90 days.
-                    Minimum accepted duration is 1 hour.
-                    Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
-                  type: string
-                emailAddresses:
-                  description: Requested email subject alternative names.
-                  type: array
-                  items:
-                    type: string
-                encodeUsagesInRequest:
-                  description: |-
-                    Whether the KeyUsage and ExtKeyUsage extensions should be set in the encoded CSR.
-
-                    This option defaults to true, and should only be disabled if the target
-                    issuer does not support CSRs with these X509 KeyUsage/ ExtKeyUsage extensions.
-                  type: boolean
-                ipAddresses:
-                  description: Requested IP address subject alternative names.
-                  type: array
-                  items:
-                    type: string
-                isCA:
-                  description: |-
-                    Requested basic constraints isCA value.
-                    The isCA value is used to set the `isCA` field on the created CertificateRequest
-                    resources. Note that the issuer may choose to ignore the requested isCA value, just
-                    like any other requested attribute.
-
-                    If true, this will automatically add the `cert sign` usage to the list
-                    of requested `usages`.
-                  type: boolean
-                issuerRef:
-                  description: |-
-                    Reference to the issuer responsible for issuing the certificate.
-                    If the issuer is namespace-scoped, it must be in the same namespace
-                    as the Certificate. If the issuer is cluster-scoped, it can be used
-                    from any namespace.
-
-                    The `name` field of the reference must always be specified.
-                  type: object
-                  required:
-                    - name
-                  properties:
-                    group:
-                      description: Group of the resource being referred to.
-                      type: string
-                    kind:
-                      description: Kind of the resource being referred to.
-                      type: string
-                    name:
-                      description: Name of the resource being referred to.
-                      type: string
-                keystores:
-                  description: Additional keystore output formats to be stored in the Certificate's Secret.
-                  type: object
-                  properties:
-                    jks:
-                      description: |-
-                        JKS configures options for storing a JKS keystore in the
-                        `spec.secretName` Secret resource.
-                      type: object
-                      required:
-                        - create
-                      properties:
-                        alias:
-                          description: |-
-                            Alias specifies the alias of the key in the keystore, required by the JKS format.
-                            If not provided, the default alias `certificate` will be used.
-                          type: string
-                        create:
-                          description: |-
-                            Create enables JKS keystore creation for the Certificate.
-                            If true, a file named `keystore.jks` will be created in the target
-                            Secret resource, encrypted using the password stored in
-                            `passwordSecretRef` or `password`.
-                            The keystore file will be updated immediately.
-                            If the issuer provided a CA certificate, a file named `truststore.jks`
-                            will also be created in the target Secret resource, encrypted using the
-                            password stored in `passwordSecretRef`
-                            containing the issuing Certificate Authority
-                          type: boolean
-                        password:
-                          description: |-
-                            Password provides a literal password used to encrypt the JKS keystore.
-                            Mutually exclusive with passwordSecretRef.
-                            One of password or passwordSecretRef must provide a password with a non-zero length.
-                          type: string
-                        passwordSecretRef:
-                          description: |-
-                            PasswordSecretRef is a reference to a non-empty key in a Secret resource
-                            containing the password used to encrypt the JKS keystore.
-                            Mutually exclusive with password.
-                            One of password or passwordSecretRef must provide a password with a non-zero length.
-                          type: object
-                          required:
-                            - name
-                          properties:
-                            key:
-                              description: |-
-                                The key of the entry in the Secret resource's `data` field to be used.
-                                Some instances of this field may be defaulted, in others it may be
-                                required.
-                              type: string
-                            name:
-                              description: |-
-                                Name of the resource being referred to.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              type: string
-                    pkcs12:
-                      description: |-
-                        PKCS12 configures options for storing a PKCS12 keystore in the
-                        `spec.secretName` Secret resource.
-                      type: object
-                      required:
-                        - create
-                      properties:
-                        create:
-                          description: |-
-                            Create enables PKCS12 keystore creation for the Certificate.
-                            If true, a file named `keystore.p12` will be created in the target
-                            Secret resource, encrypted using the password stored in
-                            `passwordSecretRef` or in `password`.
-                            The keystore file will be updated immediately.
-                            If the issuer provided a CA certificate, a file named `truststore.p12` will
-                            also be created in the target Secret resource, encrypted using the
-                            password stored in `passwordSecretRef` containing the issuing Certificate
-                            Authority
-                          type: boolean
-                        password:
-                          description: |-
-                            Password provides a literal password used to encrypt the PKCS#12 keystore.
-                            Mutually exclusive with passwordSecretRef.
-                            One of password or passwordSecretRef must provide a password with a non-zero length.
-                          type: string
-                        passwordSecretRef:
-                          description: |-
-                            PasswordSecretRef is a reference to a non-empty key in a Secret resource
-                            containing the password used to encrypt the PKCS#12 keystore.
-                            Mutually exclusive with password.
-                            One of password or passwordSecretRef must provide a password with a non-zero length.
-                          type: object
-                          required:
-                            - name
-                          properties:
-                            key:
-                              description: |-
-                                The key of the entry in the Secret resource's `data` field to be used.
-                                Some instances of this field may be defaulted, in others it may be
-                                required.
-                              type: string
-                            name:
-                              description: |-
-                                Name of the resource being referred to.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              type: string
-                        profile:
-                          description: |-
-                            Profile specifies the key and certificate encryption algorithms and the HMAC algorithm
-                            used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
-
-                            If provided, allowed values are:
-                            `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
-                            `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
-                            `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
-                            (e.g., because of company policy). Please note that the security of the algorithm is not that important
-                            in reality, because the unencrypted certificate and private key are also stored in the Secret.
-                          type: string
-                          enum:
-                            - LegacyRC2
-                            - LegacyDES
-                            - Modern2023
-                literalSubject:
-                  description: |-
-                    Requested X.509 certificate subject, represented using the LDAP "String
-                    Representation of a Distinguished Name" [1].
-                    Important: the LDAP string format also specifies the order of the attributes
-                    in the subject, this is important when issuing certs for LDAP authentication.
-                    Example: `CN=foo,DC=corp,DC=example,DC=com`
-                    More info [1]: https://datatracker.ietf.org/doc/html/rfc4514
-                    More info: https://github.com/cert-manager/cert-manager/issues/3203
-                    More info: https://github.com/cert-manager/cert-manager/issues/4424
-
-                    Cannot be set if the `subject` or `commonName` field is set.
-                  type: string
-                nameConstraints:
-                  description: |-
-                    x.509 certificate NameConstraint extension which MUST NOT be used in a non-CA certificate.
-                    More Info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10
-
-                    This is an Alpha Feature and is only enabled with the
-                    `--feature-gates=NameConstraints=true` option set on both
-                    the controller and webhook components.
-                  type: object
-                  properties:
-                    critical:
-                      description: if true then the name constraints are marked critical.
-                      type: boolean
-                    excluded:
-                      description: |-
-                        Excluded contains the constraints which must be disallowed. Any name matching a
-                        restriction in the excluded field is invalid regardless
-                        of information appearing in the permitted
-                      type: object
-                      properties:
-                        dnsDomains:
-                          description: DNSDomains is a list of DNS domains that are permitted or excluded.
-                          type: array
-                          items:
-                            type: string
-                        emailAddresses:
-                          description: EmailAddresses is a list of Email Addresses that are permitted or excluded.
-                          type: array
-                          items:
-                            type: string
-                        ipRanges:
-                          description: |-
-                            IPRanges is a list of IP Ranges that are permitted or excluded.
-                            This should be a valid CIDR notation.
-                          type: array
-                          items:
-                            type: string
-                        uriDomains:
-                          description: URIDomains is a list of URI domains that are permitted or excluded.
-                          type: array
-                          items:
-                            type: string
-                    permitted:
-                      description: Permitted contains the constraints in which the names must be located.
-                      type: object
-                      properties:
-                        dnsDomains:
-                          description: DNSDomains is a list of DNS domains that are permitted or excluded.
-                          type: array
-                          items:
-                            type: string
-                        emailAddresses:
-                          description: EmailAddresses is a list of Email Addresses that are permitted or excluded.
-                          type: array
-                          items:
-                            type: string
-                        ipRanges:
-                          description: |-
-                            IPRanges is a list of IP Ranges that are permitted or excluded.
-                            This should be a valid CIDR notation.
-                          type: array
-                          items:
-                            type: string
-                        uriDomains:
-                          description: URIDomains is a list of URI domains that are permitted or excluded.
-                          type: array
-                          items:
-                            type: string
-                otherNames:
-                  description: |-
-                    `otherNames` is an escape hatch for SAN that allows any type. We currently restrict the support to string like otherNames, cf RFC 5280 p 37
-                    Any UTF8 String valued otherName can be passed with by setting the keys oid: x.x.x.x and UTF8Value: somevalue for `otherName`.
-                    Most commonly this would be UPN set with oid: 1.3.6.1.4.1.311.20.2.3
-                    You should ensure that any OID passed is valid for the UTF8String type as we do not explicitly validate this.
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      oid:
-                        description: |-
-                          OID is the object identifier for the otherName SAN.
-                          The object identifier must be expressed as a dotted string, for
-                          example, "1.2.840.113556.1.4.221".
-                        type: string
-                      utf8Value:
-                        description: |-
-                          utf8Value is the string value of the otherName SAN.
-                          The utf8Value accepts any valid UTF8 string to set as value for the otherName SAN.
-                        type: string
-                privateKey:
-                  description: |-
-                    Private key options. These include the key algorithm and size, the used
-                    encoding and the rotation policy.
-                  type: object
-                  properties:
-                    algorithm:
-                      description: |-
-                        Algorithm is the private key algorithm of the corresponding private key
-                        for this certificate.
-
-                        If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
-                        If `algorithm` is specified and `size` is not provided,
-                        key size of 2048 will be used for `RSA` key algorithm and
-                        key size of 256 will be used for `ECDSA` key algorithm.
-                        key size is ignored when using the `Ed25519` key algorithm.
-                      type: string
-                      enum:
-                        - RSA
-                        - ECDSA
-                        - Ed25519
-                    encoding:
-                      description: |-
-                        The private key cryptography standards (PKCS) encoding for this
-                        certificate's private key to be encoded in.
-
-                        If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
-                        and PKCS#8, respectively.
-                        Defaults to `PKCS1` if not specified.
-                      type: string
-                      enum:
-                        - PKCS1
-                        - PKCS8
-                    rotationPolicy:
-                      description: |-
-                        RotationPolicy controls how private keys should be regenerated when a
-                        re-issuance is being processed.
-
-                        If set to `Never`, a private key will only be generated if one does not
-                        already exist in the target `spec.secretName`. If one does exist but it
-                        does not have the correct algorithm or size, a warning will be raised
-                        to await user intervention.
-                        If set to `Always`, a private key matching the specified requirements
-                        will be generated whenever a re-issuance occurs.
-                        Default is `Always`.
-                        The default was changed from `Never` to `Always` in cert-manager >=v1.18.0.
-                        The new default can be disabled by setting the
-                        `--feature-gates=DefaultPrivateKeyRotationPolicyAlways=false` option on
-                        the controller component.
-                      type: string
-                      enum:
-                        - Never
-                        - Always
-                    size:
-                      description: |-
-                        Size is the key bit size of the corresponding private key for this certificate.
-
-                        If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
-                        and will default to `2048` if not specified.
-                        If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
-                        and will default to `256` if not specified.
-                        If `algorithm` is set to `Ed25519`, Size is ignored.
-                        No other values are allowed.
-                      type: integer
-                renewBefore:
-                  description: |-
-                    How long before the currently issued certificate's expiry cert-manager should
-                    renew the certificate. For example, if a certificate is valid for 60 minutes,
-                    and `renewBefore=10m`, cert-manager will begin to attempt to renew the certificate
-                    50 minutes after it was issued (i.e. when there are 10 minutes remaining until
-                    the certificate is no longer valid).
-
-                    NOTE: The actual lifetime of the issued certificate is used to determine the
-                    renewal time. If an issuer returns a certificate with a different lifetime than
-                    the one requested, cert-manager will use the lifetime of the issued certificate.
-
-                    If unset, this defaults to 1/3 of the issued certificate's lifetime.
-                    Minimum accepted value is 5 minutes.
-                    Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
-                    Cannot be set if the `renewBeforePercentage` field is set.
-                  type: string
-                renewBeforePercentage:
-                  description: |-
-                    `renewBeforePercentage` is like `renewBefore`, except it is a relative percentage
-                    rather than an absolute duration. For example, if a certificate is valid for 60
-                    minutes, and  `renewBeforePercentage=25`, cert-manager will begin to attempt to
-                    renew the certificate 45 minutes after it was issued (i.e. when there are 15
-                    minutes (25%) remaining until the certificate is no longer valid).
-
-                    NOTE: The actual lifetime of the issued certificate is used to determine the
-                    renewal time. If an issuer returns a certificate with a different lifetime than
-                    the one requested, cert-manager will use the lifetime of the issued certificate.
-
-                    Value must be an integer in the range (0,100). The minimum effective
-                    `renewBefore` derived from the `renewBeforePercentage` and `duration` fields is 5
-                    minutes.
-                    Cannot be set if the `renewBefore` field is set.
-                  type: integer
-                  format: int32
-                revisionHistoryLimit:
-                  description: |-
-                    The maximum number of CertificateRequest revisions that are maintained in
-                    the Certificate's history. Each revision represents a single `CertificateRequest`
-                    created by this Certificate, either when it was created, renewed, or Spec
-                    was changed. Revisions will be removed by oldest first if the number of
-                    revisions exceeds this number.
-
-                    If set, revisionHistoryLimit must be a value of `1` or greater.
-                    Default value is `1`.
-                  type: integer
-                  format: int32
-                secretName:
-                  description: |-
-                    Name of the Secret resource that will be automatically created and
-                    managed by this Certificate resource. It will be populated with a
-                    private key and certificate, signed by the denoted issuer. The Secret
-                    resource lives in the same namespace as the Certificate resource.
-                  type: string
-                secretTemplate:
-                  description: |-
-                    Defines annotations and labels to be copied to the Certificate's Secret.
-                    Labels and annotations on the Secret will be changed as they appear on the
-                    SecretTemplate when added or removed. SecretTemplate annotations are added
-                    in conjunction with, and cannot overwrite, the base set of annotations
-                    cert-manager sets on the Certificate's Secret.
-                  type: object
-                  properties:
-                    annotations:
-                      description: Annotations is a key value map to be copied to the target Kubernetes Secret.
-                      type: object
-                      additionalProperties:
-                        type: string
-                    labels:
-                      description: Labels is a key value map to be copied to the target Kubernetes Secret.
-                      type: object
-                      additionalProperties:
-                        type: string
-                signatureAlgorithm:
-                  description: |-
-                    Signature algorithm to use.
-                    Allowed values for RSA keys: SHA256WithRSA, SHA384WithRSA, SHA512WithRSA.
-                    Allowed values for ECDSA keys: ECDSAWithSHA256, ECDSAWithSHA384, ECDSAWithSHA512.
-                    Allowed values for Ed25519 keys: PureEd25519.
-                  type: string
-                  enum:
-                    - SHA256WithRSA
-                    - SHA384WithRSA
-                    - SHA512WithRSA
-                    - ECDSAWithSHA256
-                    - ECDSAWithSHA384
-                    - ECDSAWithSHA512
-                    - PureEd25519
-                subject:
-                  description: |-
-                    Requested set of X509 certificate subject attributes.
-                    More info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
-
-                    The common name attribute is specified separately in the `commonName` field.
-                    Cannot be set if the `literalSubject` field is set.
-                  type: object
-                  properties:
-                    countries:
-                      description: Countries to be used on the Certificate.
-                      type: array
-                      items:
-                        type: string
-                    localities:
-                      description: Cities to be used on the Certificate.
-                      type: array
-                      items:
-                        type: string
-                    organizationalUnits:
-                      description: Organizational Units to be used on the Certificate.
-                      type: array
-                      items:
-                        type: string
-                    organizations:
-                      description: Organizations to be used on the Certificate.
-                      type: array
-                      items:
-                        type: string
-                    postalCodes:
-                      description: Postal codes to be used on the Certificate.
-                      type: array
-                      items:
-                        type: string
-                    provinces:
-                      description: State/Provinces to be used on the Certificate.
-                      type: array
-                      items:
-                        type: string
-                    serialNumber:
-                      description: Serial number to be used on the Certificate.
-                      type: string
-                    streetAddresses:
-                      description: Street addresses to be used on the Certificate.
-                      type: array
-                      items:
-                        type: string
-                uris:
-                  description: Requested URI subject alternative names.
-                  type: array
-                  items:
-                    type: string
-                usages:
-                  description: |-
-                    Requested key usages and extended key usages.
-                    These usages are used to set the `usages` field on the created CertificateRequest
-                    resources. If `encodeUsagesInRequest` is unset or set to `true`, the usages
-                    will additionally be encoded in the `request` field which contains the CSR blob.
-
-                    If unset, defaults to `digital signature` and `key encipherment`.
-                  type: array
-                  items:
-                    description: |-
-                      KeyUsage specifies valid usage contexts for keys.
-                      See:
-                      https://tools.ietf.org/html/rfc5280#section-4.2.1.3
-                      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
-
-                      Valid KeyUsage values are as follows:
-                      "signing",
-                      "digital signature",
-                      "content commitment",
-                      "key encipherment",
-                      "key agreement",
-                      "data encipherment",
-                      "cert sign",
-                      "crl sign",
-                      "encipher only",
-                      "decipher only",
-                      "any",
-                      "server auth",
-                      "client auth",
-                      "code signing",
-                      "email protection",
-                      "s/mime",
-                      "ipsec end system",
-                      "ipsec tunnel",
-                      "ipsec user",
-                      "timestamping",
-                      "ocsp signing",
-                      "microsoft sgc",
-                      "netscape sgc"
-                    type: string
-                    enum:
-                      - signing
-                      - digital signature
-                      - content commitment
-                      - key encipherment
-                      - key agreement
-                      - data encipherment
-                      - cert sign
-                      - crl sign
-                      - encipher only
-                      - decipher only
-                      - any
-                      - server auth
-                      - client auth
-                      - code signing
-                      - email protection
-                      - s/mime
-                      - ipsec end system
-                      - ipsec tunnel
-                      - ipsec user
-                      - timestamping
-                      - ocsp signing
-                      - microsoft sgc
-                      - netscape sgc
-            status:
-              description: |-
-                Status of the Certificate.
-                This is set and managed automatically.
-                Read-only.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-              type: object
-              properties:
-                conditions:
-                  description: |-
-                    List of status conditions to indicate the status of certificates.
-                    Known condition types are `Ready` and `Issuing`.
-                  type: array
-                  items:
-                    description: CertificateCondition contains condition information for a Certificate.
-                    type: object
-                    required:
-                      - status
-                      - type
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          LastTransitionTime is the timestamp corresponding to the last status
-                          change of this condition.
-                        type: string
-                        format: date-time
-                      message:
-                        description: |-
-                          Message is a human readable description of the details of the last
-                          transition, complementing reason.
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          If set, this represents the .metadata.generation that the condition was
-                          set based upon.
-                          For instance, if .metadata.generation is currently 12, but the
-                          .status.condition[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the Certificate.
-                        type: integer
-                        format: int64
-                      reason:
-                        description: |-
-                          Reason is a brief machine readable explanation for the condition's last
-                          transition.
-                        type: string
-                      status:
-                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
-                        type: string
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                      type:
-                        description: Type of the condition, known values are (`Ready`, `Issuing`).
-                        type: string
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-                failedIssuanceAttempts:
-                  description: |-
-                    The number of continuous failed issuance attempts up till now. This
-                    field gets removed (if set) on a successful issuance and gets set to
-                    1 if unset and an issuance has failed. If an issuance has failed, the
-                    delay till the next issuance will be calculated using formula
-                    time.Hour * 2 ^ (failedIssuanceAttempts - 1).
-                  type: integer
-                lastFailureTime:
-                  description: |-
-                    LastFailureTime is set only if the latest issuance for this
-                    Certificate failed and contains the time of the failure. If an
-                    issuance has failed, the delay till the next issuance will be
-                    calculated using formula time.Hour * 2 ^ (failedIssuanceAttempts -
-                    1). If the latest issuance has succeeded this field will be unset.
-                  type: string
-                  format: date-time
-                nextPrivateKeySecretName:
-                  description: |-
-                    The name of the Secret resource containing the private key to be used
-                    for the next certificate iteration.
-                    The keymanager controller will automatically set this field if the
-                    `Issuing` condition is set to `True`.
-                    It will automatically unset this field when the Issuing condition is
-                    not set or False.
-                  type: string
-                notAfter:
-                  description: |-
-                    The expiration time of the certificate stored in the secret named
-                    by this resource in `spec.secretName`.
-                  type: string
-                  format: date-time
-                notBefore:
-                  description: |-
-                    The time after which the certificate stored in the secret named
-                    by this resource in `spec.secretName` is valid.
-                  type: string
-                  format: date-time
-                renewalTime:
-                  description: |-
-                    RenewalTime is the time at which the certificate will be next
-                    renewed.
-                    If not set, no upcoming renewal is scheduled.
-                  type: string
-                  format: date-time
-                revision:
-                  description: |-
-                    The current 'revision' of the certificate as issued.
-
-                    When a CertificateRequest resource is created, it will have the
-                    `cert-manager.io/certificate-revision` set to one greater than the
-                    current value of this field.
-
-                    Upon issuance, this field will be set to the value of the annotation
-                    on the CertificateRequest resource used to issue the certificate.
-
-                    Persisting the value on the CertificateRequest resource allows the
-                    certificates controller to know whether a request is part of an old
-                    issuance or if it is part of the ongoing revision's issuance by
-                    checking if the revision value in the annotation is greater than this
-                    field.
-                  type: integer
-      served: true
-      storage: true
-
-# END crd
----
-# Source: cert-manager/templates/crds.yaml
-# START crd
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: challenges.acme.cert-manager.io
-  # START annotations
-  annotations:
-    helm.sh/resource-policy: keep
-  # END annotations
-  labels:
-    app: 'cert-manager'
-    app.kubernetes.io/name: 'cert-manager'
-    app.kubernetes.io/instance: 'cert-manager'
-    # Generated labels
-    app.kubernetes.io/version: "v1.18.2"
+    app: "cert-manager"
+    app.kubernetes.io/name: "cert-manager"
+    app.kubernetes.io/instance: "cert-manager"
+    app.kubernetes.io/component: "crds"
+    app.kubernetes.io/version: "v1.19.6"
 spec:
   group: acme.cert-manager.io
   names:
+    categories:
+      - cert-manager
+      - cert-manager-acme
     kind: Challenge
     listKind: ChallengeList
     plural: challenges
     singular: challenge
-    categories:
-      - cert-manager
-      - cert-manager-acme
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
@@ -1178,10 +56,6 @@ spec:
       schema:
         openAPIV3Schema:
           description: Challenge is a type to represent a Challenge request with an ACME server
-          type: object
-          required:
-            - metadata
-            - spec
           properties:
             apiVersion:
               description: |-
@@ -1201,16 +75,6 @@ spec:
             metadata:
               type: object
             spec:
-              type: object
-              required:
-                - authorizationURL
-                - dnsName
-                - issuerRef
-                - key
-                - solver
-                - token
-                - type
-                - url
               properties:
                 authorizationURL:
                   description: |-
@@ -1230,19 +94,23 @@ spec:
                     If the Issuer does not exist, processing will be retried.
                     If the Issuer is not an 'ACME' Issuer, an error will be returned and the
                     Challenge will be marked as failed.
-                  type: object
-                  required:
-                    - name
                   properties:
                     group:
-                      description: Group of the resource being referred to.
+                      description: |-
+                        Group of the issuer being referred to.
+                        Defaults to 'cert-manager.io'.
                       type: string
                     kind:
-                      description: Kind of the resource being referred to.
+                      description: |-
+                        Kind of the issuer being referred to.
+                        Defaults to 'Issuer'.
                       type: string
                     name:
-                      description: Name of the resource being referred to.
+                      description: Name of the issuer being referred to.
                       type: string
+                  required:
+                    - name
+                  type: object
                 key:
                   description: |-
                     The ACME challenge key for this challenge
@@ -1257,30 +125,21 @@ spec:
                   description: |-
                     Contains the domain solving configuration that should be used to
                     solve this challenge resource.
-                  type: object
                   properties:
                     dns01:
                       description: |-
                         Configures cert-manager to attempt to complete authorizations by
                         performing the DNS01 challenge flow.
-                      type: object
                       properties:
                         acmeDNS:
                           description: |-
                             Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage
                             DNS01 challenge records.
-                          type: object
-                          required:
-                            - accountSecretRef
-                            - host
                           properties:
                             accountSecretRef:
                               description: |-
                                 A reference to a specific 'key' within a Secret resource.
                                 In some instances, `key` is a required field.
-                              type: object
-                              required:
-                                - name
                               properties:
                                 key:
                                   description: |-
@@ -1293,24 +152,22 @@ spec:
                                     Name of the resource being referred to.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
+                              required:
+                                - name
+                              type: object
                             host:
                               type: string
+                          required:
+                            - accountSecretRef
+                            - host
+                          type: object
                         akamai:
                           description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
-                          type: object
-                          required:
-                            - accessTokenSecretRef
-                            - clientSecretSecretRef
-                            - clientTokenSecretRef
-                            - serviceConsumerDomain
                           properties:
                             accessTokenSecretRef:
                               description: |-
                                 A reference to a specific 'key' within a Secret resource.
                                 In some instances, `key` is a required field.
-                              type: object
-                              required:
-                                - name
                               properties:
                                 key:
                                   description: |-
@@ -1323,13 +180,13 @@ spec:
                                     Name of the resource being referred to.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
+                              required:
+                                - name
+                              type: object
                             clientSecretSecretRef:
                               description: |-
                                 A reference to a specific 'key' within a Secret resource.
                                 In some instances, `key` is a required field.
-                              type: object
-                              required:
-                                - name
                               properties:
                                 key:
                                   description: |-
@@ -1342,13 +199,13 @@ spec:
                                     Name of the resource being referred to.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
+                              required:
+                                - name
+                              type: object
                             clientTokenSecretRef:
                               description: |-
                                 A reference to a specific 'key' within a Secret resource.
                                 In some instances, `key` is a required field.
-                              type: object
-                              required:
-                                - name
                               properties:
                                 key:
                                   description: |-
@@ -1361,14 +218,19 @@ spec:
                                     Name of the resource being referred to.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
+                              required:
+                                - name
+                              type: object
                             serviceConsumerDomain:
                               type: string
+                          required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                          type: object
                         azureDNS:
                           description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
-                          type: object
-                          required:
-                            - resourceGroupName
-                            - subscriptionID
                           properties:
                             clientID:
                               description: |-
@@ -1381,9 +243,6 @@ spec:
                                 Auth: Azure Service Principal:
                                 A reference to a Secret containing the password associated with the Service Principal.
                                 If set, ClientID and TenantID must also be set.
-                              type: object
-                              required:
-                                - name
                               properties:
                                 key:
                                   description: |-
@@ -1396,14 +255,17 @@ spec:
                                     Name of the resource being referred to.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
+                              required:
+                                - name
+                              type: object
                             environment:
                               description: name of the Azure environment (default AzurePublicCloud)
-                              type: string
                               enum:
                                 - AzurePublicCloud
                                 - AzureChinaCloud
                                 - AzureGermanCloud
                                 - AzureUSGovernmentCloud
+                              type: string
                             hostedZoneName:
                               description: name of the DNS zone that should be used
                               type: string
@@ -1412,7 +274,6 @@ spec:
                                 Auth: Azure Workload Identity or Azure Managed Service Identity:
                                 Settings to enable Azure Workload Identity or Azure Managed Service Identity
                                 If set, ClientID, ClientSecret and TenantID must not be set.
-                              type: object
                               properties:
                                 clientID:
                                   description: client ID of the managed identity, cannot be used at the same time as resourceID
@@ -1425,6 +286,7 @@ spec:
                                 tenantID:
                                   description: tenant ID of the managed identity, cannot be used at the same time as resourceID
                                   type: string
+                              type: object
                             resourceGroupName:
                               description: resource group the DNS zone is located in
                               type: string
@@ -1437,11 +299,12 @@ spec:
                                 The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
                                 If set, ClientID and ClientSecret must also be set.
                               type: string
+                          required:
+                            - resourceGroupName
+                            - subscriptionID
+                          type: object
                         cloudDNS:
                           description: Use the Google Cloud DNS API to manage DNS01 challenge records.
-                          type: object
-                          required:
-                            - project
                           properties:
                             hostedZoneName:
                               description: |-
@@ -1455,9 +318,6 @@ spec:
                               description: |-
                                 A reference to a specific 'key' within a Secret resource.
                                 In some instances, `key` is a required field.
-                              type: object
-                              required:
-                                - name
                               properties:
                                 key:
                                   description: |-
@@ -1470,18 +330,20 @@ spec:
                                     Name of the resource being referred to.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - project
+                          type: object
                         cloudflare:
                           description: Use the Cloudflare API to manage DNS01 challenge records.
-                          type: object
                           properties:
                             apiKeySecretRef:
                               description: |-
                                 API key to use to authenticate with Cloudflare.
                                 Note: using an API token to authenticate is now the recommended method
                                 as it allows greater control of permissions.
-                              type: object
-                              required:
-                                - name
                               properties:
                                 key:
                                   description: |-
@@ -1494,11 +356,11 @@ spec:
                                     Name of the resource being referred to.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
+                              required:
+                                - name
+                              type: object
                             apiTokenSecretRef:
                               description: API token used to authenticate with Cloudflare.
-                              type: object
-                              required:
-                                - name
                               properties:
                                 key:
                                   description: |-
@@ -1511,30 +373,28 @@ spec:
                                     Name of the resource being referred to.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
+                              required:
+                                - name
+                              type: object
                             email:
                               description: Email of the account, only required when using API key based authentication.
                               type: string
+                          type: object
                         cnameStrategy:
                           description: |-
                             CNAMEStrategy configures how the DNS01 provider should handle CNAME
                             records when found in DNS zones.
-                          type: string
                           enum:
                             - None
                             - Follow
+                          type: string
                         digitalocean:
                           description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
-                          type: object
-                          required:
-                            - tokenSecretRef
                           properties:
                             tokenSecretRef:
                               description: |-
                                 A reference to a specific 'key' within a Secret resource.
                                 In some instances, `key` is a required field.
-                              type: object
-                              required:
-                                - name
                               properties:
                                 key:
                                   description: |-
@@ -1547,20 +407,29 @@ spec:
                                     Name of the resource being referred to.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - tokenSecretRef
+                          type: object
                         rfc2136:
                           description: |-
                             Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/)
                             to manage DNS01 challenge records.
-                          type: object
-                          required:
-                            - nameserver
                           properties:
                             nameserver:
                               description: |-
                                 The IP address or hostname of an authoritative DNS server supporting
                                 RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                 This field is required.
+                              type: string
+                            protocol:
+                              description: Protocol to use for dynamic DNS update queries. Valid values are (case-sensitive) ``TCP`` and ``UDP``; ``UDP`` (default).
+                              enum:
+                                - TCP
+                                - UDP
                               type: string
                             tsigAlgorithm:
                               description: |-
@@ -1578,9 +447,6 @@ spec:
                               description: |-
                                 The name of the secret containing the TSIG value.
                                 If ``tsigKeyName`` is defined, this field is required.
-                              type: object
-                              required:
-                                - name
                               properties:
                                 key:
                                   description: |-
@@ -1593,9 +459,14 @@ spec:
                                     Name of the resource being referred to.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - nameserver
+                          type: object
                         route53:
                           description: Use the AWS Route53 API to manage DNS01 challenge records.
-                          type: object
                           properties:
                             accessKeyID:
                               description: |-
@@ -1613,9 +484,6 @@ spec:
                                 If neither the Access Key nor Key ID are set, we fall-back to using env
                                 vars, shared credentials file or AWS Instance metadata,
                                 see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                              type: object
-                              required:
-                                - name
                               properties:
                                 key:
                                   description: |-
@@ -1628,28 +496,22 @@ spec:
                                     Name of the resource being referred to.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
+                              required:
+                                - name
+                              type: object
                             auth:
                               description: Auth configures how cert-manager authenticates.
-                              type: object
-                              required:
-                                - kubernetes
                               properties:
                                 kubernetes:
                                   description: |-
                                     Kubernetes authenticates with Route53 using AssumeRoleWithWebIdentity
                                     by passing a bound ServiceAccount token.
-                                  type: object
-                                  required:
-                                    - serviceAccountRef
                                   properties:
                                     serviceAccountRef:
                                       description: |-
                                         A reference to a service account that will be used to request a bound
                                         token (also known as "projected token"). To use this field, you must
                                         configure an RBAC rule to let cert-manager request a token.
-                                      type: object
-                                      required:
-                                        - name
                                       properties:
                                         audiences:
                                           description: |-
@@ -1657,12 +519,22 @@ spec:
                                             token passed to AWS. The default token consisting of the issuer's namespace
                                             and name is always included.
                                             If unset the audience defaults to `sts.amazonaws.com`.
-                                          type: array
                                           items:
                                             type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
                                         name:
                                           description: Name of the ServiceAccount used to request a token.
                                           type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - serviceAccountRef
+                                  type: object
+                              required:
+                                - kubernetes
+                              type: object
                             hostedZoneID:
                               description: If set, the provider will manage only this zone in Route53 and will not do a lookup using the route53:ListHostedZonesByName api call.
                               type: string
@@ -1702,9 +574,6 @@ spec:
                                 If neither the Access Key nor Key ID are set, we fall-back to using env
                                 vars, shared credentials file or AWS Instance metadata,
                                 see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                              type: object
-                              required:
-                                - name
                               properties:
                                 key:
                                   description: |-
@@ -1717,14 +586,14 @@ spec:
                                     Name of the resource being referred to.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
+                              required:
+                                - name
+                              type: object
+                          type: object
                         webhook:
                           description: |-
                             Configure an external webhook based DNS01 challenge solver to manage
                             DNS01 challenge records.
-                          type: object
-                          required:
-                            - groupName
-                            - solverName
                           properties:
                             config:
                               description: |-
@@ -1750,13 +619,17 @@ spec:
                                 implementation.
                                 This will typically be the name of the provider, e.g., 'cloudflare'.
                               type: string
+                          required:
+                            - groupName
+                            - solverName
+                          type: object
+                      type: object
                     http01:
                       description: |-
                         Configures cert-manager to attempt to complete authorizations by
                         performing the HTTP01 challenge flow.
                         It is not possible to obtain certificates for wildcard domain names
                         (e.g., `*.example.com`) using the HTTP01 challenge mechanism.
-                      type: object
                       properties:
                         gatewayHTTPRoute:
                           description: |-
@@ -1764,22 +637,20 @@ spec:
                             in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will
                             create HTTPRoutes with the specified labels in the same namespace as the challenge.
                             This solver is experimental, and fields / behaviour may change in the future.
-                          type: object
                           properties:
                             labels:
+                              additionalProperties:
+                                type: string
                               description: |-
                                 Custom labels that will be applied to HTTPRoutes created by cert-manager
                                 while solving HTTP-01 challenges.
                               type: object
-                              additionalProperties:
-                                type: string
                             parentRefs:
                               description: |-
                                 When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.
                                 cert-manager needs to know which parentRefs should be used when creating
                                 the HTTPRoute. Usually, the parentRef references a Gateway. See:
                                 https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways
-                              type: array
                               items:
                                 description: |-
                                   ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -1794,11 +665,9 @@ spec:
 
                                   The API object must be valid in the cluster; the Group and Kind must
                                   be registered in the cluster for this reference to be valid.
-                                type: object
-                                required:
-                                  - name
                                 properties:
                                   group:
+                                    default: gateway.networking.k8s.io
                                     description: |-
                                       Group is the group of the referent.
                                       When unspecified, "gateway.networking.k8s.io" is inferred.
@@ -1806,11 +675,11 @@ spec:
                                       Group must be explicitly set to "" (empty string).
 
                                       Support: Core
-                                    type: string
-                                    default: gateway.networking.k8s.io
                                     maxLength: 253
                                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
                                   kind:
+                                    default: Gateway
                                     description: |-
                                       Kind is kind of the referent.
 
@@ -1820,19 +689,18 @@ spec:
                                       * Service (Mesh conformance profile, ClusterIP Services only)
 
                                       Support for other resources is Implementation-Specific.
-                                    type: string
-                                    default: Gateway
                                     maxLength: 63
                                     minLength: 1
                                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
                                   name:
                                     description: |-
                                       Name is the name of the referent.
 
                                       Support: Core
-                                    type: string
                                     maxLength: 253
                                     minLength: 1
+                                    type: string
                                   namespace:
                                     description: |-
                                       Namespace is the namespace of the referent. When unspecified, this refers
@@ -1857,10 +725,10 @@ spec:
                                       </gateway:experimental:description>
 
                                       Support: Core
-                                    type: string
                                     maxLength: 63
                                     minLength: 1
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
                                   port:
                                     description: |-
                                       Port is the network port this Route targets. It can be interpreted
@@ -1893,10 +761,10 @@ spec:
                                       the Route MUST be considered detached from the Gateway.
 
                                       Support: Extended
-                                    type: integer
                                     format: int32
                                     maximum: 65535
                                     minimum: 1
+                                    type: integer
                                   sectionName:
                                     description: |-
                                       SectionName is the name of a section within the target resource. In the
@@ -1923,15 +791,19 @@ spec:
                                       Route MUST be considered detached from the Gateway.
 
                                       Support: Core
-                                    type: string
                                     maxLength: 253
                                     minLength: 1
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             podTemplate:
                               description: |-
                                 Optional pod template used to configure the ACME challenge solver pods
                                 used for HTTP01 challenges.
-                              type: object
                               properties:
                                 metadata:
                                   description: |-
@@ -1939,32 +811,29 @@ spec:
                                     Only the 'labels' and 'annotations' fields may be set.
                                     If labels or annotations overlap with in-built values, the values here
                                     will override the in-built values.
-                                  type: object
                                   properties:
                                     annotations:
+                                      additionalProperties:
+                                        type: string
                                       description: Annotations that should be added to the created ACME HTTP01 solver pods.
                                       type: object
+                                    labels:
                                       additionalProperties:
                                         type: string
-                                    labels:
                                       description: Labels that should be added to the created ACME HTTP01 solver pods.
                                       type: object
-                                      additionalProperties:
-                                        type: string
+                                  type: object
                                 spec:
                                   description: |-
                                     PodSpec defines overrides for the HTTP01 challenge solver pod.
                                     Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
                                     All other fields will be ignored.
-                                  type: object
                                   properties:
                                     affinity:
                                       description: If specified, the pod's scheduling constraints
-                                      type: object
                                       properties:
                                         nodeAffinity:
                                           description: Describes node affinity scheduling rules for the pod.
-                                          type: object
                                           properties:
                                             preferredDuringSchedulingIgnoredDuringExecution:
                                               description: |-
@@ -1977,31 +846,20 @@ spec:
                                                 compute a sum by iterating through the elements of this field and adding
                                                 "weight" to the sum if the node matches the corresponding matchExpressions; the
                                                 node(s) with the highest sum are the most preferred.
-                                              type: array
                                               items:
                                                 description: |-
                                                   An empty preferred scheduling term matches all objects with implicit weight 0
                                                   (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
-                                                type: object
-                                                required:
-                                                  - preference
-                                                  - weight
                                                 properties:
                                                   preference:
                                                     description: A node selector term, associated with the corresponding weight.
-                                                    type: object
                                                     properties:
                                                       matchExpressions:
                                                         description: A list of node selector requirements by node's labels.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A node selector requirement is a selector that contains values, a key, and an operator
                                                             that relates the key and values.
-                                                          type: object
-                                                          required:
-                                                            - key
-                                                            - operator
                                                           properties:
                                                             key:
                                                               description: The label key that the selector applies to.
@@ -2018,22 +876,22 @@ spec:
                                                                 the values array must be empty. If the operator is Gt or Lt, the values
                                                                 array must have a single element, which will be interpreted as an integer.
                                                                 This array is replaced during a strategic merge patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       matchFields:
                                                         description: A list of node selector requirements by node's fields.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A node selector requirement is a selector that contains values, a key, and an operator
                                                             that relates the key and values.
-                                                          type: object
-                                                          required:
-                                                            - key
-                                                            - operator
                                                           properties:
                                                             key:
                                                               description: The label key that the selector applies to.
@@ -2050,16 +908,27 @@ spec:
                                                                 the values array must be empty. If the operator is Gt or Lt, the values
                                                                 array must have a single element, which will be interpreted as an integer.
                                                                 This array is replaced during a strategic merge patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
+                                                    type: object
                                                     x-kubernetes-map-type: atomic
                                                   weight:
                                                     description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
-                                                    type: integer
                                                     format: int32
+                                                    type: integer
+                                                required:
+                                                  - preference
+                                                  - weight
+                                                type: object
+                                              type: array
                                               x-kubernetes-list-type: atomic
                                             requiredDuringSchedulingIgnoredDuringExecution:
                                               description: |-
@@ -2068,31 +937,21 @@ spec:
                                                 If the affinity requirements specified by this field cease to be met
                                                 at some point during pod execution (e.g. due to an update), the system
                                                 may or may not try to eventually evict the pod from its node.
-                                              type: object
-                                              required:
-                                                - nodeSelectorTerms
                                               properties:
                                                 nodeSelectorTerms:
                                                   description: Required. A list of node selector terms. The terms are ORed.
-                                                  type: array
                                                   items:
                                                     description: |-
                                                       A null or empty node selector term matches no objects. The requirements of
                                                       them are ANDed.
                                                       The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
-                                                    type: object
                                                     properties:
                                                       matchExpressions:
                                                         description: A list of node selector requirements by node's labels.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A node selector requirement is a selector that contains values, a key, and an operator
                                                             that relates the key and values.
-                                                          type: object
-                                                          required:
-                                                            - key
-                                                            - operator
                                                           properties:
                                                             key:
                                                               description: The label key that the selector applies to.
@@ -2109,22 +968,22 @@ spec:
                                                                 the values array must be empty. If the operator is Gt or Lt, the values
                                                                 array must have a single element, which will be interpreted as an integer.
                                                                 This array is replaced during a strategic merge patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       matchFields:
                                                         description: A list of node selector requirements by node's fields.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A node selector requirement is a selector that contains values, a key, and an operator
                                                             that relates the key and values.
-                                                          type: object
-                                                          required:
-                                                            - key
-                                                            - operator
                                                           properties:
                                                             key:
                                                               description: The label key that the selector applies to.
@@ -2141,17 +1000,27 @@ spec:
                                                                 the values array must be empty. If the operator is Gt or Lt, the values
                                                                 array must have a single element, which will be interpreted as an integer.
                                                                 This array is replaced during a strategic merge patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
+                                                    type: object
                                                     x-kubernetes-map-type: atomic
+                                                  type: array
                                                   x-kubernetes-list-type: atomic
+                                              required:
+                                                - nodeSelectorTerms
+                                              type: object
                                               x-kubernetes-map-type: atomic
+                                          type: object
                                         podAffinity:
                                           description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
-                                          type: object
                                           properties:
                                             preferredDuringSchedulingIgnoredDuringExecution:
                                               description: |-
@@ -2164,37 +1033,23 @@ spec:
                                                 compute a sum by iterating through the elements of this field and adding
                                                 "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                 node(s) with the highest sum are the most preferred.
-                                              type: array
                                               items:
                                                 description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                                                type: object
-                                                required:
-                                                  - podAffinityTerm
-                                                  - weight
                                                 properties:
                                                   podAffinityTerm:
                                                     description: Required. A pod affinity term, associated with the corresponding weight.
-                                                    type: object
-                                                    required:
-                                                      - topologyKey
                                                     properties:
                                                       labelSelector:
                                                         description: |-
                                                           A label query over a set of resources, in this case pods.
                                                           If it's null, this PodAffinityTerm matches with no Pods.
-                                                        type: object
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                            type: array
                                                             items:
                                                               description: |-
                                                                 A label selector requirement is a selector that contains values, a key, and an operator that
                                                                 relates the key and values.
-                                                              type: object
-                                                              required:
-                                                                - key
-                                                                - operator
                                                               properties:
                                                                 key:
                                                                   description: key is the label key that the selector applies to.
@@ -2210,19 +1065,25 @@ spec:
                                                                     the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                     the values array must be empty. This array is replaced during a strategic
                                                                     merge patch.
-                                                                  type: array
                                                                   items:
                                                                     type: string
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
                                                             x-kubernetes-list-type: atomic
                                                           matchLabels:
+                                                            additionalProperties:
+                                                              type: string
                                                             description: |-
                                                               matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                               map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                               operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                             type: object
-                                                            additionalProperties:
-                                                              type: string
+                                                        type: object
                                                         x-kubernetes-map-type: atomic
                                                       matchLabelKeys:
                                                         description: |-
@@ -2234,10 +1095,9 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                           Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                        type: array
                                                         items:
                                                           type: string
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       mismatchLabelKeys:
                                                         description: |-
@@ -2249,10 +1109,9 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                           Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                        type: array
                                                         items:
                                                           type: string
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         description: |-
@@ -2261,19 +1120,13 @@ spec:
                                                           and the ones listed in the namespaces field.
                                                           null selector and null or empty namespaces list means "this pod's namespace".
                                                           An empty selector ({}) matches all namespaces.
-                                                        type: object
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                            type: array
                                                             items:
                                                               description: |-
                                                                 A label selector requirement is a selector that contains values, a key, and an operator that
                                                                 relates the key and values.
-                                                              type: object
-                                                              required:
-                                                                - key
-                                                                - operator
                                                               properties:
                                                                 key:
                                                                   description: key is the label key that the selector applies to.
@@ -2289,19 +1142,25 @@ spec:
                                                                     the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                     the values array must be empty. This array is replaced during a strategic
                                                                     merge patch.
-                                                                  type: array
                                                                   items:
                                                                     type: string
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
                                                             x-kubernetes-list-type: atomic
                                                           matchLabels:
+                                                            additionalProperties:
+                                                              type: string
                                                             description: |-
                                                               matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                               map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                               operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                             type: object
-                                                            additionalProperties:
-                                                              type: string
+                                                        type: object
                                                         x-kubernetes-map-type: atomic
                                                       namespaces:
                                                         description: |-
@@ -2309,9 +1168,9 @@ spec:
                                                           The term is applied to the union of the namespaces listed in this field
                                                           and the ones selected by namespaceSelector.
                                                           null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                        type: array
                                                         items:
                                                           type: string
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         description: |-
@@ -2321,12 +1180,20 @@ spec:
                                                           selected pods is running.
                                                           Empty topologyKey is not allowed.
                                                         type: string
+                                                    required:
+                                                      - topologyKey
+                                                    type: object
                                                   weight:
                                                     description: |-
                                                       weight associated with matching the corresponding podAffinityTerm,
                                                       in the range 1-100.
-                                                    type: integer
                                                     format: int32
+                                                    type: integer
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                type: object
+                                              type: array
                                               x-kubernetes-list-type: atomic
                                             requiredDuringSchedulingIgnoredDuringExecution:
                                               description: |-
@@ -2337,7 +1204,6 @@ spec:
                                                 system may or may not try to eventually evict the pod from its node.
                                                 When there are multiple elements, the lists of nodes corresponding to each
                                                 podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                                              type: array
                                               items:
                                                 description: |-
                                                   Defines a set of pods (namely those matching the labelSelector
@@ -2346,27 +1212,18 @@ spec:
                                                   where co-located is defined as running on a node whose value of
                                                   the label with key <topologyKey> matches that of any node on which
                                                   a pod of the set of pods is running
-                                                type: object
-                                                required:
-                                                  - topologyKey
                                                 properties:
                                                   labelSelector:
                                                     description: |-
                                                       A label query over a set of resources, in this case pods.
                                                       If it's null, this PodAffinityTerm matches with no Pods.
-                                                    type: object
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A label selector requirement is a selector that contains values, a key, and an operator that
                                                             relates the key and values.
-                                                          type: object
-                                                          required:
-                                                            - key
-                                                            - operator
                                                           properties:
                                                             key:
                                                               description: key is the label key that the selector applies to.
@@ -2382,19 +1239,25 @@ spec:
                                                                 the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                 the values array must be empty. This array is replaced during a strategic
                                                                 merge patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       matchLabels:
+                                                        additionalProperties:
+                                                          type: string
                                                         description: |-
                                                           matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                           map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                           operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                         type: object
-                                                        additionalProperties:
-                                                          type: string
+                                                    type: object
                                                     x-kubernetes-map-type: atomic
                                                   matchLabelKeys:
                                                     description: |-
@@ -2406,10 +1269,9 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                       Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                    type: array
                                                     items:
                                                       type: string
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   mismatchLabelKeys:
                                                     description: |-
@@ -2421,10 +1283,9 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                       Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                    type: array
                                                     items:
                                                       type: string
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   namespaceSelector:
                                                     description: |-
@@ -2433,19 +1294,13 @@ spec:
                                                       and the ones listed in the namespaces field.
                                                       null selector and null or empty namespaces list means "this pod's namespace".
                                                       An empty selector ({}) matches all namespaces.
-                                                    type: object
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A label selector requirement is a selector that contains values, a key, and an operator that
                                                             relates the key and values.
-                                                          type: object
-                                                          required:
-                                                            - key
-                                                            - operator
                                                           properties:
                                                             key:
                                                               description: key is the label key that the selector applies to.
@@ -2461,19 +1316,25 @@ spec:
                                                                 the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                 the values array must be empty. This array is replaced during a strategic
                                                                 merge patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       matchLabels:
+                                                        additionalProperties:
+                                                          type: string
                                                         description: |-
                                                           matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                           map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                           operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                         type: object
-                                                        additionalProperties:
-                                                          type: string
+                                                    type: object
                                                     x-kubernetes-map-type: atomic
                                                   namespaces:
                                                     description: |-
@@ -2481,9 +1342,9 @@ spec:
                                                       The term is applied to the union of the namespaces listed in this field
                                                       and the ones selected by namespaceSelector.
                                                       null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                    type: array
                                                     items:
                                                       type: string
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   topologyKey:
                                                     description: |-
@@ -2493,10 +1354,14 @@ spec:
                                                       selected pods is running.
                                                       Empty topologyKey is not allowed.
                                                     type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              type: array
                                               x-kubernetes-list-type: atomic
+                                          type: object
                                         podAntiAffinity:
                                           description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
-                                          type: object
                                           properties:
                                             preferredDuringSchedulingIgnoredDuringExecution:
                                               description: |-
@@ -2506,40 +1371,26 @@ spec:
                                                 most preferred is the one with the greatest sum of weights, i.e.
                                                 for each node that meets all of the scheduling requirements (resource
                                                 request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                                compute a sum by iterating through the elements of this field and adding
-                                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                compute a sum by iterating through the elements of this field and subtracting
+                                                "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                 node(s) with the highest sum are the most preferred.
-                                              type: array
                                               items:
                                                 description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                                                type: object
-                                                required:
-                                                  - podAffinityTerm
-                                                  - weight
                                                 properties:
                                                   podAffinityTerm:
                                                     description: Required. A pod affinity term, associated with the corresponding weight.
-                                                    type: object
-                                                    required:
-                                                      - topologyKey
                                                     properties:
                                                       labelSelector:
                                                         description: |-
                                                           A label query over a set of resources, in this case pods.
                                                           If it's null, this PodAffinityTerm matches with no Pods.
-                                                        type: object
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                            type: array
                                                             items:
                                                               description: |-
                                                                 A label selector requirement is a selector that contains values, a key, and an operator that
                                                                 relates the key and values.
-                                                              type: object
-                                                              required:
-                                                                - key
-                                                                - operator
                                                               properties:
                                                                 key:
                                                                   description: key is the label key that the selector applies to.
@@ -2555,19 +1406,25 @@ spec:
                                                                     the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                     the values array must be empty. This array is replaced during a strategic
                                                                     merge patch.
-                                                                  type: array
                                                                   items:
                                                                     type: string
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
                                                             x-kubernetes-list-type: atomic
                                                           matchLabels:
+                                                            additionalProperties:
+                                                              type: string
                                                             description: |-
                                                               matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                               map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                               operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                             type: object
-                                                            additionalProperties:
-                                                              type: string
+                                                        type: object
                                                         x-kubernetes-map-type: atomic
                                                       matchLabelKeys:
                                                         description: |-
@@ -2579,10 +1436,9 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                           Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                        type: array
                                                         items:
                                                           type: string
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       mismatchLabelKeys:
                                                         description: |-
@@ -2594,10 +1450,9 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                           Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                        type: array
                                                         items:
                                                           type: string
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         description: |-
@@ -2606,19 +1461,13 @@ spec:
                                                           and the ones listed in the namespaces field.
                                                           null selector and null or empty namespaces list means "this pod's namespace".
                                                           An empty selector ({}) matches all namespaces.
-                                                        type: object
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                            type: array
                                                             items:
                                                               description: |-
                                                                 A label selector requirement is a selector that contains values, a key, and an operator that
                                                                 relates the key and values.
-                                                              type: object
-                                                              required:
-                                                                - key
-                                                                - operator
                                                               properties:
                                                                 key:
                                                                   description: key is the label key that the selector applies to.
@@ -2634,19 +1483,25 @@ spec:
                                                                     the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                     the values array must be empty. This array is replaced during a strategic
                                                                     merge patch.
-                                                                  type: array
                                                                   items:
                                                                     type: string
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
                                                             x-kubernetes-list-type: atomic
                                                           matchLabels:
+                                                            additionalProperties:
+                                                              type: string
                                                             description: |-
                                                               matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                               map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                               operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                             type: object
-                                                            additionalProperties:
-                                                              type: string
+                                                        type: object
                                                         x-kubernetes-map-type: atomic
                                                       namespaces:
                                                         description: |-
@@ -2654,9 +1509,9 @@ spec:
                                                           The term is applied to the union of the namespaces listed in this field
                                                           and the ones selected by namespaceSelector.
                                                           null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                        type: array
                                                         items:
                                                           type: string
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         description: |-
@@ -2666,12 +1521,20 @@ spec:
                                                           selected pods is running.
                                                           Empty topologyKey is not allowed.
                                                         type: string
+                                                    required:
+                                                      - topologyKey
+                                                    type: object
                                                   weight:
                                                     description: |-
                                                       weight associated with matching the corresponding podAffinityTerm,
                                                       in the range 1-100.
-                                                    type: integer
                                                     format: int32
+                                                    type: integer
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                type: object
+                                              type: array
                                               x-kubernetes-list-type: atomic
                                             requiredDuringSchedulingIgnoredDuringExecution:
                                               description: |-
@@ -2682,7 +1545,6 @@ spec:
                                                 system may or may not try to eventually evict the pod from its node.
                                                 When there are multiple elements, the lists of nodes corresponding to each
                                                 podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                                              type: array
                                               items:
                                                 description: |-
                                                   Defines a set of pods (namely those matching the labelSelector
@@ -2691,27 +1553,18 @@ spec:
                                                   where co-located is defined as running on a node whose value of
                                                   the label with key <topologyKey> matches that of any node on which
                                                   a pod of the set of pods is running
-                                                type: object
-                                                required:
-                                                  - topologyKey
                                                 properties:
                                                   labelSelector:
                                                     description: |-
                                                       A label query over a set of resources, in this case pods.
                                                       If it's null, this PodAffinityTerm matches with no Pods.
-                                                    type: object
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A label selector requirement is a selector that contains values, a key, and an operator that
                                                             relates the key and values.
-                                                          type: object
-                                                          required:
-                                                            - key
-                                                            - operator
                                                           properties:
                                                             key:
                                                               description: key is the label key that the selector applies to.
@@ -2727,19 +1580,25 @@ spec:
                                                                 the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                 the values array must be empty. This array is replaced during a strategic
                                                                 merge patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       matchLabels:
+                                                        additionalProperties:
+                                                          type: string
                                                         description: |-
                                                           matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                           map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                           operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                         type: object
-                                                        additionalProperties:
-                                                          type: string
+                                                    type: object
                                                     x-kubernetes-map-type: atomic
                                                   matchLabelKeys:
                                                     description: |-
@@ -2751,10 +1610,9 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                       Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                    type: array
                                                     items:
                                                       type: string
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   mismatchLabelKeys:
                                                     description: |-
@@ -2766,10 +1624,9 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                       Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                    type: array
                                                     items:
                                                       type: string
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   namespaceSelector:
                                                     description: |-
@@ -2778,19 +1635,13 @@ spec:
                                                       and the ones listed in the namespaces field.
                                                       null selector and null or empty namespaces list means "this pod's namespace".
                                                       An empty selector ({}) matches all namespaces.
-                                                    type: object
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A label selector requirement is a selector that contains values, a key, and an operator that
                                                             relates the key and values.
-                                                          type: object
-                                                          required:
-                                                            - key
-                                                            - operator
                                                           properties:
                                                             key:
                                                               description: key is the label key that the selector applies to.
@@ -2806,19 +1657,25 @@ spec:
                                                                 the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                 the values array must be empty. This array is replaced during a strategic
                                                                 merge patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       matchLabels:
+                                                        additionalProperties:
+                                                          type: string
                                                         description: |-
                                                           matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                           map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                           operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                         type: object
-                                                        additionalProperties:
-                                                          type: string
+                                                    type: object
                                                     x-kubernetes-map-type: atomic
                                                   namespaces:
                                                     description: |-
@@ -2826,9 +1683,9 @@ spec:
                                                       The term is applied to the union of the namespaces listed in this field
                                                       and the ones selected by namespaceSelector.
                                                       null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                    type: array
                                                     items:
                                                       type: string
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   topologyKey:
                                                     description: |-
@@ -2838,17 +1695,22 @@ spec:
                                                       selected pods is running.
                                                       Empty topologyKey is not allowed.
                                                     type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              type: array
                                               x-kubernetes-list-type: atomic
+                                          type: object
+                                      type: object
                                     imagePullSecrets:
                                       description: If specified, the pod's imagePullSecrets
-                                      type: array
                                       items:
                                         description: |-
                                           LocalObjectReference contains enough information to let you locate the
                                           referenced object inside the same namespace.
-                                        type: object
                                         properties:
                                           name:
+                                            default: ""
                                             description: |-
                                               Name of the referent.
                                               This field is effectively required, but due to backwards compatibility is
@@ -2856,22 +1718,59 @@ spec:
                                               almost certainly wrong.
                                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                             type: string
-                                            default: ""
+                                        type: object
                                         x-kubernetes-map-type: atomic
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - name
+                                      x-kubernetes-list-type: map
                                     nodeSelector:
+                                      additionalProperties:
+                                        type: string
                                       description: |-
                                         NodeSelector is a selector which must be true for the pod to fit on a node.
                                         Selector which must match a node's labels for the pod to be scheduled on that node.
                                         More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                                       type: object
-                                      additionalProperties:
-                                        type: string
                                     priorityClassName:
                                       description: If specified, the pod's priorityClassName.
                                       type: string
+                                    resources:
+                                      description: |-
+                                        If specified, the pod's resource requirements.
+                                        These values override the global resource configuration flags.
+                                        Note that when only specifying resource limits, ensure they are greater than or equal
+                                        to the corresponding global resource requests configured via controller flags
+                                        (--acme-http01-solver-resource-request-cpu, --acme-http01-solver-resource-request-memory).
+                                        Kubernetes will reject pod creation if limits are lower than requests, causing challenge failures.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to the global values configured via controller flags. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                      type: object
                                     securityContext:
                                       description: If specified, the pod's security context
-                                      type: object
                                       properties:
                                         fsGroup:
                                           description: |-
@@ -2885,8 +1784,8 @@ spec:
 
                                             If unset, the Kubelet will not modify the ownership and permissions of any volume.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          type: integer
                                           format: int64
+                                          type: integer
                                         fsGroupChangePolicy:
                                           description: |-
                                             fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
@@ -2905,8 +1804,8 @@ spec:
                                             PodSecurityContext, the value specified in SecurityContext takes precedence
                                             for that container.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          type: integer
                                           format: int64
+                                          type: integer
                                         runAsNonRoot:
                                           description: |-
                                             Indicates that the container must run as a non-root user.
@@ -2924,8 +1823,8 @@ spec:
                                             PodSecurityContext, the value specified in SecurityContext takes precedence
                                             for that container.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          type: integer
                                           format: int64
+                                          type: integer
                                         seLinuxOptions:
                                           description: |-
                                             The SELinux context to be applied to all containers.
@@ -2934,7 +1833,6 @@ spec:
                                             both SecurityContext and PodSecurityContext, the value specified in SecurityContext
                                             takes precedence for that container.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          type: object
                                           properties:
                                             level:
                                               description: Level is SELinux level label that applies to the container.
@@ -2948,13 +1846,11 @@ spec:
                                             user:
                                               description: User is a SELinux user label that applies to the container.
                                               type: string
+                                          type: object
                                         seccompProfile:
                                           description: |-
                                             The seccomp options to use by the containers in this pod.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          type: object
-                                          required:
-                                            - type
                                           properties:
                                             localhostProfile:
                                               description: |-
@@ -2972,6 +1868,9 @@ spec:
                                                 RuntimeDefault - the container runtime default profile should be used.
                                                 Unconfined - no profile should be applied.
                                               type: string
+                                          required:
+                                            - type
+                                          type: object
                                         supplementalGroups:
                                           description: |-
                                             A list of groups applied to the first process run in each container, in addition
@@ -2981,22 +1880,18 @@ spec:
                                             defined in the container image for the uid of the container process are still effective,
                                             even if they are not included in this list.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          type: array
                                           items:
-                                            type: integer
                                             format: int64
+                                            type: integer
+                                          type: array
+                                          x-kubernetes-list-type: atomic
                                         sysctls:
                                           description: |-
                                             Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
                                             sysctls (by the container runtime) might fail to launch.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          type: array
                                           items:
                                             description: Sysctl defines a kernel parameter to be set
-                                            type: object
-                                            required:
-                                              - name
-                                              - value
                                             properties:
                                               name:
                                                 description: Name of a property to set
@@ -3004,17 +1899,22 @@ spec:
                                               value:
                                                 description: Value of a property to set
                                                 type: string
+                                            required:
+                                              - name
+                                              - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
                                     serviceAccountName:
                                       description: If specified, the pod's service account
                                       type: string
                                     tolerations:
                                       description: If specified, the pod's tolerations.
-                                      type: array
                                       items:
                                         description: |-
                                           The pod this Toleration is attached to tolerates any taint that matches
                                           the triple <key,value,effect> using the matching operator <operator>.
-                                        type: object
                                         properties:
                                           effect:
                                             description: |-
@@ -3039,25 +1939,30 @@ spec:
                                               of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                                               it is not set, which means tolerate the taint forever (do not evict). Zero and
                                               negative values will be treated as 0 (evict immediately) by the system.
-                                            type: integer
                                             format: int64
+                                            type: integer
                                           value:
                                             description: |-
                                               Value is the taint value the toleration matches to.
                                               If the operator is Exists, the value should be empty, otherwise just a regular string.
                                             type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                              type: object
                             serviceType:
                               description: |-
                                 Optional service type for Kubernetes solver service. Supported values
                                 are NodePort or ClusterIP. If unset, defaults to NodePort.
                               type: string
+                          type: object
                         ingress:
                           description: |-
                             The ingress based HTTP01 challenge solver will solve challenges by
                             creating or modifying Ingress resources in order to route requests for
                             '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are
                             provisioned by cert-manager for each Challenge to be completed.
-                          type: object
                           properties:
                             class:
                               description: |-
@@ -3077,7 +1982,6 @@ spec:
                               description: |-
                                 Optional ingress template used to configure the ACME challenge solver
                                 ingress used for HTTP01 challenges.
-                              type: object
                               properties:
                                 metadata:
                                   description: |-
@@ -3085,18 +1989,19 @@ spec:
                                     Only the 'labels' and 'annotations' fields may be set.
                                     If labels or annotations overlap with in-built values, the values here
                                     will override the in-built values.
-                                  type: object
                                   properties:
                                     annotations:
+                                      additionalProperties:
+                                        type: string
                                       description: Annotations that should be added to the created ACME HTTP01 solver ingress.
                                       type: object
+                                    labels:
                                       additionalProperties:
                                         type: string
-                                    labels:
                                       description: Labels that should be added to the created ACME HTTP01 solver ingress.
                                       type: object
-                                      additionalProperties:
-                                        type: string
+                                  type: object
+                              type: object
                             name:
                               description: |-
                                 The name of the ingress resource that should have ACME challenge solving
@@ -3110,7 +2015,6 @@ spec:
                               description: |-
                                 Optional pod template used to configure the ACME challenge solver pods
                                 used for HTTP01 challenges.
-                              type: object
                               properties:
                                 metadata:
                                   description: |-
@@ -3118,32 +2022,29 @@ spec:
                                     Only the 'labels' and 'annotations' fields may be set.
                                     If labels or annotations overlap with in-built values, the values here
                                     will override the in-built values.
-                                  type: object
                                   properties:
                                     annotations:
+                                      additionalProperties:
+                                        type: string
                                       description: Annotations that should be added to the created ACME HTTP01 solver pods.
                                       type: object
+                                    labels:
                                       additionalProperties:
                                         type: string
-                                    labels:
                                       description: Labels that should be added to the created ACME HTTP01 solver pods.
                                       type: object
-                                      additionalProperties:
-                                        type: string
+                                  type: object
                                 spec:
                                   description: |-
                                     PodSpec defines overrides for the HTTP01 challenge solver pod.
                                     Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
                                     All other fields will be ignored.
-                                  type: object
                                   properties:
                                     affinity:
                                       description: If specified, the pod's scheduling constraints
-                                      type: object
                                       properties:
                                         nodeAffinity:
                                           description: Describes node affinity scheduling rules for the pod.
-                                          type: object
                                           properties:
                                             preferredDuringSchedulingIgnoredDuringExecution:
                                               description: |-
@@ -3156,31 +2057,20 @@ spec:
                                                 compute a sum by iterating through the elements of this field and adding
                                                 "weight" to the sum if the node matches the corresponding matchExpressions; the
                                                 node(s) with the highest sum are the most preferred.
-                                              type: array
                                               items:
                                                 description: |-
                                                   An empty preferred scheduling term matches all objects with implicit weight 0
                                                   (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
-                                                type: object
-                                                required:
-                                                  - preference
-                                                  - weight
                                                 properties:
                                                   preference:
                                                     description: A node selector term, associated with the corresponding weight.
-                                                    type: object
                                                     properties:
                                                       matchExpressions:
                                                         description: A list of node selector requirements by node's labels.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A node selector requirement is a selector that contains values, a key, and an operator
                                                             that relates the key and values.
-                                                          type: object
-                                                          required:
-                                                            - key
-                                                            - operator
                                                           properties:
                                                             key:
                                                               description: The label key that the selector applies to.
@@ -3197,22 +2087,22 @@ spec:
                                                                 the values array must be empty. If the operator is Gt or Lt, the values
                                                                 array must have a single element, which will be interpreted as an integer.
                                                                 This array is replaced during a strategic merge patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       matchFields:
                                                         description: A list of node selector requirements by node's fields.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A node selector requirement is a selector that contains values, a key, and an operator
                                                             that relates the key and values.
-                                                          type: object
-                                                          required:
-                                                            - key
-                                                            - operator
                                                           properties:
                                                             key:
                                                               description: The label key that the selector applies to.
@@ -3229,16 +2119,27 @@ spec:
                                                                 the values array must be empty. If the operator is Gt or Lt, the values
                                                                 array must have a single element, which will be interpreted as an integer.
                                                                 This array is replaced during a strategic merge patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
+                                                    type: object
                                                     x-kubernetes-map-type: atomic
                                                   weight:
                                                     description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
-                                                    type: integer
                                                     format: int32
+                                                    type: integer
+                                                required:
+                                                  - preference
+                                                  - weight
+                                                type: object
+                                              type: array
                                               x-kubernetes-list-type: atomic
                                             requiredDuringSchedulingIgnoredDuringExecution:
                                               description: |-
@@ -3247,31 +2148,21 @@ spec:
                                                 If the affinity requirements specified by this field cease to be met
                                                 at some point during pod execution (e.g. due to an update), the system
                                                 may or may not try to eventually evict the pod from its node.
-                                              type: object
-                                              required:
-                                                - nodeSelectorTerms
                                               properties:
                                                 nodeSelectorTerms:
                                                   description: Required. A list of node selector terms. The terms are ORed.
-                                                  type: array
                                                   items:
                                                     description: |-
                                                       A null or empty node selector term matches no objects. The requirements of
                                                       them are ANDed.
                                                       The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
-                                                    type: object
                                                     properties:
                                                       matchExpressions:
                                                         description: A list of node selector requirements by node's labels.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A node selector requirement is a selector that contains values, a key, and an operator
                                                             that relates the key and values.
-                                                          type: object
-                                                          required:
-                                                            - key
-                                                            - operator
                                                           properties:
                                                             key:
                                                               description: The label key that the selector applies to.
@@ -3288,22 +2179,22 @@ spec:
                                                                 the values array must be empty. If the operator is Gt or Lt, the values
                                                                 array must have a single element, which will be interpreted as an integer.
                                                                 This array is replaced during a strategic merge patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       matchFields:
                                                         description: A list of node selector requirements by node's fields.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A node selector requirement is a selector that contains values, a key, and an operator
                                                             that relates the key and values.
-                                                          type: object
-                                                          required:
-                                                            - key
-                                                            - operator
                                                           properties:
                                                             key:
                                                               description: The label key that the selector applies to.
@@ -3320,17 +2211,27 @@ spec:
                                                                 the values array must be empty. If the operator is Gt or Lt, the values
                                                                 array must have a single element, which will be interpreted as an integer.
                                                                 This array is replaced during a strategic merge patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
+                                                    type: object
                                                     x-kubernetes-map-type: atomic
+                                                  type: array
                                                   x-kubernetes-list-type: atomic
+                                              required:
+                                                - nodeSelectorTerms
+                                              type: object
                                               x-kubernetes-map-type: atomic
+                                          type: object
                                         podAffinity:
                                           description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
-                                          type: object
                                           properties:
                                             preferredDuringSchedulingIgnoredDuringExecution:
                                               description: |-
@@ -3343,37 +2244,23 @@ spec:
                                                 compute a sum by iterating through the elements of this field and adding
                                                 "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                 node(s) with the highest sum are the most preferred.
-                                              type: array
                                               items:
                                                 description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                                                type: object
-                                                required:
-                                                  - podAffinityTerm
-                                                  - weight
                                                 properties:
                                                   podAffinityTerm:
                                                     description: Required. A pod affinity term, associated with the corresponding weight.
-                                                    type: object
-                                                    required:
-                                                      - topologyKey
                                                     properties:
                                                       labelSelector:
                                                         description: |-
                                                           A label query over a set of resources, in this case pods.
                                                           If it's null, this PodAffinityTerm matches with no Pods.
-                                                        type: object
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                            type: array
                                                             items:
                                                               description: |-
                                                                 A label selector requirement is a selector that contains values, a key, and an operator that
                                                                 relates the key and values.
-                                                              type: object
-                                                              required:
-                                                                - key
-                                                                - operator
                                                               properties:
                                                                 key:
                                                                   description: key is the label key that the selector applies to.
@@ -3389,19 +2276,25 @@ spec:
                                                                     the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                     the values array must be empty. This array is replaced during a strategic
                                                                     merge patch.
-                                                                  type: array
                                                                   items:
                                                                     type: string
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
                                                             x-kubernetes-list-type: atomic
                                                           matchLabels:
+                                                            additionalProperties:
+                                                              type: string
                                                             description: |-
                                                               matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                               map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                               operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                             type: object
-                                                            additionalProperties:
-                                                              type: string
+                                                        type: object
                                                         x-kubernetes-map-type: atomic
                                                       matchLabelKeys:
                                                         description: |-
@@ -3413,10 +2306,9 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                           Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                        type: array
                                                         items:
                                                           type: string
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       mismatchLabelKeys:
                                                         description: |-
@@ -3428,10 +2320,9 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                           Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                        type: array
                                                         items:
                                                           type: string
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         description: |-
@@ -3440,19 +2331,13 @@ spec:
                                                           and the ones listed in the namespaces field.
                                                           null selector and null or empty namespaces list means "this pod's namespace".
                                                           An empty selector ({}) matches all namespaces.
-                                                        type: object
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                            type: array
                                                             items:
                                                               description: |-
                                                                 A label selector requirement is a selector that contains values, a key, and an operator that
                                                                 relates the key and values.
-                                                              type: object
-                                                              required:
-                                                                - key
-                                                                - operator
                                                               properties:
                                                                 key:
                                                                   description: key is the label key that the selector applies to.
@@ -3468,19 +2353,25 @@ spec:
                                                                     the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                     the values array must be empty. This array is replaced during a strategic
                                                                     merge patch.
-                                                                  type: array
                                                                   items:
                                                                     type: string
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
                                                             x-kubernetes-list-type: atomic
                                                           matchLabels:
+                                                            additionalProperties:
+                                                              type: string
                                                             description: |-
                                                               matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                               map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                               operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                             type: object
-                                                            additionalProperties:
-                                                              type: string
+                                                        type: object
                                                         x-kubernetes-map-type: atomic
                                                       namespaces:
                                                         description: |-
@@ -3488,9 +2379,9 @@ spec:
                                                           The term is applied to the union of the namespaces listed in this field
                                                           and the ones selected by namespaceSelector.
                                                           null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                        type: array
                                                         items:
                                                           type: string
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         description: |-
@@ -3500,12 +2391,20 @@ spec:
                                                           selected pods is running.
                                                           Empty topologyKey is not allowed.
                                                         type: string
+                                                    required:
+                                                      - topologyKey
+                                                    type: object
                                                   weight:
                                                     description: |-
                                                       weight associated with matching the corresponding podAffinityTerm,
                                                       in the range 1-100.
-                                                    type: integer
                                                     format: int32
+                                                    type: integer
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                type: object
+                                              type: array
                                               x-kubernetes-list-type: atomic
                                             requiredDuringSchedulingIgnoredDuringExecution:
                                               description: |-
@@ -3516,7 +2415,6 @@ spec:
                                                 system may or may not try to eventually evict the pod from its node.
                                                 When there are multiple elements, the lists of nodes corresponding to each
                                                 podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                                              type: array
                                               items:
                                                 description: |-
                                                   Defines a set of pods (namely those matching the labelSelector
@@ -3525,27 +2423,18 @@ spec:
                                                   where co-located is defined as running on a node whose value of
                                                   the label with key <topologyKey> matches that of any node on which
                                                   a pod of the set of pods is running
-                                                type: object
-                                                required:
-                                                  - topologyKey
                                                 properties:
                                                   labelSelector:
                                                     description: |-
                                                       A label query over a set of resources, in this case pods.
                                                       If it's null, this PodAffinityTerm matches with no Pods.
-                                                    type: object
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A label selector requirement is a selector that contains values, a key, and an operator that
                                                             relates the key and values.
-                                                          type: object
-                                                          required:
-                                                            - key
-                                                            - operator
                                                           properties:
                                                             key:
                                                               description: key is the label key that the selector applies to.
@@ -3561,19 +2450,25 @@ spec:
                                                                 the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                 the values array must be empty. This array is replaced during a strategic
                                                                 merge patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       matchLabels:
+                                                        additionalProperties:
+                                                          type: string
                                                         description: |-
                                                           matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                           map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                           operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                         type: object
-                                                        additionalProperties:
-                                                          type: string
+                                                    type: object
                                                     x-kubernetes-map-type: atomic
                                                   matchLabelKeys:
                                                     description: |-
@@ -3585,10 +2480,9 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                       Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                    type: array
                                                     items:
                                                       type: string
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   mismatchLabelKeys:
                                                     description: |-
@@ -3600,10 +2494,9 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                       Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                    type: array
                                                     items:
                                                       type: string
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   namespaceSelector:
                                                     description: |-
@@ -3612,19 +2505,13 @@ spec:
                                                       and the ones listed in the namespaces field.
                                                       null selector and null or empty namespaces list means "this pod's namespace".
                                                       An empty selector ({}) matches all namespaces.
-                                                    type: object
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A label selector requirement is a selector that contains values, a key, and an operator that
                                                             relates the key and values.
-                                                          type: object
-                                                          required:
-                                                            - key
-                                                            - operator
                                                           properties:
                                                             key:
                                                               description: key is the label key that the selector applies to.
@@ -3640,19 +2527,25 @@ spec:
                                                                 the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                 the values array must be empty. This array is replaced during a strategic
                                                                 merge patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       matchLabels:
+                                                        additionalProperties:
+                                                          type: string
                                                         description: |-
                                                           matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                           map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                           operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                         type: object
-                                                        additionalProperties:
-                                                          type: string
+                                                    type: object
                                                     x-kubernetes-map-type: atomic
                                                   namespaces:
                                                     description: |-
@@ -3660,9 +2553,9 @@ spec:
                                                       The term is applied to the union of the namespaces listed in this field
                                                       and the ones selected by namespaceSelector.
                                                       null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                    type: array
                                                     items:
                                                       type: string
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   topologyKey:
                                                     description: |-
@@ -3672,10 +2565,14 @@ spec:
                                                       selected pods is running.
                                                       Empty topologyKey is not allowed.
                                                     type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              type: array
                                               x-kubernetes-list-type: atomic
+                                          type: object
                                         podAntiAffinity:
                                           description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
-                                          type: object
                                           properties:
                                             preferredDuringSchedulingIgnoredDuringExecution:
                                               description: |-
@@ -3685,40 +2582,26 @@ spec:
                                                 most preferred is the one with the greatest sum of weights, i.e.
                                                 for each node that meets all of the scheduling requirements (resource
                                                 request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                                compute a sum by iterating through the elements of this field and adding
-                                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                compute a sum by iterating through the elements of this field and subtracting
+                                                "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                 node(s) with the highest sum are the most preferred.
-                                              type: array
                                               items:
                                                 description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                                                type: object
-                                                required:
-                                                  - podAffinityTerm
-                                                  - weight
                                                 properties:
                                                   podAffinityTerm:
                                                     description: Required. A pod affinity term, associated with the corresponding weight.
-                                                    type: object
-                                                    required:
-                                                      - topologyKey
                                                     properties:
                                                       labelSelector:
                                                         description: |-
                                                           A label query over a set of resources, in this case pods.
                                                           If it's null, this PodAffinityTerm matches with no Pods.
-                                                        type: object
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                            type: array
                                                             items:
                                                               description: |-
                                                                 A label selector requirement is a selector that contains values, a key, and an operator that
                                                                 relates the key and values.
-                                                              type: object
-                                                              required:
-                                                                - key
-                                                                - operator
                                                               properties:
                                                                 key:
                                                                   description: key is the label key that the selector applies to.
@@ -3734,19 +2617,25 @@ spec:
                                                                     the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                     the values array must be empty. This array is replaced during a strategic
                                                                     merge patch.
-                                                                  type: array
                                                                   items:
                                                                     type: string
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
                                                             x-kubernetes-list-type: atomic
                                                           matchLabels:
+                                                            additionalProperties:
+                                                              type: string
                                                             description: |-
                                                               matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                               map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                               operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                             type: object
-                                                            additionalProperties:
-                                                              type: string
+                                                        type: object
                                                         x-kubernetes-map-type: atomic
                                                       matchLabelKeys:
                                                         description: |-
@@ -3758,10 +2647,9 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                           Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                        type: array
                                                         items:
                                                           type: string
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       mismatchLabelKeys:
                                                         description: |-
@@ -3773,10 +2661,9 @@ spec:
                                                           pod labels will be ignored. The default value is empty.
                                                           The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                           Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                        type: array
                                                         items:
                                                           type: string
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       namespaceSelector:
                                                         description: |-
@@ -3785,19 +2672,13 @@ spec:
                                                           and the ones listed in the namespaces field.
                                                           null selector and null or empty namespaces list means "this pod's namespace".
                                                           An empty selector ({}) matches all namespaces.
-                                                        type: object
                                                         properties:
                                                           matchExpressions:
                                                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                            type: array
                                                             items:
                                                               description: |-
                                                                 A label selector requirement is a selector that contains values, a key, and an operator that
                                                                 relates the key and values.
-                                                              type: object
-                                                              required:
-                                                                - key
-                                                                - operator
                                                               properties:
                                                                 key:
                                                                   description: key is the label key that the selector applies to.
@@ -3813,19 +2694,25 @@ spec:
                                                                     the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                     the values array must be empty. This array is replaced during a strategic
                                                                     merge patch.
-                                                                  type: array
                                                                   items:
                                                                     type: string
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              type: object
+                                                            type: array
                                                             x-kubernetes-list-type: atomic
                                                           matchLabels:
+                                                            additionalProperties:
+                                                              type: string
                                                             description: |-
                                                               matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                               map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                               operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                             type: object
-                                                            additionalProperties:
-                                                              type: string
+                                                        type: object
                                                         x-kubernetes-map-type: atomic
                                                       namespaces:
                                                         description: |-
@@ -3833,9 +2720,9 @@ spec:
                                                           The term is applied to the union of the namespaces listed in this field
                                                           and the ones selected by namespaceSelector.
                                                           null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                        type: array
                                                         items:
                                                           type: string
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       topologyKey:
                                                         description: |-
@@ -3845,12 +2732,20 @@ spec:
                                                           selected pods is running.
                                                           Empty topologyKey is not allowed.
                                                         type: string
+                                                    required:
+                                                      - topologyKey
+                                                    type: object
                                                   weight:
                                                     description: |-
                                                       weight associated with matching the corresponding podAffinityTerm,
                                                       in the range 1-100.
-                                                    type: integer
                                                     format: int32
+                                                    type: integer
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                type: object
+                                              type: array
                                               x-kubernetes-list-type: atomic
                                             requiredDuringSchedulingIgnoredDuringExecution:
                                               description: |-
@@ -3861,7 +2756,6 @@ spec:
                                                 system may or may not try to eventually evict the pod from its node.
                                                 When there are multiple elements, the lists of nodes corresponding to each
                                                 podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                                              type: array
                                               items:
                                                 description: |-
                                                   Defines a set of pods (namely those matching the labelSelector
@@ -3870,27 +2764,18 @@ spec:
                                                   where co-located is defined as running on a node whose value of
                                                   the label with key <topologyKey> matches that of any node on which
                                                   a pod of the set of pods is running
-                                                type: object
-                                                required:
-                                                  - topologyKey
                                                 properties:
                                                   labelSelector:
                                                     description: |-
                                                       A label query over a set of resources, in this case pods.
                                                       If it's null, this PodAffinityTerm matches with no Pods.
-                                                    type: object
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A label selector requirement is a selector that contains values, a key, and an operator that
                                                             relates the key and values.
-                                                          type: object
-                                                          required:
-                                                            - key
-                                                            - operator
                                                           properties:
                                                             key:
                                                               description: key is the label key that the selector applies to.
@@ -3906,19 +2791,25 @@ spec:
                                                                 the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                 the values array must be empty. This array is replaced during a strategic
                                                                 merge patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       matchLabels:
+                                                        additionalProperties:
+                                                          type: string
                                                         description: |-
                                                           matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                           map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                           operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                         type: object
-                                                        additionalProperties:
-                                                          type: string
+                                                    type: object
                                                     x-kubernetes-map-type: atomic
                                                   matchLabelKeys:
                                                     description: |-
@@ -3930,10 +2821,9 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                       Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                    type: array
                                                     items:
                                                       type: string
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   mismatchLabelKeys:
                                                     description: |-
@@ -3945,10 +2835,9 @@ spec:
                                                       pod labels will be ignored. The default value is empty.
                                                       The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                       Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                    type: array
                                                     items:
                                                       type: string
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   namespaceSelector:
                                                     description: |-
@@ -3957,19 +2846,13 @@ spec:
                                                       and the ones listed in the namespaces field.
                                                       null selector and null or empty namespaces list means "this pod's namespace".
                                                       An empty selector ({}) matches all namespaces.
-                                                    type: object
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A label selector requirement is a selector that contains values, a key, and an operator that
                                                             relates the key and values.
-                                                          type: object
-                                                          required:
-                                                            - key
-                                                            - operator
                                                           properties:
                                                             key:
                                                               description: key is the label key that the selector applies to.
@@ -3985,19 +2868,25 @@ spec:
                                                                 the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                 the values array must be empty. This array is replaced during a strategic
                                                                 merge patch.
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
                                                       matchLabels:
+                                                        additionalProperties:
+                                                          type: string
                                                         description: |-
                                                           matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                           map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                           operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                         type: object
-                                                        additionalProperties:
-                                                          type: string
+                                                    type: object
                                                     x-kubernetes-map-type: atomic
                                                   namespaces:
                                                     description: |-
@@ -4005,9 +2894,9 @@ spec:
                                                       The term is applied to the union of the namespaces listed in this field
                                                       and the ones selected by namespaceSelector.
                                                       null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                    type: array
                                                     items:
                                                       type: string
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   topologyKey:
                                                     description: |-
@@ -4017,17 +2906,22 @@ spec:
                                                       selected pods is running.
                                                       Empty topologyKey is not allowed.
                                                     type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              type: array
                                               x-kubernetes-list-type: atomic
+                                          type: object
+                                      type: object
                                     imagePullSecrets:
                                       description: If specified, the pod's imagePullSecrets
-                                      type: array
                                       items:
                                         description: |-
                                           LocalObjectReference contains enough information to let you locate the
                                           referenced object inside the same namespace.
-                                        type: object
                                         properties:
                                           name:
+                                            default: ""
                                             description: |-
                                               Name of the referent.
                                               This field is effectively required, but due to backwards compatibility is
@@ -4035,22 +2929,59 @@ spec:
                                               almost certainly wrong.
                                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                             type: string
-                                            default: ""
+                                        type: object
                                         x-kubernetes-map-type: atomic
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - name
+                                      x-kubernetes-list-type: map
                                     nodeSelector:
+                                      additionalProperties:
+                                        type: string
                                       description: |-
                                         NodeSelector is a selector which must be true for the pod to fit on a node.
                                         Selector which must match a node's labels for the pod to be scheduled on that node.
                                         More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                                       type: object
-                                      additionalProperties:
-                                        type: string
                                     priorityClassName:
                                       description: If specified, the pod's priorityClassName.
                                       type: string
+                                    resources:
+                                      description: |-
+                                        If specified, the pod's resource requirements.
+                                        These values override the global resource configuration flags.
+                                        Note that when only specifying resource limits, ensure they are greater than or equal
+                                        to the corresponding global resource requests configured via controller flags
+                                        (--acme-http01-solver-resource-request-cpu, --acme-http01-solver-resource-request-memory).
+                                        Kubernetes will reject pod creation if limits are lower than requests, causing challenge failures.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to the global values configured via controller flags. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                      type: object
                                     securityContext:
                                       description: If specified, the pod's security context
-                                      type: object
                                       properties:
                                         fsGroup:
                                           description: |-
@@ -4064,8 +2995,8 @@ spec:
 
                                             If unset, the Kubelet will not modify the ownership and permissions of any volume.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          type: integer
                                           format: int64
+                                          type: integer
                                         fsGroupChangePolicy:
                                           description: |-
                                             fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
@@ -4084,8 +3015,8 @@ spec:
                                             PodSecurityContext, the value specified in SecurityContext takes precedence
                                             for that container.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          type: integer
                                           format: int64
+                                          type: integer
                                         runAsNonRoot:
                                           description: |-
                                             Indicates that the container must run as a non-root user.
@@ -4103,8 +3034,8 @@ spec:
                                             PodSecurityContext, the value specified in SecurityContext takes precedence
                                             for that container.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          type: integer
                                           format: int64
+                                          type: integer
                                         seLinuxOptions:
                                           description: |-
                                             The SELinux context to be applied to all containers.
@@ -4113,7 +3044,6 @@ spec:
                                             both SecurityContext and PodSecurityContext, the value specified in SecurityContext
                                             takes precedence for that container.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          type: object
                                           properties:
                                             level:
                                               description: Level is SELinux level label that applies to the container.
@@ -4127,13 +3057,11 @@ spec:
                                             user:
                                               description: User is a SELinux user label that applies to the container.
                                               type: string
+                                          type: object
                                         seccompProfile:
                                           description: |-
                                             The seccomp options to use by the containers in this pod.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          type: object
-                                          required:
-                                            - type
                                           properties:
                                             localhostProfile:
                                               description: |-
@@ -4151,6 +3079,9 @@ spec:
                                                 RuntimeDefault - the container runtime default profile should be used.
                                                 Unconfined - no profile should be applied.
                                               type: string
+                                          required:
+                                            - type
+                                          type: object
                                         supplementalGroups:
                                           description: |-
                                             A list of groups applied to the first process run in each container, in addition
@@ -4160,22 +3091,18 @@ spec:
                                             defined in the container image for the uid of the container process are still effective,
                                             even if they are not included in this list.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          type: array
                                           items:
-                                            type: integer
                                             format: int64
+                                            type: integer
+                                          type: array
+                                          x-kubernetes-list-type: atomic
                                         sysctls:
                                           description: |-
                                             Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
                                             sysctls (by the container runtime) might fail to launch.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          type: array
                                           items:
                                             description: Sysctl defines a kernel parameter to be set
-                                            type: object
-                                            required:
-                                              - name
-                                              - value
                                             properties:
                                               name:
                                                 description: Name of a property to set
@@ -4183,17 +3110,22 @@ spec:
                                               value:
                                                 description: Value of a property to set
                                                 type: string
+                                            required:
+                                              - name
+                                              - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
                                     serviceAccountName:
                                       description: If specified, the pod's service account
                                       type: string
                                     tolerations:
                                       description: If specified, the pod's tolerations.
-                                      type: array
                                       items:
                                         description: |-
                                           The pod this Toleration is attached to tolerates any taint that matches
                                           the triple <key,value,effect> using the matching operator <operator>.
-                                        type: object
                                         properties:
                                           effect:
                                             description: |-
@@ -4218,18 +3150,25 @@ spec:
                                               of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                                               it is not set, which means tolerate the taint forever (do not evict). Zero and
                                               negative values will be treated as 0 (evict immediately) by the system.
-                                            type: integer
                                             format: int64
+                                            type: integer
                                           value:
                                             description: |-
                                               Value is the taint value the toleration matches to.
                                               If the operator is Exists, the value should be empty, otherwise just a regular string.
                                             type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                              type: object
                             serviceType:
                               description: |-
                                 Optional service type for Kubernetes solver service. Supported values
                                 are NodePort or ClusterIP. If unset, defaults to NodePort.
                               type: string
+                          type: object
+                      type: object
                     selector:
                       description: |-
                         Selector selects a set of DNSNames on the Certificate resource that
@@ -4237,7 +3176,6 @@ spec:
                         If not specified, the solver will be treated as the 'default' solver
                         with the lowest priority, i.e. if any other solver has a more specific
                         match, it will be used instead.
-                      type: object
                       properties:
                         dnsNames:
                           description: |-
@@ -4248,9 +3186,10 @@ spec:
                             with the most matching labels in matchLabels will be selected.
                             If neither has more matches, the solver defined earlier in the list
                             will be selected.
-                          type: array
                           items:
                             type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
                         dnsZones:
                           description: |-
                             List of DNSZones that this solver will be used to solve.
@@ -4262,16 +3201,19 @@ spec:
                             with the most matching labels in matchLabels will be selected.
                             If neither has more matches, the solver defined earlier in the list
                             will be selected.
-                          type: array
                           items:
                             type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
                         matchLabels:
+                          additionalProperties:
+                            type: string
                           description: |-
                             A label selector that is used to refine the set of certificate's that
                             this challenge solver will apply to.
                           type: object
-                          additionalProperties:
-                            type: string
+                      type: object
+                  type: object
                 token:
                   description: |-
                     The ACME challenge token for this challenge.
@@ -4281,10 +3223,10 @@ spec:
                   description: |-
                     The type of ACME challenge this resource represents.
                     One of "HTTP-01" or "DNS-01".
-                  type: string
                   enum:
                     - HTTP-01
                     - DNS-01
+                  type: string
                 url:
                   description: |-
                     The URL of the ACME Challenge resource for this challenge.
@@ -4295,8 +3237,17 @@ spec:
                     wildcard will be true if this challenge is for a wildcard identifier,
                     for example '*.example.com'.
                   type: boolean
-            status:
+              required:
+                - authorizationURL
+                - dnsName
+                - issuerRef
+                - key
+                - solver
+                - token
+                - type
+                - url
               type: object
+            status:
               properties:
                 presented:
                   description: |-
@@ -4325,7 +3276,6 @@ spec:
                   description: |-
                     Contains the current 'state' of the challenge.
                     If not set, the state of the challenge is unknown.
-                  type: string
                   enum:
                     - valid
                     - ready
@@ -4334,57 +3284,1471 @@ spec:
                     - invalid
                     - expired
                     - errored
+                  type: string
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
       served: true
       storage: true
       subresources:
         status: {}
-
-# END crd
 ---
-# Source: cert-manager/templates/crds.yaml
-# START crd
+# Source: cert-manager/templates/crd-acme.cert-manager.io_orders.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clusterissuers.cert-manager.io
-  # START annotations
+  name: "orders.acme.cert-manager.io"
   annotations:
     helm.sh/resource-policy: keep
-  # END annotations
   labels:
-    app: 'cert-manager'
-    app.kubernetes.io/name: 'cert-manager'
-    app.kubernetes.io/instance: 'cert-manager'
-    # Generated labels
-    app.kubernetes.io/version: "v1.18.2"
+    app: "cert-manager"
+    app.kubernetes.io/name: "cert-manager"
+    app.kubernetes.io/instance: "cert-manager"
+    app.kubernetes.io/component: "crds"
+    app.kubernetes.io/version: "v1.19.6"
+spec:
+  group: acme.cert-manager.io
+  names:
+    categories:
+      - cert-manager
+      - cert-manager-acme
+    kind: Order
+    listKind: OrderList
+    plural: orders
+    singular: order
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          priority: 1
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Order is a type to represent an Order with an ACME server
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                commonName:
+                  description: |-
+                    CommonName is the common name as specified on the DER encoded CSR.
+                    If specified, this value must also be present in `dnsNames` or `ipAddresses`.
+                    This field must match the corresponding field on the DER encoded CSR.
+                  type: string
+                dnsNames:
+                  description: |-
+                    DNSNames is a list of DNS names that should be included as part of the Order
+                    validation process.
+                    This field must match the corresponding field on the DER encoded CSR.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                duration:
+                  description: |-
+                    Duration is the duration for the not after date for the requested certificate.
+                    this is set on order creation as pe the ACME spec.
+                  type: string
+                ipAddresses:
+                  description: |-
+                    IPAddresses is a list of IP addresses that should be included as part of the Order
+                    validation process.
+                    This field must match the corresponding field on the DER encoded CSR.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                issuerRef:
+                  description: |-
+                    IssuerRef references a properly configured ACME-type Issuer which should
+                    be used to create this Order.
+                    If the Issuer does not exist, processing will be retried.
+                    If the Issuer is not an 'ACME' Issuer, an error will be returned and the
+                    Order will be marked as failed.
+                  properties:
+                    group:
+                      description: |-
+                        Group of the issuer being referred to.
+                        Defaults to 'cert-manager.io'.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the issuer being referred to.
+                        Defaults to 'Issuer'.
+                      type: string
+                    name:
+                      description: Name of the issuer being referred to.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                profile:
+                  description: |-
+                    Profile allows requesting a certificate profile from the ACME server.
+                    Supported profiles are listed by the server's ACME directory URL.
+                  type: string
+                request:
+                  description: |-
+                    Certificate signing request bytes in DER encoding.
+                    This will be used when finalizing the order.
+                    This field must be set on the order.
+                  format: byte
+                  type: string
+              required:
+                - issuerRef
+                - request
+              type: object
+            status:
+              properties:
+                authorizations:
+                  description: |-
+                    Authorizations contains data returned from the ACME server on what
+                    authorizations must be completed in order to validate the DNS names
+                    specified on the Order.
+                  items:
+                    description: |-
+                      ACMEAuthorization contains data returned from the ACME server on an
+                      authorization that must be completed in order validate a DNS name on an ACME
+                      Order resource.
+                    properties:
+                      challenges:
+                        description: |-
+                          Challenges specifies the challenge types offered by the ACME server.
+                          One of these challenge types will be selected when validating the DNS
+                          name and an appropriate Challenge resource will be created to perform
+                          the ACME challenge process.
+                        items:
+                          description: |-
+                            Challenge specifies a challenge offered by the ACME server for an Order.
+                            An appropriate Challenge resource can be created to perform the ACME
+                            challenge process.
+                          properties:
+                            token:
+                              description: |-
+                                Token is the token that must be presented for this challenge.
+                                This is used to compute the 'key' that must also be presented.
+                              type: string
+                            type:
+                              description: |-
+                                Type is the type of challenge being offered, e.g., 'http-01', 'dns-01',
+                                'tls-sni-01', etc.
+                                This is the raw value retrieved from the ACME server.
+                                Only 'http-01' and 'dns-01' are supported by cert-manager, other values
+                                will be ignored.
+                              type: string
+                            url:
+                              description: |-
+                                URL is the URL of this challenge. It can be used to retrieve additional
+                                metadata about the Challenge from the ACME server.
+                              type: string
+                          required:
+                            - token
+                            - type
+                            - url
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      identifier:
+                        description: Identifier is the DNS name to be validated as part of this authorization
+                        type: string
+                      initialState:
+                        description: |-
+                          InitialState is the initial state of the ACME authorization when first
+                          fetched from the ACME server.
+                          If an Authorization is already 'valid', the Order controller will not
+                          create a Challenge resource for the authorization. This will occur when
+                          working with an ACME server that enables 'authz reuse' (such as Let's
+                          Encrypt's production endpoint).
+                          If not set and 'identifier' is set, the state is assumed to be pending
+                          and a Challenge will be created.
+                        enum:
+                          - valid
+                          - ready
+                          - pending
+                          - processing
+                          - invalid
+                          - expired
+                          - errored
+                        type: string
+                      url:
+                        description: URL is the URL of the Authorization that must be completed
+                        type: string
+                      wildcard:
+                        description: |-
+                          Wildcard will be true if this authorization is for a wildcard DNS name.
+                          If this is true, the identifier will be the *non-wildcard* version of
+                          the DNS name.
+                          For example, if '*.example.com' is the DNS name being validated, this
+                          field will be 'true' and the 'identifier' field will be 'example.com'.
+                        type: boolean
+                    required:
+                      - url
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                certificate:
+                  description: |-
+                    Certificate is a copy of the PEM encoded certificate for this Order.
+                    This field will be populated after the order has been successfully
+                    finalized with the ACME server, and the order has transitioned to the
+                    'valid' state.
+                  format: byte
+                  type: string
+                failureTime:
+                  description: |-
+                    FailureTime stores the time that this order failed.
+                    This is used to influence garbage collection and back-off.
+                  format: date-time
+                  type: string
+                finalizeURL:
+                  description: |-
+                    FinalizeURL of the Order.
+                    This is used to obtain certificates for this order once it has been completed.
+                  type: string
+                reason:
+                  description: |-
+                    Reason optionally provides more information about a why the order is in
+                    the current state.
+                  type: string
+                state:
+                  description: |-
+                    State contains the current state of this Order resource.
+                    States 'success' and 'expired' are 'final'
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+                  type: string
+                url:
+                  description: |-
+                    URL of the Order.
+                    This will initially be empty when the resource is first created.
+                    The Order controller will populate this field when the Order is first processed.
+                    This field will be immutable after it is initially set.
+                  type: string
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: cert-manager/templates/crd-cert-manager.io_certificaterequests.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: "certificaterequests.cert-manager.io"
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: "cert-manager"
+    app.kubernetes.io/name: "cert-manager"
+    app.kubernetes.io/instance: "cert-manager"
+    app.kubernetes.io/component: "crds"
+    app.kubernetes.io/version: "v1.19.6"
 spec:
   group: cert-manager.io
   names:
+    categories:
+      - cert-manager
+    kind: CertificateRequest
+    listKind: CertificateRequestList
+    plural: certificaterequests
+    shortNames:
+      - cr
+      - crs
+    singular: certificaterequest
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type == "Approved")].status
+          name: Approved
+          type: string
+        - jsonPath: .status.conditions[?(@.type == "Denied")].status
+          name: Denied
+          type: string
+        - jsonPath: .status.conditions[?(@.type == "Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          type: string
+        - jsonPath: .spec.username
+          name: Requester
+          type: string
+        - jsonPath: .status.conditions[?(@.type == "Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            A CertificateRequest is used to request a signed certificate from one of the
+            configured issuers.
+
+            All fields within the CertificateRequest's `spec` are immutable after creation.
+            A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
+            condition and its `status.failureTime` field.
+
+            A CertificateRequest is a one-shot resource, meaning it represents a single
+            point in time request for a certificate and cannot be re-used.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Specification of the desired state of the CertificateRequest resource.
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                duration:
+                  description: |-
+                    Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
+                    issuer may choose to ignore the requested duration, just like any other
+                    requested attribute.
+                  type: string
+                extra:
+                  additionalProperties:
+                    items:
+                      type: string
+                    type: array
+                  description: |-
+                    Extra contains extra attributes of the user that created the CertificateRequest.
+                    Populated by the cert-manager webhook on creation and immutable.
+                  type: object
+                groups:
+                  description: |-
+                    Groups contains group membership of the user that created the CertificateRequest.
+                    Populated by the cert-manager webhook on creation and immutable.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                isCA:
+                  description: |-
+                    Requested basic constraints isCA value. Note that the issuer may choose
+                    to ignore the requested isCA value, just like any other requested attribute.
+
+                    NOTE: If the CSR in the `Request` field has a BasicConstraints extension,
+                    it must have the same isCA value as specified here.
+
+                    If true, this will automatically add the `cert sign` usage to the list
+                    of requested `usages`.
+                  type: boolean
+                issuerRef:
+                  description: |-
+                    Reference to the issuer responsible for issuing the certificate.
+                    If the issuer is namespace-scoped, it must be in the same namespace
+                    as the Certificate. If the issuer is cluster-scoped, it can be used
+                    from any namespace.
+
+                    The `name` field of the reference must always be specified.
+                  properties:
+                    group:
+                      description: |-
+                        Group of the issuer being referred to.
+                        Defaults to 'cert-manager.io'.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the issuer being referred to.
+                        Defaults to 'Issuer'.
+                      type: string
+                    name:
+                      description: Name of the issuer being referred to.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                request:
+                  description: |-
+                    The PEM-encoded X.509 certificate signing request to be submitted to the
+                    issuer for signing.
+
+                    If the CSR has a BasicConstraints extension, its isCA attribute must
+                    match the `isCA` value of this CertificateRequest.
+                    If the CSR has a KeyUsage extension, its key usages must match the
+                    key usages in the `usages` field of this CertificateRequest.
+                    If the CSR has a ExtKeyUsage extension, its extended key usages
+                    must match the extended key usages in the `usages` field of this
+                    CertificateRequest.
+                  format: byte
+                  type: string
+                uid:
+                  description: |-
+                    UID contains the uid of the user that created the CertificateRequest.
+                    Populated by the cert-manager webhook on creation and immutable.
+                  type: string
+                usages:
+                  description: |-
+                    Requested key usages and extended key usages.
+
+                    NOTE: If the CSR in the `Request` field has uses the KeyUsage or
+                    ExtKeyUsage extension, these extensions must have the same values
+                    as specified here without any additional values.
+
+                    If unset, defaults to `digital signature` and `key encipherment`.
+                  items:
+                    description: |-
+                      KeyUsage specifies valid usage contexts for keys.
+                      See:
+                      https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                      Valid KeyUsage values are as follows:
+                      "signing",
+                      "digital signature",
+                      "content commitment",
+                      "key encipherment",
+                      "key agreement",
+                      "data encipherment",
+                      "cert sign",
+                      "crl sign",
+                      "encipher only",
+                      "decipher only",
+                      "any",
+                      "server auth",
+                      "client auth",
+                      "code signing",
+                      "email protection",
+                      "s/mime",
+                      "ipsec end system",
+                      "ipsec tunnel",
+                      "ipsec user",
+                      "timestamping",
+                      "ocsp signing",
+                      "microsoft sgc",
+                      "netscape sgc"
+                    enum:
+                      - signing
+                      - digital signature
+                      - content commitment
+                      - key encipherment
+                      - key agreement
+                      - data encipherment
+                      - cert sign
+                      - crl sign
+                      - encipher only
+                      - decipher only
+                      - any
+                      - server auth
+                      - client auth
+                      - code signing
+                      - email protection
+                      - s/mime
+                      - ipsec end system
+                      - ipsec tunnel
+                      - ipsec user
+                      - timestamping
+                      - ocsp signing
+                      - microsoft sgc
+                      - netscape sgc
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                username:
+                  description: |-
+                    Username contains the name of the user that created the CertificateRequest.
+                    Populated by the cert-manager webhook on creation and immutable.
+                  type: string
+              required:
+                - issuerRef
+                - request
+              type: object
+            status:
+              description: |-
+                Status of the CertificateRequest.
+                This is set and managed automatically.
+                Read-only.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                ca:
+                  description: |-
+                    The PEM encoded X.509 certificate of the signer, also known as the CA
+                    (Certificate Authority).
+                    This is set on a best-effort basis by different issuers.
+                    If not set, the CA is assumed to be unknown/not available.
+                  format: byte
+                  type: string
+                certificate:
+                  description: |-
+                    The PEM encoded X.509 certificate resulting from the certificate
+                    signing request.
+                    If not set, the CertificateRequest has either not been completed or has
+                    failed. More information on failure can be found by checking the
+                    `conditions` field.
+                  format: byte
+                  type: string
+                conditions:
+                  description: |-
+                    List of status conditions to indicate the status of a CertificateRequest.
+                    Known condition types are `Ready`, `InvalidRequest`, `Approved` and `Denied`.
+                  items:
+                    description: CertificateRequestCondition contains condition information for a CertificateRequest.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the timestamp corresponding to the last status
+                          change of this condition.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          Message is a human readable description of the details of the last
+                          transition, complementing reason.
+                        type: string
+                      reason:
+                        description: |-
+                          Reason is a brief machine readable explanation for the condition's last
+                          transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          Type of the condition, known values are (`Ready`, `InvalidRequest`,
+                          `Approved`, `Denied`).
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                failureTime:
+                  description: |-
+                    FailureTime stores the time that this CertificateRequest failed. This is
+                    used to influence garbage collection and back-off.
+                  format: date-time
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: cert-manager/templates/crd-cert-manager.io_certificates.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: "certificates.cert-manager.io"
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: "cert-manager"
+    app.kubernetes.io/name: "cert-manager"
+    app.kubernetes.io/instance: "cert-manager"
+    app.kubernetes.io/component: "crds"
+    app.kubernetes.io/version: "v1.19.6"
+spec:
+  group: cert-manager.io
+  names:
+    categories:
+      - cert-manager
+    kind: Certificate
+    listKind: CertificateList
+    plural: certificates
+    shortNames:
+      - cert
+      - certs
+    singular: certificate
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type == "Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .spec.secretName
+          name: Secret
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          priority: 1
+          type: string
+        - jsonPath: .status.conditions[?(@.type == "Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            A Certificate resource should be created to ensure an up to date and signed
+            X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
+
+            The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Specification of the desired state of the Certificate resource.
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                additionalOutputFormats:
+                  description: |-
+                    Defines extra output formats of the private key and signed certificate chain
+                    to be written to this Certificate's target Secret.
+                  items:
+                    description: |-
+                      CertificateAdditionalOutputFormat defines an additional output format of a
+                      Certificate resource. These contain supplementary data formats of the signed
+                      certificate chain and paired private key.
+                    properties:
+                      type:
+                        description: |-
+                          Type is the name of the format type that should be written to the
+                          Certificate's target Secret.
+                        enum:
+                          - DER
+                          - CombinedPEM
+                        type: string
+                    required:
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                commonName:
+                  description: |-
+                    Requested common name X509 certificate subject attribute.
+                    More info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+                    NOTE: TLS clients will ignore this value when any subject alternative name is
+                    set (see https://tools.ietf.org/html/rfc6125#section-6.4.4).
+
+                    Should have a length of 64 characters or fewer to avoid generating invalid CSRs.
+                    Cannot be set if the `literalSubject` field is set.
+                  type: string
+                dnsNames:
+                  description: Requested DNS subject alternative names.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                duration:
+                  description: |-
+                    Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
+                    issuer may choose to ignore the requested duration, just like any other
+                    requested attribute.
+
+                    If unset, this defaults to 90 days.
+                    Minimum accepted duration is 1 hour.
+                    Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                  type: string
+                emailAddresses:
+                  description: Requested email subject alternative names.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                encodeUsagesInRequest:
+                  description: |-
+                    Whether the KeyUsage and ExtKeyUsage extensions should be set in the encoded CSR.
+
+                    This option defaults to true, and should only be disabled if the target
+                    issuer does not support CSRs with these X509 KeyUsage/ ExtKeyUsage extensions.
+                  type: boolean
+                ipAddresses:
+                  description: Requested IP address subject alternative names.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                isCA:
+                  description: |-
+                    Requested basic constraints isCA value.
+                    The isCA value is used to set the `isCA` field on the created CertificateRequest
+                    resources. Note that the issuer may choose to ignore the requested isCA value, just
+                    like any other requested attribute.
+
+                    If true, this will automatically add the `cert sign` usage to the list
+                    of requested `usages`.
+                  type: boolean
+                issuerRef:
+                  description: |-
+                    Reference to the issuer responsible for issuing the certificate.
+                    If the issuer is namespace-scoped, it must be in the same namespace
+                    as the Certificate. If the issuer is cluster-scoped, it can be used
+                    from any namespace.
+
+                    The `name` field of the reference must always be specified.
+                  properties:
+                    group:
+                      description: |-
+                        Group of the issuer being referred to.
+                        Defaults to 'cert-manager.io'.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the issuer being referred to.
+                        Defaults to 'Issuer'.
+                      type: string
+                    name:
+                      description: Name of the issuer being referred to.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                keystores:
+                  description: Additional keystore output formats to be stored in the Certificate's Secret.
+                  properties:
+                    jks:
+                      description: |-
+                        JKS configures options for storing a JKS keystore in the
+                        `spec.secretName` Secret resource.
+                      properties:
+                        alias:
+                          description: |-
+                            Alias specifies the alias of the key in the keystore, required by the JKS format.
+                            If not provided, the default alias `certificate` will be used.
+                          type: string
+                        create:
+                          description: |-
+                            Create enables JKS keystore creation for the Certificate.
+                            If true, a file named `keystore.jks` will be created in the target
+                            Secret resource, encrypted using the password stored in
+                            `passwordSecretRef` or `password`.
+                            The keystore file will be updated immediately.
+                            If the issuer provided a CA certificate, a file named `truststore.jks`
+                            will also be created in the target Secret resource, encrypted using the
+                            password stored in `passwordSecretRef`
+                            containing the issuing Certificate Authority
+                          type: boolean
+                        password:
+                          description: |-
+                            Password provides a literal password used to encrypt the JKS keystore.
+                            Mutually exclusive with passwordSecretRef.
+                            One of password or passwordSecretRef must provide a password with a non-zero length.
+                          type: string
+                        passwordSecretRef:
+                          description: |-
+                            PasswordSecretRef is a reference to a non-empty key in a Secret resource
+                            containing the password used to encrypt the JKS keystore.
+                            Mutually exclusive with password.
+                            One of password or passwordSecretRef must provide a password with a non-zero length.
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      required:
+                        - create
+                      type: object
+                    pkcs12:
+                      description: |-
+                        PKCS12 configures options for storing a PKCS12 keystore in the
+                        `spec.secretName` Secret resource.
+                      properties:
+                        create:
+                          description: |-
+                            Create enables PKCS12 keystore creation for the Certificate.
+                            If true, a file named `keystore.p12` will be created in the target
+                            Secret resource, encrypted using the password stored in
+                            `passwordSecretRef` or in `password`.
+                            The keystore file will be updated immediately.
+                            If the issuer provided a CA certificate, a file named `truststore.p12` will
+                            also be created in the target Secret resource, encrypted using the
+                            password stored in `passwordSecretRef` containing the issuing Certificate
+                            Authority
+                          type: boolean
+                        password:
+                          description: |-
+                            Password provides a literal password used to encrypt the PKCS#12 keystore.
+                            Mutually exclusive with passwordSecretRef.
+                            One of password or passwordSecretRef must provide a password with a non-zero length.
+                          type: string
+                        passwordSecretRef:
+                          description: |-
+                            PasswordSecretRef is a reference to a non-empty key in a Secret resource
+                            containing the password used to encrypt the PKCS#12 keystore.
+                            Mutually exclusive with password.
+                            One of password or passwordSecretRef must provide a password with a non-zero length.
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        profile:
+                          description: |-
+                            Profile specifies the key and certificate encryption algorithms and the HMAC algorithm
+                            used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
+
+                            If provided, allowed values are:
+                            `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+                            `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+                            `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
+                            (e.g., because of company policy). Please note that the security of the algorithm is not that important
+                            in reality, because the unencrypted certificate and private key are also stored in the Secret.
+                          enum:
+                            - LegacyRC2
+                            - LegacyDES
+                            - Modern2023
+                          type: string
+                      required:
+                        - create
+                      type: object
+                  type: object
+                literalSubject:
+                  description: |-
+                    Requested X.509 certificate subject, represented using the LDAP "String
+                    Representation of a Distinguished Name" [1].
+                    Important: the LDAP string format also specifies the order of the attributes
+                    in the subject, this is important when issuing certs for LDAP authentication.
+                    Example: `CN=foo,DC=corp,DC=example,DC=com`
+                    More info [1]: https://datatracker.ietf.org/doc/html/rfc4514
+                    More info: https://github.com/cert-manager/cert-manager/issues/3203
+                    More info: https://github.com/cert-manager/cert-manager/issues/4424
+
+                    Cannot be set if the `subject` or `commonName` field is set.
+                  type: string
+                nameConstraints:
+                  description: |-
+                    x.509 certificate NameConstraint extension which MUST NOT be used in a non-CA certificate.
+                    More Info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10
+
+                    This is an Alpha Feature and is only enabled with the
+                    `--feature-gates=NameConstraints=true` option set on both
+                    the controller and webhook components.
+                  properties:
+                    critical:
+                      description: if true then the name constraints are marked critical.
+                      type: boolean
+                    excluded:
+                      description: |-
+                        Excluded contains the constraints which must be disallowed. Any name matching a
+                        restriction in the excluded field is invalid regardless
+                        of information appearing in the permitted
+                      properties:
+                        dnsDomains:
+                          description: DNSDomains is a list of DNS domains that are permitted or excluded.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        emailAddresses:
+                          description: EmailAddresses is a list of Email Addresses that are permitted or excluded.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ipRanges:
+                          description: |-
+                            IPRanges is a list of IP Ranges that are permitted or excluded.
+                            This should be a valid CIDR notation.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        uriDomains:
+                          description: URIDomains is a list of URI domains that are permitted or excluded.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    permitted:
+                      description: Permitted contains the constraints in which the names must be located.
+                      properties:
+                        dnsDomains:
+                          description: DNSDomains is a list of DNS domains that are permitted or excluded.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        emailAddresses:
+                          description: EmailAddresses is a list of Email Addresses that are permitted or excluded.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ipRanges:
+                          description: |-
+                            IPRanges is a list of IP Ranges that are permitted or excluded.
+                            This should be a valid CIDR notation.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        uriDomains:
+                          description: URIDomains is a list of URI domains that are permitted or excluded.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                  type: object
+                otherNames:
+                  description: |-
+                    `otherNames` is an escape hatch for SAN that allows any type. We currently restrict the support to string like otherNames, cf RFC 5280 p 37
+                    Any UTF8 String valued otherName can be passed with by setting the keys oid: x.x.x.x and UTF8Value: somevalue for `otherName`.
+                    Most commonly this would be UPN set with oid: 1.3.6.1.4.1.311.20.2.3
+                    You should ensure that any OID passed is valid for the UTF8String type as we do not explicitly validate this.
+                  items:
+                    properties:
+                      oid:
+                        description: |-
+                          OID is the object identifier for the otherName SAN.
+                          The object identifier must be expressed as a dotted string, for
+                          example, "1.2.840.113556.1.4.221".
+                        type: string
+                      utf8Value:
+                        description: |-
+                          utf8Value is the string value of the otherName SAN.
+                          The utf8Value accepts any valid UTF8 string to set as value for the otherName SAN.
+                        type: string
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                privateKey:
+                  description: |-
+                    Private key options. These include the key algorithm and size, the used
+                    encoding and the rotation policy.
+                  properties:
+                    algorithm:
+                      description: |-
+                        Algorithm is the private key algorithm of the corresponding private key
+                        for this certificate.
+
+                        If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                        If `algorithm` is specified and `size` is not provided,
+                        key size of 2048 will be used for `RSA` key algorithm and
+                        key size of 256 will be used for `ECDSA` key algorithm.
+                        key size is ignored when using the `Ed25519` key algorithm.
+                      enum:
+                        - RSA
+                        - ECDSA
+                        - Ed25519
+                      type: string
+                    encoding:
+                      description: |-
+                        The private key cryptography standards (PKCS) encoding for this
+                        certificate's private key to be encoded in.
+
+                        If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                        and PKCS#8, respectively.
+                        Defaults to `PKCS1` if not specified.
+                      enum:
+                        - PKCS1
+                        - PKCS8
+                      type: string
+                    rotationPolicy:
+                      description: |-
+                        RotationPolicy controls how private keys should be regenerated when a
+                        re-issuance is being processed.
+
+                        If set to `Never`, a private key will only be generated if one does not
+                        already exist in the target `spec.secretName`. If one does exist but it
+                        does not have the correct algorithm or size, a warning will be raised
+                        to await user intervention.
+                        If set to `Always`, a private key matching the specified requirements
+                        will be generated whenever a re-issuance occurs.
+                        Default is `Always`.
+                        The default was changed from `Never` to `Always` in cert-manager >=v1.18.0.
+                        The new default can be disabled by setting the
+                        `--feature-gates=DefaultPrivateKeyRotationPolicyAlways=false` option on
+                        the controller component.
+                      enum:
+                        - Never
+                        - Always
+                      type: string
+                    size:
+                      description: |-
+                        Size is the key bit size of the corresponding private key for this certificate.
+
+                        If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                        and will default to `2048` if not specified.
+                        If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                        and will default to `256` if not specified.
+                        If `algorithm` is set to `Ed25519`, Size is ignored.
+                        No other values are allowed.
+                      type: integer
+                  type: object
+                renewBefore:
+                  description: |-
+                    How long before the currently issued certificate's expiry cert-manager should
+                    renew the certificate. For example, if a certificate is valid for 60 minutes,
+                    and `renewBefore=10m`, cert-manager will begin to attempt to renew the certificate
+                    50 minutes after it was issued (i.e. when there are 10 minutes remaining until
+                    the certificate is no longer valid).
+
+                    NOTE: The actual lifetime of the issued certificate is used to determine the
+                    renewal time. If an issuer returns a certificate with a different lifetime than
+                    the one requested, cert-manager will use the lifetime of the issued certificate.
+
+                    If unset, this defaults to 1/3 of the issued certificate's lifetime.
+                    Minimum accepted value is 5 minutes.
+                    Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                    Cannot be set if the `renewBeforePercentage` field is set.
+                  type: string
+                renewBeforePercentage:
+                  description: |-
+                    `renewBeforePercentage` is like `renewBefore`, except it is a relative percentage
+                    rather than an absolute duration. For example, if a certificate is valid for 60
+                    minutes, and  `renewBeforePercentage=25`, cert-manager will begin to attempt to
+                    renew the certificate 45 minutes after it was issued (i.e. when there are 15
+                    minutes (25%) remaining until the certificate is no longer valid).
+
+                    NOTE: The actual lifetime of the issued certificate is used to determine the
+                    renewal time. If an issuer returns a certificate with a different lifetime than
+                    the one requested, cert-manager will use the lifetime of the issued certificate.
+
+                    Value must be an integer in the range (0,100). The minimum effective
+                    `renewBefore` derived from the `renewBeforePercentage` and `duration` fields is 5
+                    minutes.
+                    Cannot be set if the `renewBefore` field is set.
+                  format: int32
+                  type: integer
+                revisionHistoryLimit:
+                  description: |-
+                    The maximum number of CertificateRequest revisions that are maintained in
+                    the Certificate's history. Each revision represents a single `CertificateRequest`
+                    created by this Certificate, either when it was created, renewed, or Spec
+                    was changed. Revisions will be removed by oldest first if the number of
+                    revisions exceeds this number.
+
+                    If set, revisionHistoryLimit must be a value of `1` or greater.
+                    Default value is `1`.
+                  format: int32
+                  type: integer
+                secretName:
+                  description: |-
+                    Name of the Secret resource that will be automatically created and
+                    managed by this Certificate resource. It will be populated with a
+                    private key and certificate, signed by the denoted issuer. The Secret
+                    resource lives in the same namespace as the Certificate resource.
+                  type: string
+                secretTemplate:
+                  description: |-
+                    Defines annotations and labels to be copied to the Certificate's Secret.
+                    Labels and annotations on the Secret will be changed as they appear on the
+                    SecretTemplate when added or removed. SecretTemplate annotations are added
+                    in conjunction with, and cannot overwrite, the base set of annotations
+                    cert-manager sets on the Certificate's Secret.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations is a key value map to be copied to the target Kubernetes Secret.
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels is a key value map to be copied to the target Kubernetes Secret.
+                      type: object
+                  type: object
+                signatureAlgorithm:
+                  description: |-
+                    Signature algorithm to use.
+                    Allowed values for RSA keys: SHA256WithRSA, SHA384WithRSA, SHA512WithRSA.
+                    Allowed values for ECDSA keys: ECDSAWithSHA256, ECDSAWithSHA384, ECDSAWithSHA512.
+                    Allowed values for Ed25519 keys: PureEd25519.
+                  enum:
+                    - SHA256WithRSA
+                    - SHA384WithRSA
+                    - SHA512WithRSA
+                    - ECDSAWithSHA256
+                    - ECDSAWithSHA384
+                    - ECDSAWithSHA512
+                    - PureEd25519
+                  type: string
+                subject:
+                  description: |-
+                    Requested set of X509 certificate subject attributes.
+                    More info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+
+                    The common name attribute is specified separately in the `commonName` field.
+                    Cannot be set if the `literalSubject` field is set.
+                  properties:
+                    countries:
+                      description: Countries to be used on the Certificate.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    localities:
+                      description: Cities to be used on the Certificate.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    organizationalUnits:
+                      description: Organizational Units to be used on the Certificate.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    organizations:
+                      description: Organizations to be used on the Certificate.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    postalCodes:
+                      description: Postal codes to be used on the Certificate.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    provinces:
+                      description: State/Provinces to be used on the Certificate.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    serialNumber:
+                      description: Serial number to be used on the Certificate.
+                      type: string
+                    streetAddresses:
+                      description: Street addresses to be used on the Certificate.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                uris:
+                  description: Requested URI subject alternative names.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                usages:
+                  description: |-
+                    Requested key usages and extended key usages.
+                    These usages are used to set the `usages` field on the created CertificateRequest
+                    resources. If `encodeUsagesInRequest` is unset or set to `true`, the usages
+                    will additionally be encoded in the `request` field which contains the CSR blob.
+
+                    If unset, defaults to `digital signature` and `key encipherment`.
+                  items:
+                    description: |-
+                      KeyUsage specifies valid usage contexts for keys.
+                      See:
+                      https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                      Valid KeyUsage values are as follows:
+                      "signing",
+                      "digital signature",
+                      "content commitment",
+                      "key encipherment",
+                      "key agreement",
+                      "data encipherment",
+                      "cert sign",
+                      "crl sign",
+                      "encipher only",
+                      "decipher only",
+                      "any",
+                      "server auth",
+                      "client auth",
+                      "code signing",
+                      "email protection",
+                      "s/mime",
+                      "ipsec end system",
+                      "ipsec tunnel",
+                      "ipsec user",
+                      "timestamping",
+                      "ocsp signing",
+                      "microsoft sgc",
+                      "netscape sgc"
+                    enum:
+                      - signing
+                      - digital signature
+                      - content commitment
+                      - key encipherment
+                      - key agreement
+                      - data encipherment
+                      - cert sign
+                      - crl sign
+                      - encipher only
+                      - decipher only
+                      - any
+                      - server auth
+                      - client auth
+                      - code signing
+                      - email protection
+                      - s/mime
+                      - ipsec end system
+                      - ipsec tunnel
+                      - ipsec user
+                      - timestamping
+                      - ocsp signing
+                      - microsoft sgc
+                      - netscape sgc
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+              required:
+                - issuerRef
+                - secretName
+              type: object
+            status:
+              description: |-
+                Status of the Certificate.
+                This is set and managed automatically.
+                Read-only.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              properties:
+                conditions:
+                  description: |-
+                    List of status conditions to indicate the status of certificates.
+                    Known condition types are `Ready` and `Issuing`.
+                  items:
+                    description: CertificateCondition contains condition information for a Certificate.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the timestamp corresponding to the last status
+                          change of this condition.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          Message is a human readable description of the details of the last
+                          transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          If set, this represents the .metadata.generation that the condition was
+                          set based upon.
+                          For instance, if .metadata.generation is currently 12, but the
+                          .status.condition[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the Certificate.
+                        format: int64
+                        type: integer
+                      reason:
+                        description: |-
+                          Reason is a brief machine readable explanation for the condition's last
+                          transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: Type of the condition, known values are (`Ready`, `Issuing`).
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                failedIssuanceAttempts:
+                  description: |-
+                    The number of continuous failed issuance attempts up till now. This
+                    field gets removed (if set) on a successful issuance and gets set to
+                    1 if unset and an issuance has failed. If an issuance has failed, the
+                    delay till the next issuance will be calculated using formula
+                    time.Hour * 2 ^ (failedIssuanceAttempts - 1).
+                  type: integer
+                lastFailureTime:
+                  description: |-
+                    LastFailureTime is set only if the latest issuance for this
+                    Certificate failed and contains the time of the failure. If an
+                    issuance has failed, the delay till the next issuance will be
+                    calculated using formula time.Hour * 2 ^ (failedIssuanceAttempts -
+                    1). If the latest issuance has succeeded this field will be unset.
+                  format: date-time
+                  type: string
+                nextPrivateKeySecretName:
+                  description: |-
+                    The name of the Secret resource containing the private key to be used
+                    for the next certificate iteration.
+                    The keymanager controller will automatically set this field if the
+                    `Issuing` condition is set to `True`.
+                    It will automatically unset this field when the Issuing condition is
+                    not set or False.
+                  type: string
+                notAfter:
+                  description: |-
+                    The expiration time of the certificate stored in the secret named
+                    by this resource in `spec.secretName`.
+                  format: date-time
+                  type: string
+                notBefore:
+                  description: |-
+                    The time after which the certificate stored in the secret named
+                    by this resource in `spec.secretName` is valid.
+                  format: date-time
+                  type: string
+                renewalTime:
+                  description: |-
+                    RenewalTime is the time at which the certificate will be next
+                    renewed.
+                    If not set, no upcoming renewal is scheduled.
+                  format: date-time
+                  type: string
+                revision:
+                  description: |-
+                    The current 'revision' of the certificate as issued.
+
+                    When a CertificateRequest resource is created, it will have the
+                    `cert-manager.io/certificate-revision` set to one greater than the
+                    current value of this field.
+
+                    Upon issuance, this field will be set to the value of the annotation
+                    on the CertificateRequest resource used to issue the certificate.
+
+                    Persisting the value on the CertificateRequest resource allows the
+                    certificates controller to know whether a request is part of an old
+                    issuance or if it is part of the ongoing revision's issuance by
+                    checking if the revision value in the annotation is greater than this
+                    field.
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: "clusterissuers.cert-manager.io"
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: "cert-manager"
+    app.kubernetes.io/name: "cert-manager"
+    app.kubernetes.io/instance: "cert-manager"
+    app.kubernetes.io/component: "crds"
+    app.kubernetes.io/version: "v1.19.6"
+spec:
+  group: cert-manager.io
+  names:
+    categories:
+      - cert-manager
     kind: ClusterIssuer
     listKind: ClusterIssuerList
     plural: clusterissuers
     shortNames:
       - ciss
     singular: clusterissuer
-    categories:
-      - cert-manager
   scope: Cluster
   versions:
-    - name: v1
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type == "Ready")].status
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+        - jsonPath: .status.conditions[?(@.type == "Ready")].message
           name: Status
           priority: 1
           type: string
-        - jsonPath: .metadata.creationTimestamp
-          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
+      name: v1
       schema:
         openAPIV3Schema:
           description: |-
@@ -4393,9 +4757,6 @@ spec:
             It is similar to an Issuer, however it is cluster-scoped and therefore can
             be referenced by resources that exist in *any* namespace, not just the same
             namespace as the referent.
-          type: object
-          required:
-            - spec
           properties:
             apiVersion:
               description: |-
@@ -4416,16 +4777,11 @@ spec:
               type: object
             spec:
               description: Desired state of the ClusterIssuer resource.
-              type: object
               properties:
                 acme:
                   description: |-
                     ACME configures this issuer to communicate with a RFC8555 (ACME) server
                     to obtain signed x509 certificates.
-                  type: object
-                  required:
-                    - privateKeySecretRef
-                    - server
                   properties:
                     caBundle:
                       description: |-
@@ -4435,8 +4791,8 @@ spec:
                         kinds of security vulnerabilities.
                         If CABundle and SkipTLSVerify are unset, the system certificate bundle inside
                         the container is used to validate the TLS connection.
-                      type: string
                       format: byte
+                      type: string
                     disableAccountKeyGeneration:
                       description: |-
                         Enables or disables generating a new ACME account key.
@@ -4468,21 +4824,17 @@ spec:
                         server.
                         If set, upon registration cert-manager will attempt to associate the given
                         external account credentials with the registered ACME account.
-                      type: object
-                      required:
-                        - keyID
-                        - keySecretRef
                       properties:
                         keyAlgorithm:
                           description: |-
                             Deprecated: keyAlgorithm field exists for historical compatibility
                             reasons and should not be used. The algorithm is now hardcoded to HS256
                             in golang/x/crypto/acme.
-                          type: string
                           enum:
                             - HS256
                             - HS384
                             - HS512
+                          type: string
                         keyID:
                           description: keyID is the ID of the CA key that the External Account is bound to.
                           type: string
@@ -4495,9 +4847,6 @@ spec:
                             the External Account Binding keyID above.
                             The secret key stored in the Secret **must** be un-padded, base64 URL
                             encoded data.
-                          type: object
-                          required:
-                            - name
                           properties:
                             key:
                               description: |-
@@ -4510,6 +4859,13 @@ spec:
                                 Name of the resource being referred to.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
+                          required:
+                            - name
+                          type: object
+                      required:
+                        - keyID
+                        - keySecretRef
+                      type: object
                     preferredChain:
                       description: |-
                         PreferredChain is the chain to use if the ACME server outputs multiple.
@@ -4520,8 +4876,8 @@ spec:
                         This value picks the first certificate bundle in the combined set of
                         ACME default and alternative chains that has a root-most certificate with
                         this value as its issuer's commonname.
-                      type: string
                       maxLength: 64
+                      type: string
                     privateKeySecretRef:
                       description: |-
                         PrivateKey is the name of a Kubernetes Secret resource that will be used to
@@ -4529,9 +4885,6 @@ spec:
                         Optionally, a `key` may be specified to select a specific entry within
                         the named Secret resource.
                         If `key` is not specified, a default of `tls.key` will be used.
-                      type: object
-                      required:
-                        - name
                       properties:
                         key:
                           description: |-
@@ -4544,6 +4897,9 @@ spec:
                             Name of the resource being referred to.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                           type: string
+                      required:
+                        - name
+                      type: object
                     profile:
                       description: |-
                         Profile allows requesting a certificate profile from the ACME server.
@@ -4575,36 +4931,26 @@ spec:
                         Solver configurations must be provided in order to obtain certificates
                         from an ACME server.
                         For more information, see: https://cert-manager.io/docs/configuration/acme/
-                      type: array
                       items:
                         description: |-
                           An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of.
                           A selector may be provided to use different solving strategies for different DNS names.
                           Only one of HTTP01 or DNS01 must be provided.
-                        type: object
                         properties:
                           dns01:
                             description: |-
                               Configures cert-manager to attempt to complete authorizations by
                               performing the DNS01 challenge flow.
-                            type: object
                             properties:
                               acmeDNS:
                                 description: |-
                                   Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage
                                   DNS01 challenge records.
-                                type: object
-                                required:
-                                  - accountSecretRef
-                                  - host
                                 properties:
                                   accountSecretRef:
                                     description: |-
                                       A reference to a specific 'key' within a Secret resource.
                                       In some instances, `key` is a required field.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -4617,24 +4963,22 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
                                   host:
                                     type: string
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                type: object
                               akamai:
                                 description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
-                                type: object
-                                required:
-                                  - accessTokenSecretRef
-                                  - clientSecretSecretRef
-                                  - clientTokenSecretRef
-                                  - serviceConsumerDomain
                                 properties:
                                   accessTokenSecretRef:
                                     description: |-
                                       A reference to a specific 'key' within a Secret resource.
                                       In some instances, `key` is a required field.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -4647,13 +4991,13 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
                                   clientSecretSecretRef:
                                     description: |-
                                       A reference to a specific 'key' within a Secret resource.
                                       In some instances, `key` is a required field.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -4666,13 +5010,13 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
                                   clientTokenSecretRef:
                                     description: |-
                                       A reference to a specific 'key' within a Secret resource.
                                       In some instances, `key` is a required field.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -4685,14 +5029,19 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
                                   serviceConsumerDomain:
                                     type: string
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                type: object
                               azureDNS:
                                 description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
-                                type: object
-                                required:
-                                  - resourceGroupName
-                                  - subscriptionID
                                 properties:
                                   clientID:
                                     description: |-
@@ -4705,9 +5054,6 @@ spec:
                                       Auth: Azure Service Principal:
                                       A reference to a Secret containing the password associated with the Service Principal.
                                       If set, ClientID and TenantID must also be set.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -4720,14 +5066,17 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
                                   environment:
                                     description: name of the Azure environment (default AzurePublicCloud)
-                                    type: string
                                     enum:
                                       - AzurePublicCloud
                                       - AzureChinaCloud
                                       - AzureGermanCloud
                                       - AzureUSGovernmentCloud
+                                    type: string
                                   hostedZoneName:
                                     description: name of the DNS zone that should be used
                                     type: string
@@ -4736,7 +5085,6 @@ spec:
                                       Auth: Azure Workload Identity or Azure Managed Service Identity:
                                       Settings to enable Azure Workload Identity or Azure Managed Service Identity
                                       If set, ClientID, ClientSecret and TenantID must not be set.
-                                    type: object
                                     properties:
                                       clientID:
                                         description: client ID of the managed identity, cannot be used at the same time as resourceID
@@ -4749,6 +5097,7 @@ spec:
                                       tenantID:
                                         description: tenant ID of the managed identity, cannot be used at the same time as resourceID
                                         type: string
+                                    type: object
                                   resourceGroupName:
                                     description: resource group the DNS zone is located in
                                     type: string
@@ -4761,11 +5110,12 @@ spec:
                                       The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
                                       If set, ClientID and ClientSecret must also be set.
                                     type: string
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                type: object
                               cloudDNS:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
-                                type: object
-                                required:
-                                  - project
                                 properties:
                                   hostedZoneName:
                                     description: |-
@@ -4779,9 +5129,6 @@ spec:
                                     description: |-
                                       A reference to a specific 'key' within a Secret resource.
                                       In some instances, `key` is a required field.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -4794,18 +5141,20 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - project
+                                type: object
                               cloudflare:
                                 description: Use the Cloudflare API to manage DNS01 challenge records.
-                                type: object
                                 properties:
                                   apiKeySecretRef:
                                     description: |-
                                       API key to use to authenticate with Cloudflare.
                                       Note: using an API token to authenticate is now the recommended method
                                       as it allows greater control of permissions.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -4818,11 +5167,11 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
                                   apiTokenSecretRef:
                                     description: API token used to authenticate with Cloudflare.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -4835,30 +5184,28 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
                                   email:
                                     description: Email of the account, only required when using API key based authentication.
                                     type: string
+                                type: object
                               cnameStrategy:
                                 description: |-
                                   CNAMEStrategy configures how the DNS01 provider should handle CNAME
                                   records when found in DNS zones.
-                                type: string
                                 enum:
                                   - None
                                   - Follow
+                                type: string
                               digitalocean:
                                 description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
-                                type: object
-                                required:
-                                  - tokenSecretRef
                                 properties:
                                   tokenSecretRef:
                                     description: |-
                                       A reference to a specific 'key' within a Secret resource.
                                       In some instances, `key` is a required field.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -4871,20 +5218,29 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - tokenSecretRef
+                                type: object
                               rfc2136:
                                 description: |-
                                   Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/)
                                   to manage DNS01 challenge records.
-                                type: object
-                                required:
-                                  - nameserver
                                 properties:
                                   nameserver:
                                     description: |-
                                       The IP address or hostname of an authoritative DNS server supporting
                                       RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                      enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                      enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                       This field is required.
+                                    type: string
+                                  protocol:
+                                    description: Protocol to use for dynamic DNS update queries. Valid values are (case-sensitive) ``TCP`` and ``UDP``; ``UDP`` (default).
+                                    enum:
+                                      - TCP
+                                      - UDP
                                     type: string
                                   tsigAlgorithm:
                                     description: |-
@@ -4902,9 +5258,6 @@ spec:
                                     description: |-
                                       The name of the secret containing the TSIG value.
                                       If ``tsigKeyName`` is defined, this field is required.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -4917,9 +5270,14 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - nameserver
+                                type: object
                               route53:
                                 description: Use the AWS Route53 API to manage DNS01 challenge records.
-                                type: object
                                 properties:
                                   accessKeyID:
                                     description: |-
@@ -4937,9 +5295,6 @@ spec:
                                       If neither the Access Key nor Key ID are set, we fall-back to using env
                                       vars, shared credentials file or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -4952,28 +5307,22 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
                                   auth:
                                     description: Auth configures how cert-manager authenticates.
-                                    type: object
-                                    required:
-                                      - kubernetes
                                     properties:
                                       kubernetes:
                                         description: |-
                                           Kubernetes authenticates with Route53 using AssumeRoleWithWebIdentity
                                           by passing a bound ServiceAccount token.
-                                        type: object
-                                        required:
-                                          - serviceAccountRef
                                         properties:
                                           serviceAccountRef:
                                             description: |-
                                               A reference to a service account that will be used to request a bound
                                               token (also known as "projected token"). To use this field, you must
                                               configure an RBAC rule to let cert-manager request a token.
-                                            type: object
-                                            required:
-                                              - name
                                             properties:
                                               audiences:
                                                 description: |-
@@ -4981,12 +5330,22 @@ spec:
                                                   token passed to AWS. The default token consisting of the issuer's namespace
                                                   and name is always included.
                                                   If unset the audience defaults to `sts.amazonaws.com`.
-                                                type: array
                                                 items:
                                                   type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               name:
                                                 description: Name of the ServiceAccount used to request a token.
                                                 type: string
+                                            required:
+                                              - name
+                                            type: object
+                                        required:
+                                          - serviceAccountRef
+                                        type: object
+                                    required:
+                                      - kubernetes
+                                    type: object
                                   hostedZoneID:
                                     description: If set, the provider will manage only this zone in Route53 and will not do a lookup using the route53:ListHostedZonesByName api call.
                                     type: string
@@ -5026,9 +5385,6 @@ spec:
                                       If neither the Access Key nor Key ID are set, we fall-back to using env
                                       vars, shared credentials file or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -5041,14 +5397,14 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
+                                type: object
                               webhook:
                                 description: |-
                                   Configure an external webhook based DNS01 challenge solver to manage
                                   DNS01 challenge records.
-                                type: object
-                                required:
-                                  - groupName
-                                  - solverName
                                 properties:
                                   config:
                                     description: |-
@@ -5074,13 +5430,17 @@ spec:
                                       implementation.
                                       This will typically be the name of the provider, e.g., 'cloudflare'.
                                     type: string
+                                required:
+                                  - groupName
+                                  - solverName
+                                type: object
+                            type: object
                           http01:
                             description: |-
                               Configures cert-manager to attempt to complete authorizations by
                               performing the HTTP01 challenge flow.
                               It is not possible to obtain certificates for wildcard domain names
                               (e.g., `*.example.com`) using the HTTP01 challenge mechanism.
-                            type: object
                             properties:
                               gatewayHTTPRoute:
                                 description: |-
@@ -5088,22 +5448,20 @@ spec:
                                   in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will
                                   create HTTPRoutes with the specified labels in the same namespace as the challenge.
                                   This solver is experimental, and fields / behaviour may change in the future.
-                                type: object
                                 properties:
                                   labels:
+                                    additionalProperties:
+                                      type: string
                                     description: |-
                                       Custom labels that will be applied to HTTPRoutes created by cert-manager
                                       while solving HTTP-01 challenges.
                                     type: object
-                                    additionalProperties:
-                                      type: string
                                   parentRefs:
                                     description: |-
                                       When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.
                                       cert-manager needs to know which parentRefs should be used when creating
                                       the HTTPRoute. Usually, the parentRef references a Gateway. See:
                                       https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways
-                                    type: array
                                     items:
                                       description: |-
                                         ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -5118,11 +5476,9 @@ spec:
 
                                         The API object must be valid in the cluster; the Group and Kind must
                                         be registered in the cluster for this reference to be valid.
-                                      type: object
-                                      required:
-                                        - name
                                       properties:
                                         group:
+                                          default: gateway.networking.k8s.io
                                           description: |-
                                             Group is the group of the referent.
                                             When unspecified, "gateway.networking.k8s.io" is inferred.
@@ -5130,11 +5486,11 @@ spec:
                                             Group must be explicitly set to "" (empty string).
 
                                             Support: Core
-                                          type: string
-                                          default: gateway.networking.k8s.io
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
                                         kind:
+                                          default: Gateway
                                           description: |-
                                             Kind is kind of the referent.
 
@@ -5144,19 +5500,18 @@ spec:
                                             * Service (Mesh conformance profile, ClusterIP Services only)
 
                                             Support for other resources is Implementation-Specific.
-                                          type: string
-                                          default: Gateway
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
                                         name:
                                           description: |-
                                             Name is the name of the referent.
 
                                             Support: Core
-                                          type: string
                                           maxLength: 253
                                           minLength: 1
+                                          type: string
                                         namespace:
                                           description: |-
                                             Namespace is the namespace of the referent. When unspecified, this refers
@@ -5181,10 +5536,10 @@ spec:
                                             </gateway:experimental:description>
 
                                             Support: Core
-                                          type: string
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
                                         port:
                                           description: |-
                                             Port is the network port this Route targets. It can be interpreted
@@ -5217,10 +5572,10 @@ spec:
                                             the Route MUST be considered detached from the Gateway.
 
                                             Support: Extended
-                                          type: integer
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
+                                          type: integer
                                         sectionName:
                                           description: |-
                                             SectionName is the name of a section within the target resource. In the
@@ -5247,15 +5602,19 @@ spec:
                                             Route MUST be considered detached from the Gateway.
 
                                             Support: Core
-                                          type: string
                                           maxLength: 253
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   podTemplate:
                                     description: |-
                                       Optional pod template used to configure the ACME challenge solver pods
                                       used for HTTP01 challenges.
-                                    type: object
                                     properties:
                                       metadata:
                                         description: |-
@@ -5263,32 +5622,29 @@ spec:
                                           Only the 'labels' and 'annotations' fields may be set.
                                           If labels or annotations overlap with in-built values, the values here
                                           will override the in-built values.
-                                        type: object
                                         properties:
                                           annotations:
+                                            additionalProperties:
+                                              type: string
                                             description: Annotations that should be added to the created ACME HTTP01 solver pods.
                                             type: object
+                                          labels:
                                             additionalProperties:
                                               type: string
-                                          labels:
                                             description: Labels that should be added to the created ACME HTTP01 solver pods.
                                             type: object
-                                            additionalProperties:
-                                              type: string
+                                        type: object
                                       spec:
                                         description: |-
                                           PodSpec defines overrides for the HTTP01 challenge solver pod.
                                           Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
                                           All other fields will be ignored.
-                                        type: object
                                         properties:
                                           affinity:
                                             description: If specified, the pod's scheduling constraints
-                                            type: object
                                             properties:
                                               nodeAffinity:
                                                 description: Describes node affinity scheduling rules for the pod.
-                                                type: object
                                                 properties:
                                                   preferredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -5301,31 +5657,20 @@ spec:
                                                       compute a sum by iterating through the elements of this field and adding
                                                       "weight" to the sum if the node matches the corresponding matchExpressions; the
                                                       node(s) with the highest sum are the most preferred.
-                                                    type: array
                                                     items:
                                                       description: |-
                                                         An empty preferred scheduling term matches all objects with implicit weight 0
                                                         (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
-                                                      type: object
-                                                      required:
-                                                        - preference
-                                                        - weight
                                                       properties:
                                                         preference:
                                                           description: A node selector term, associated with the corresponding weight.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: A list of node selector requirements by node's labels.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A node selector requirement is a selector that contains values, a key, and an operator
                                                                   that relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: The label key that the selector applies to.
@@ -5342,22 +5687,22 @@ spec:
                                                                       the values array must be empty. If the operator is Gt or Lt, the values
                                                                       array must have a single element, which will be interpreted as an integer.
                                                                       This array is replaced during a strategic merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchFields:
                                                               description: A list of node selector requirements by node's fields.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A node selector requirement is a selector that contains values, a key, and an operator
                                                                   that relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: The label key that the selector applies to.
@@ -5374,16 +5719,27 @@ spec:
                                                                       the values array must be empty. If the operator is Gt or Lt, the values
                                                                       array must have a single element, which will be interpreted as an integer.
                                                                       This array is replaced during a strategic merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         weight:
                                                           description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
-                                                          type: integer
                                                           format: int32
+                                                          type: integer
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   requiredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -5392,31 +5748,21 @@ spec:
                                                       If the affinity requirements specified by this field cease to be met
                                                       at some point during pod execution (e.g. due to an update), the system
                                                       may or may not try to eventually evict the pod from its node.
-                                                    type: object
-                                                    required:
-                                                      - nodeSelectorTerms
                                                     properties:
                                                       nodeSelectorTerms:
                                                         description: Required. A list of node selector terms. The terms are ORed.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A null or empty node selector term matches no objects. The requirements of
                                                             them are ANDed.
                                                             The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: A list of node selector requirements by node's labels.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A node selector requirement is a selector that contains values, a key, and an operator
                                                                   that relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: The label key that the selector applies to.
@@ -5433,22 +5779,22 @@ spec:
                                                                       the values array must be empty. If the operator is Gt or Lt, the values
                                                                       array must have a single element, which will be interpreted as an integer.
                                                                       This array is replaced during a strategic merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchFields:
                                                               description: A list of node selector requirements by node's fields.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A node selector requirement is a selector that contains values, a key, and an operator
                                                                   that relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: The label key that the selector applies to.
@@ -5465,17 +5811,27 @@ spec:
                                                                       the values array must be empty. If the operator is Gt or Lt, the values
                                                                       array must have a single element, which will be interpreted as an integer.
                                                                       This array is replaced during a strategic merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    type: object
                                                     x-kubernetes-map-type: atomic
+                                                type: object
                                               podAffinity:
                                                 description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
-                                                type: object
                                                 properties:
                                                   preferredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -5488,37 +5844,23 @@ spec:
                                                       compute a sum by iterating through the elements of this field and adding
                                                       "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                       node(s) with the highest sum are the most preferred.
-                                                    type: array
                                                     items:
                                                       description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                                                      type: object
-                                                      required:
-                                                        - podAffinityTerm
-                                                        - weight
                                                       properties:
                                                         podAffinityTerm:
                                                           description: Required. A pod affinity term, associated with the corresponding weight.
-                                                          type: object
-                                                          required:
-                                                            - topologyKey
                                                           properties:
                                                             labelSelector:
                                                               description: |-
                                                                 A label query over a set of resources, in this case pods.
                                                                 If it's null, this PodAffinityTerm matches with no Pods.
-                                                              type: object
                                                               properties:
                                                                 matchExpressions:
                                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                                  type: array
                                                                   items:
                                                                     description: |-
                                                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                                                       relates the key and values.
-                                                                    type: object
-                                                                    required:
-                                                                      - key
-                                                                      - operator
                                                                     properties:
                                                                       key:
                                                                         description: key is the label key that the selector applies to.
@@ -5534,19 +5876,25 @@ spec:
                                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                           the values array must be empty. This array is replaced during a strategic
                                                                           merge patch.
-                                                                        type: array
                                                                         items:
                                                                           type: string
+                                                                        type: array
                                                                         x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
                                                                 matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
                                                                   description: |-
                                                                     matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                     map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                     operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                                   type: object
-                                                                  additionalProperties:
-                                                                    type: string
+                                                              type: object
                                                               x-kubernetes-map-type: atomic
                                                             matchLabelKeys:
                                                               description: |-
@@ -5558,10 +5906,9 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             mismatchLabelKeys:
                                                               description: |-
@@ -5573,10 +5920,9 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             namespaceSelector:
                                                               description: |-
@@ -5585,19 +5931,13 @@ spec:
                                                                 and the ones listed in the namespaces field.
                                                                 null selector and null or empty namespaces list means "this pod's namespace".
                                                                 An empty selector ({}) matches all namespaces.
-                                                              type: object
                                                               properties:
                                                                 matchExpressions:
                                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                                  type: array
                                                                   items:
                                                                     description: |-
                                                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                                                       relates the key and values.
-                                                                    type: object
-                                                                    required:
-                                                                      - key
-                                                                      - operator
                                                                     properties:
                                                                       key:
                                                                         description: key is the label key that the selector applies to.
@@ -5613,19 +5953,25 @@ spec:
                                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                           the values array must be empty. This array is replaced during a strategic
                                                                           merge patch.
-                                                                        type: array
                                                                         items:
                                                                           type: string
+                                                                        type: array
                                                                         x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
                                                                 matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
                                                                   description: |-
                                                                     matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                     map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                     operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                                   type: object
-                                                                  additionalProperties:
-                                                                    type: string
+                                                              type: object
                                                               x-kubernetes-map-type: atomic
                                                             namespaces:
                                                               description: |-
@@ -5633,9 +5979,9 @@ spec:
                                                                 The term is applied to the union of the namespaces listed in this field
                                                                 and the ones selected by namespaceSelector.
                                                                 null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             topologyKey:
                                                               description: |-
@@ -5645,12 +5991,20 @@ spec:
                                                                 selected pods is running.
                                                                 Empty topologyKey is not allowed.
                                                               type: string
+                                                          required:
+                                                            - topologyKey
+                                                          type: object
                                                         weight:
                                                           description: |-
                                                             weight associated with matching the corresponding podAffinityTerm,
                                                             in the range 1-100.
-                                                          type: integer
                                                           format: int32
+                                                          type: integer
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   requiredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -5661,7 +6015,6 @@ spec:
                                                       system may or may not try to eventually evict the pod from its node.
                                                       When there are multiple elements, the lists of nodes corresponding to each
                                                       podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                                                    type: array
                                                     items:
                                                       description: |-
                                                         Defines a set of pods (namely those matching the labelSelector
@@ -5670,27 +6023,18 @@ spec:
                                                         where co-located is defined as running on a node whose value of
                                                         the label with key <topologyKey> matches that of any node on which
                                                         a pod of the set of pods is running
-                                                      type: object
-                                                      required:
-                                                        - topologyKey
                                                       properties:
                                                         labelSelector:
                                                           description: |-
                                                             A label query over a set of resources, in this case pods.
                                                             If it's null, this PodAffinityTerm matches with no Pods.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                                   relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: key is the label key that the selector applies to.
@@ -5706,19 +6050,25 @@ spec:
                                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                       the values array must be empty. This array is replaced during a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: |-
                                                                 matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                 map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                 operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         matchLabelKeys:
                                                           description: |-
@@ -5730,10 +6080,9 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         mismatchLabelKeys:
                                                           description: |-
@@ -5745,10 +6094,9 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         namespaceSelector:
                                                           description: |-
@@ -5757,19 +6105,13 @@ spec:
                                                             and the ones listed in the namespaces field.
                                                             null selector and null or empty namespaces list means "this pod's namespace".
                                                             An empty selector ({}) matches all namespaces.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                                   relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: key is the label key that the selector applies to.
@@ -5785,19 +6127,25 @@ spec:
                                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                       the values array must be empty. This array is replaced during a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: |-
                                                                 matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                 map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                 operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         namespaces:
                                                           description: |-
@@ -5805,9 +6153,9 @@ spec:
                                                             The term is applied to the union of the namespaces listed in this field
                                                             and the ones selected by namespaceSelector.
                                                             null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         topologyKey:
                                                           description: |-
@@ -5817,10 +6165,14 @@ spec:
                                                             selected pods is running.
                                                             Empty topologyKey is not allowed.
                                                           type: string
+                                                      required:
+                                                        - topologyKey
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
+                                                type: object
                                               podAntiAffinity:
                                                 description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
-                                                type: object
                                                 properties:
                                                   preferredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -5830,40 +6182,26 @@ spec:
                                                       most preferred is the one with the greatest sum of weights, i.e.
                                                       for each node that meets all of the scheduling requirements (resource
                                                       request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                                      compute a sum by iterating through the elements of this field and adding
-                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      compute a sum by iterating through the elements of this field and subtracting
+                                                      "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                       node(s) with the highest sum are the most preferred.
-                                                    type: array
                                                     items:
                                                       description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                                                      type: object
-                                                      required:
-                                                        - podAffinityTerm
-                                                        - weight
                                                       properties:
                                                         podAffinityTerm:
                                                           description: Required. A pod affinity term, associated with the corresponding weight.
-                                                          type: object
-                                                          required:
-                                                            - topologyKey
                                                           properties:
                                                             labelSelector:
                                                               description: |-
                                                                 A label query over a set of resources, in this case pods.
                                                                 If it's null, this PodAffinityTerm matches with no Pods.
-                                                              type: object
                                                               properties:
                                                                 matchExpressions:
                                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                                  type: array
                                                                   items:
                                                                     description: |-
                                                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                                                       relates the key and values.
-                                                                    type: object
-                                                                    required:
-                                                                      - key
-                                                                      - operator
                                                                     properties:
                                                                       key:
                                                                         description: key is the label key that the selector applies to.
@@ -5879,19 +6217,25 @@ spec:
                                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                           the values array must be empty. This array is replaced during a strategic
                                                                           merge patch.
-                                                                        type: array
                                                                         items:
                                                                           type: string
+                                                                        type: array
                                                                         x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
                                                                 matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
                                                                   description: |-
                                                                     matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                     map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                     operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                                   type: object
-                                                                  additionalProperties:
-                                                                    type: string
+                                                              type: object
                                                               x-kubernetes-map-type: atomic
                                                             matchLabelKeys:
                                                               description: |-
@@ -5903,10 +6247,9 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             mismatchLabelKeys:
                                                               description: |-
@@ -5918,10 +6261,9 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             namespaceSelector:
                                                               description: |-
@@ -5930,19 +6272,13 @@ spec:
                                                                 and the ones listed in the namespaces field.
                                                                 null selector and null or empty namespaces list means "this pod's namespace".
                                                                 An empty selector ({}) matches all namespaces.
-                                                              type: object
                                                               properties:
                                                                 matchExpressions:
                                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                                  type: array
                                                                   items:
                                                                     description: |-
                                                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                                                       relates the key and values.
-                                                                    type: object
-                                                                    required:
-                                                                      - key
-                                                                      - operator
                                                                     properties:
                                                                       key:
                                                                         description: key is the label key that the selector applies to.
@@ -5958,19 +6294,25 @@ spec:
                                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                           the values array must be empty. This array is replaced during a strategic
                                                                           merge patch.
-                                                                        type: array
                                                                         items:
                                                                           type: string
+                                                                        type: array
                                                                         x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
                                                                 matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
                                                                   description: |-
                                                                     matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                     map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                     operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                                   type: object
-                                                                  additionalProperties:
-                                                                    type: string
+                                                              type: object
                                                               x-kubernetes-map-type: atomic
                                                             namespaces:
                                                               description: |-
@@ -5978,9 +6320,9 @@ spec:
                                                                 The term is applied to the union of the namespaces listed in this field
                                                                 and the ones selected by namespaceSelector.
                                                                 null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             topologyKey:
                                                               description: |-
@@ -5990,12 +6332,20 @@ spec:
                                                                 selected pods is running.
                                                                 Empty topologyKey is not allowed.
                                                               type: string
+                                                          required:
+                                                            - topologyKey
+                                                          type: object
                                                         weight:
                                                           description: |-
                                                             weight associated with matching the corresponding podAffinityTerm,
                                                             in the range 1-100.
-                                                          type: integer
                                                           format: int32
+                                                          type: integer
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   requiredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -6006,7 +6356,6 @@ spec:
                                                       system may or may not try to eventually evict the pod from its node.
                                                       When there are multiple elements, the lists of nodes corresponding to each
                                                       podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                                                    type: array
                                                     items:
                                                       description: |-
                                                         Defines a set of pods (namely those matching the labelSelector
@@ -6015,27 +6364,18 @@ spec:
                                                         where co-located is defined as running on a node whose value of
                                                         the label with key <topologyKey> matches that of any node on which
                                                         a pod of the set of pods is running
-                                                      type: object
-                                                      required:
-                                                        - topologyKey
                                                       properties:
                                                         labelSelector:
                                                           description: |-
                                                             A label query over a set of resources, in this case pods.
                                                             If it's null, this PodAffinityTerm matches with no Pods.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                                   relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: key is the label key that the selector applies to.
@@ -6051,19 +6391,25 @@ spec:
                                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                       the values array must be empty. This array is replaced during a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: |-
                                                                 matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                 map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                 operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         matchLabelKeys:
                                                           description: |-
@@ -6075,10 +6421,9 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         mismatchLabelKeys:
                                                           description: |-
@@ -6090,10 +6435,9 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         namespaceSelector:
                                                           description: |-
@@ -6102,19 +6446,13 @@ spec:
                                                             and the ones listed in the namespaces field.
                                                             null selector and null or empty namespaces list means "this pod's namespace".
                                                             An empty selector ({}) matches all namespaces.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                                   relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: key is the label key that the selector applies to.
@@ -6130,19 +6468,25 @@ spec:
                                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                       the values array must be empty. This array is replaced during a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: |-
                                                                 matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                 map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                 operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         namespaces:
                                                           description: |-
@@ -6150,9 +6494,9 @@ spec:
                                                             The term is applied to the union of the namespaces listed in this field
                                                             and the ones selected by namespaceSelector.
                                                             null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         topologyKey:
                                                           description: |-
@@ -6162,17 +6506,22 @@ spec:
                                                             selected pods is running.
                                                             Empty topologyKey is not allowed.
                                                           type: string
+                                                      required:
+                                                        - topologyKey
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
+                                                type: object
+                                            type: object
                                           imagePullSecrets:
                                             description: If specified, the pod's imagePullSecrets
-                                            type: array
                                             items:
                                               description: |-
                                                 LocalObjectReference contains enough information to let you locate the
                                                 referenced object inside the same namespace.
-                                              type: object
                                               properties:
                                                 name:
+                                                  default: ""
                                                   description: |-
                                                     Name of the referent.
                                                     This field is effectively required, but due to backwards compatibility is
@@ -6180,22 +6529,59 @@ spec:
                                                     almost certainly wrong.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                                   type: string
-                                                  default: ""
+                                              type: object
                                               x-kubernetes-map-type: atomic
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
                                           nodeSelector:
+                                            additionalProperties:
+                                              type: string
                                             description: |-
                                               NodeSelector is a selector which must be true for the pod to fit on a node.
                                               Selector which must match a node's labels for the pod to be scheduled on that node.
                                               More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                                             type: object
-                                            additionalProperties:
-                                              type: string
                                           priorityClassName:
                                             description: If specified, the pod's priorityClassName.
                                             type: string
+                                          resources:
+                                            description: |-
+                                              If specified, the pod's resource requirements.
+                                              These values override the global resource configuration flags.
+                                              Note that when only specifying resource limits, ensure they are greater than or equal
+                                              to the corresponding global resource requests configured via controller flags
+                                              (--acme-http01-solver-resource-request-cpu, --acme-http01-solver-resource-request-memory).
+                                              Kubernetes will reject pod creation if limits are lower than requests, causing challenge failures.
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Requests describes the minimum amount of compute resources required.
+                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                  otherwise to the global values configured via controller flags. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                            type: object
                                           securityContext:
                                             description: If specified, the pod's security context
-                                            type: object
                                             properties:
                                               fsGroup:
                                                 description: |-
@@ -6209,8 +6595,8 @@ spec:
 
                                                   If unset, the Kubelet will not modify the ownership and permissions of any volume.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: integer
                                                 format: int64
+                                                type: integer
                                               fsGroupChangePolicy:
                                                 description: |-
                                                   fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
@@ -6229,8 +6615,8 @@ spec:
                                                   PodSecurityContext, the value specified in SecurityContext takes precedence
                                                   for that container.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: integer
                                                 format: int64
+                                                type: integer
                                               runAsNonRoot:
                                                 description: |-
                                                   Indicates that the container must run as a non-root user.
@@ -6248,8 +6634,8 @@ spec:
                                                   PodSecurityContext, the value specified in SecurityContext takes precedence
                                                   for that container.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: integer
                                                 format: int64
+                                                type: integer
                                               seLinuxOptions:
                                                 description: |-
                                                   The SELinux context to be applied to all containers.
@@ -6258,7 +6644,6 @@ spec:
                                                   both SecurityContext and PodSecurityContext, the value specified in SecurityContext
                                                   takes precedence for that container.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: object
                                                 properties:
                                                   level:
                                                     description: Level is SELinux level label that applies to the container.
@@ -6272,13 +6657,11 @@ spec:
                                                   user:
                                                     description: User is a SELinux user label that applies to the container.
                                                     type: string
+                                                type: object
                                               seccompProfile:
                                                 description: |-
                                                   The seccomp options to use by the containers in this pod.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: object
-                                                required:
-                                                  - type
                                                 properties:
                                                   localhostProfile:
                                                     description: |-
@@ -6296,6 +6679,9 @@ spec:
                                                       RuntimeDefault - the container runtime default profile should be used.
                                                       Unconfined - no profile should be applied.
                                                     type: string
+                                                required:
+                                                  - type
+                                                type: object
                                               supplementalGroups:
                                                 description: |-
                                                   A list of groups applied to the first process run in each container, in addition
@@ -6305,22 +6691,18 @@ spec:
                                                   defined in the container image for the uid of the container process are still effective,
                                                   even if they are not included in this list.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: array
                                                 items:
-                                                  type: integer
                                                   format: int64
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               sysctls:
                                                 description: |-
                                                   Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
                                                   sysctls (by the container runtime) might fail to launch.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: array
                                                 items:
                                                   description: Sysctl defines a kernel parameter to be set
-                                                  type: object
-                                                  required:
-                                                    - name
-                                                    - value
                                                   properties:
                                                     name:
                                                       description: Name of a property to set
@@ -6328,17 +6710,22 @@ spec:
                                                     value:
                                                       description: Value of a property to set
                                                       type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
                                           serviceAccountName:
                                             description: If specified, the pod's service account
                                             type: string
                                           tolerations:
                                             description: If specified, the pod's tolerations.
-                                            type: array
                                             items:
                                               description: |-
                                                 The pod this Toleration is attached to tolerates any taint that matches
                                                 the triple <key,value,effect> using the matching operator <operator>.
-                                              type: object
                                               properties:
                                                 effect:
                                                   description: |-
@@ -6363,25 +6750,30 @@ spec:
                                                     of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                                                     it is not set, which means tolerate the taint forever (do not evict). Zero and
                                                     negative values will be treated as 0 (evict immediately) by the system.
-                                                  type: integer
                                                   format: int64
+                                                  type: integer
                                                 value:
                                                   description: |-
                                                     Value is the taint value the toleration matches to.
                                                     If the operator is Exists, the value should be empty, otherwise just a regular string.
                                                   type: string
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                    type: object
                                   serviceType:
                                     description: |-
                                       Optional service type for Kubernetes solver service. Supported values
                                       are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
+                                type: object
                               ingress:
                                 description: |-
                                   The ingress based HTTP01 challenge solver will solve challenges by
                                   creating or modifying Ingress resources in order to route requests for
                                   '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are
                                   provisioned by cert-manager for each Challenge to be completed.
-                                type: object
                                 properties:
                                   class:
                                     description: |-
@@ -6401,7 +6793,6 @@ spec:
                                     description: |-
                                       Optional ingress template used to configure the ACME challenge solver
                                       ingress used for HTTP01 challenges.
-                                    type: object
                                     properties:
                                       metadata:
                                         description: |-
@@ -6409,18 +6800,19 @@ spec:
                                           Only the 'labels' and 'annotations' fields may be set.
                                           If labels or annotations overlap with in-built values, the values here
                                           will override the in-built values.
-                                        type: object
                                         properties:
                                           annotations:
+                                            additionalProperties:
+                                              type: string
                                             description: Annotations that should be added to the created ACME HTTP01 solver ingress.
                                             type: object
+                                          labels:
                                             additionalProperties:
                                               type: string
-                                          labels:
                                             description: Labels that should be added to the created ACME HTTP01 solver ingress.
                                             type: object
-                                            additionalProperties:
-                                              type: string
+                                        type: object
+                                    type: object
                                   name:
                                     description: |-
                                       The name of the ingress resource that should have ACME challenge solving
@@ -6434,7 +6826,6 @@ spec:
                                     description: |-
                                       Optional pod template used to configure the ACME challenge solver pods
                                       used for HTTP01 challenges.
-                                    type: object
                                     properties:
                                       metadata:
                                         description: |-
@@ -6442,32 +6833,29 @@ spec:
                                           Only the 'labels' and 'annotations' fields may be set.
                                           If labels or annotations overlap with in-built values, the values here
                                           will override the in-built values.
-                                        type: object
                                         properties:
                                           annotations:
+                                            additionalProperties:
+                                              type: string
                                             description: Annotations that should be added to the created ACME HTTP01 solver pods.
                                             type: object
+                                          labels:
                                             additionalProperties:
                                               type: string
-                                          labels:
                                             description: Labels that should be added to the created ACME HTTP01 solver pods.
                                             type: object
-                                            additionalProperties:
-                                              type: string
+                                        type: object
                                       spec:
                                         description: |-
                                           PodSpec defines overrides for the HTTP01 challenge solver pod.
                                           Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
                                           All other fields will be ignored.
-                                        type: object
                                         properties:
                                           affinity:
                                             description: If specified, the pod's scheduling constraints
-                                            type: object
                                             properties:
                                               nodeAffinity:
                                                 description: Describes node affinity scheduling rules for the pod.
-                                                type: object
                                                 properties:
                                                   preferredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -6480,31 +6868,20 @@ spec:
                                                       compute a sum by iterating through the elements of this field and adding
                                                       "weight" to the sum if the node matches the corresponding matchExpressions; the
                                                       node(s) with the highest sum are the most preferred.
-                                                    type: array
                                                     items:
                                                       description: |-
                                                         An empty preferred scheduling term matches all objects with implicit weight 0
                                                         (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
-                                                      type: object
-                                                      required:
-                                                        - preference
-                                                        - weight
                                                       properties:
                                                         preference:
                                                           description: A node selector term, associated with the corresponding weight.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: A list of node selector requirements by node's labels.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A node selector requirement is a selector that contains values, a key, and an operator
                                                                   that relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: The label key that the selector applies to.
@@ -6521,22 +6898,22 @@ spec:
                                                                       the values array must be empty. If the operator is Gt or Lt, the values
                                                                       array must have a single element, which will be interpreted as an integer.
                                                                       This array is replaced during a strategic merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchFields:
                                                               description: A list of node selector requirements by node's fields.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A node selector requirement is a selector that contains values, a key, and an operator
                                                                   that relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: The label key that the selector applies to.
@@ -6553,16 +6930,27 @@ spec:
                                                                       the values array must be empty. If the operator is Gt or Lt, the values
                                                                       array must have a single element, which will be interpreted as an integer.
                                                                       This array is replaced during a strategic merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         weight:
                                                           description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
-                                                          type: integer
                                                           format: int32
+                                                          type: integer
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   requiredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -6571,31 +6959,21 @@ spec:
                                                       If the affinity requirements specified by this field cease to be met
                                                       at some point during pod execution (e.g. due to an update), the system
                                                       may or may not try to eventually evict the pod from its node.
-                                                    type: object
-                                                    required:
-                                                      - nodeSelectorTerms
                                                     properties:
                                                       nodeSelectorTerms:
                                                         description: Required. A list of node selector terms. The terms are ORed.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A null or empty node selector term matches no objects. The requirements of
                                                             them are ANDed.
                                                             The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: A list of node selector requirements by node's labels.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A node selector requirement is a selector that contains values, a key, and an operator
                                                                   that relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: The label key that the selector applies to.
@@ -6612,22 +6990,22 @@ spec:
                                                                       the values array must be empty. If the operator is Gt or Lt, the values
                                                                       array must have a single element, which will be interpreted as an integer.
                                                                       This array is replaced during a strategic merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchFields:
                                                               description: A list of node selector requirements by node's fields.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A node selector requirement is a selector that contains values, a key, and an operator
                                                                   that relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: The label key that the selector applies to.
@@ -6644,17 +7022,27 @@ spec:
                                                                       the values array must be empty. If the operator is Gt or Lt, the values
                                                                       array must have a single element, which will be interpreted as an integer.
                                                                       This array is replaced during a strategic merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    type: object
                                                     x-kubernetes-map-type: atomic
+                                                type: object
                                               podAffinity:
                                                 description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
-                                                type: object
                                                 properties:
                                                   preferredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -6667,37 +7055,23 @@ spec:
                                                       compute a sum by iterating through the elements of this field and adding
                                                       "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                       node(s) with the highest sum are the most preferred.
-                                                    type: array
                                                     items:
                                                       description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                                                      type: object
-                                                      required:
-                                                        - podAffinityTerm
-                                                        - weight
                                                       properties:
                                                         podAffinityTerm:
                                                           description: Required. A pod affinity term, associated with the corresponding weight.
-                                                          type: object
-                                                          required:
-                                                            - topologyKey
                                                           properties:
                                                             labelSelector:
                                                               description: |-
                                                                 A label query over a set of resources, in this case pods.
                                                                 If it's null, this PodAffinityTerm matches with no Pods.
-                                                              type: object
                                                               properties:
                                                                 matchExpressions:
                                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                                  type: array
                                                                   items:
                                                                     description: |-
                                                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                                                       relates the key and values.
-                                                                    type: object
-                                                                    required:
-                                                                      - key
-                                                                      - operator
                                                                     properties:
                                                                       key:
                                                                         description: key is the label key that the selector applies to.
@@ -6713,19 +7087,25 @@ spec:
                                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                           the values array must be empty. This array is replaced during a strategic
                                                                           merge patch.
-                                                                        type: array
                                                                         items:
                                                                           type: string
+                                                                        type: array
                                                                         x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
                                                                 matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
                                                                   description: |-
                                                                     matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                     map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                     operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                                   type: object
-                                                                  additionalProperties:
-                                                                    type: string
+                                                              type: object
                                                               x-kubernetes-map-type: atomic
                                                             matchLabelKeys:
                                                               description: |-
@@ -6737,10 +7117,9 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             mismatchLabelKeys:
                                                               description: |-
@@ -6752,10 +7131,9 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             namespaceSelector:
                                                               description: |-
@@ -6764,19 +7142,13 @@ spec:
                                                                 and the ones listed in the namespaces field.
                                                                 null selector and null or empty namespaces list means "this pod's namespace".
                                                                 An empty selector ({}) matches all namespaces.
-                                                              type: object
                                                               properties:
                                                                 matchExpressions:
                                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                                  type: array
                                                                   items:
                                                                     description: |-
                                                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                                                       relates the key and values.
-                                                                    type: object
-                                                                    required:
-                                                                      - key
-                                                                      - operator
                                                                     properties:
                                                                       key:
                                                                         description: key is the label key that the selector applies to.
@@ -6792,19 +7164,25 @@ spec:
                                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                           the values array must be empty. This array is replaced during a strategic
                                                                           merge patch.
-                                                                        type: array
                                                                         items:
                                                                           type: string
+                                                                        type: array
                                                                         x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
                                                                 matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
                                                                   description: |-
                                                                     matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                     map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                     operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                                   type: object
-                                                                  additionalProperties:
-                                                                    type: string
+                                                              type: object
                                                               x-kubernetes-map-type: atomic
                                                             namespaces:
                                                               description: |-
@@ -6812,9 +7190,9 @@ spec:
                                                                 The term is applied to the union of the namespaces listed in this field
                                                                 and the ones selected by namespaceSelector.
                                                                 null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             topologyKey:
                                                               description: |-
@@ -6824,12 +7202,20 @@ spec:
                                                                 selected pods is running.
                                                                 Empty topologyKey is not allowed.
                                                               type: string
+                                                          required:
+                                                            - topologyKey
+                                                          type: object
                                                         weight:
                                                           description: |-
                                                             weight associated with matching the corresponding podAffinityTerm,
                                                             in the range 1-100.
-                                                          type: integer
                                                           format: int32
+                                                          type: integer
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   requiredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -6840,7 +7226,6 @@ spec:
                                                       system may or may not try to eventually evict the pod from its node.
                                                       When there are multiple elements, the lists of nodes corresponding to each
                                                       podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                                                    type: array
                                                     items:
                                                       description: |-
                                                         Defines a set of pods (namely those matching the labelSelector
@@ -6849,27 +7234,18 @@ spec:
                                                         where co-located is defined as running on a node whose value of
                                                         the label with key <topologyKey> matches that of any node on which
                                                         a pod of the set of pods is running
-                                                      type: object
-                                                      required:
-                                                        - topologyKey
                                                       properties:
                                                         labelSelector:
                                                           description: |-
                                                             A label query over a set of resources, in this case pods.
                                                             If it's null, this PodAffinityTerm matches with no Pods.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                                   relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: key is the label key that the selector applies to.
@@ -6885,19 +7261,25 @@ spec:
                                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                       the values array must be empty. This array is replaced during a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: |-
                                                                 matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                 map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                 operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         matchLabelKeys:
                                                           description: |-
@@ -6909,10 +7291,9 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         mismatchLabelKeys:
                                                           description: |-
@@ -6924,10 +7305,9 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         namespaceSelector:
                                                           description: |-
@@ -6936,19 +7316,13 @@ spec:
                                                             and the ones listed in the namespaces field.
                                                             null selector and null or empty namespaces list means "this pod's namespace".
                                                             An empty selector ({}) matches all namespaces.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                                   relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: key is the label key that the selector applies to.
@@ -6964,19 +7338,25 @@ spec:
                                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                       the values array must be empty. This array is replaced during a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: |-
                                                                 matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                 map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                 operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         namespaces:
                                                           description: |-
@@ -6984,9 +7364,9 @@ spec:
                                                             The term is applied to the union of the namespaces listed in this field
                                                             and the ones selected by namespaceSelector.
                                                             null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         topologyKey:
                                                           description: |-
@@ -6996,10 +7376,14 @@ spec:
                                                             selected pods is running.
                                                             Empty topologyKey is not allowed.
                                                           type: string
+                                                      required:
+                                                        - topologyKey
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
+                                                type: object
                                               podAntiAffinity:
                                                 description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
-                                                type: object
                                                 properties:
                                                   preferredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -7009,40 +7393,26 @@ spec:
                                                       most preferred is the one with the greatest sum of weights, i.e.
                                                       for each node that meets all of the scheduling requirements (resource
                                                       request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                                      compute a sum by iterating through the elements of this field and adding
-                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      compute a sum by iterating through the elements of this field and subtracting
+                                                      "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                       node(s) with the highest sum are the most preferred.
-                                                    type: array
                                                     items:
                                                       description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                                                      type: object
-                                                      required:
-                                                        - podAffinityTerm
-                                                        - weight
                                                       properties:
                                                         podAffinityTerm:
                                                           description: Required. A pod affinity term, associated with the corresponding weight.
-                                                          type: object
-                                                          required:
-                                                            - topologyKey
                                                           properties:
                                                             labelSelector:
                                                               description: |-
                                                                 A label query over a set of resources, in this case pods.
                                                                 If it's null, this PodAffinityTerm matches with no Pods.
-                                                              type: object
                                                               properties:
                                                                 matchExpressions:
                                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                                  type: array
                                                                   items:
                                                                     description: |-
                                                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                                                       relates the key and values.
-                                                                    type: object
-                                                                    required:
-                                                                      - key
-                                                                      - operator
                                                                     properties:
                                                                       key:
                                                                         description: key is the label key that the selector applies to.
@@ -7058,19 +7428,25 @@ spec:
                                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                           the values array must be empty. This array is replaced during a strategic
                                                                           merge patch.
-                                                                        type: array
                                                                         items:
                                                                           type: string
+                                                                        type: array
                                                                         x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
                                                                 matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
                                                                   description: |-
                                                                     matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                     map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                     operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                                   type: object
-                                                                  additionalProperties:
-                                                                    type: string
+                                                              type: object
                                                               x-kubernetes-map-type: atomic
                                                             matchLabelKeys:
                                                               description: |-
@@ -7082,10 +7458,9 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             mismatchLabelKeys:
                                                               description: |-
@@ -7097,10 +7472,9 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             namespaceSelector:
                                                               description: |-
@@ -7109,19 +7483,13 @@ spec:
                                                                 and the ones listed in the namespaces field.
                                                                 null selector and null or empty namespaces list means "this pod's namespace".
                                                                 An empty selector ({}) matches all namespaces.
-                                                              type: object
                                                               properties:
                                                                 matchExpressions:
                                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                                  type: array
                                                                   items:
                                                                     description: |-
                                                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                                                       relates the key and values.
-                                                                    type: object
-                                                                    required:
-                                                                      - key
-                                                                      - operator
                                                                     properties:
                                                                       key:
                                                                         description: key is the label key that the selector applies to.
@@ -7137,19 +7505,25 @@ spec:
                                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                           the values array must be empty. This array is replaced during a strategic
                                                                           merge patch.
-                                                                        type: array
                                                                         items:
                                                                           type: string
+                                                                        type: array
                                                                         x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
                                                                 matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
                                                                   description: |-
                                                                     matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                     map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                     operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                                   type: object
-                                                                  additionalProperties:
-                                                                    type: string
+                                                              type: object
                                                               x-kubernetes-map-type: atomic
                                                             namespaces:
                                                               description: |-
@@ -7157,9 +7531,9 @@ spec:
                                                                 The term is applied to the union of the namespaces listed in this field
                                                                 and the ones selected by namespaceSelector.
                                                                 null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             topologyKey:
                                                               description: |-
@@ -7169,12 +7543,20 @@ spec:
                                                                 selected pods is running.
                                                                 Empty topologyKey is not allowed.
                                                               type: string
+                                                          required:
+                                                            - topologyKey
+                                                          type: object
                                                         weight:
                                                           description: |-
                                                             weight associated with matching the corresponding podAffinityTerm,
                                                             in the range 1-100.
-                                                          type: integer
                                                           format: int32
+                                                          type: integer
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   requiredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -7185,7 +7567,6 @@ spec:
                                                       system may or may not try to eventually evict the pod from its node.
                                                       When there are multiple elements, the lists of nodes corresponding to each
                                                       podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                                                    type: array
                                                     items:
                                                       description: |-
                                                         Defines a set of pods (namely those matching the labelSelector
@@ -7194,27 +7575,18 @@ spec:
                                                         where co-located is defined as running on a node whose value of
                                                         the label with key <topologyKey> matches that of any node on which
                                                         a pod of the set of pods is running
-                                                      type: object
-                                                      required:
-                                                        - topologyKey
                                                       properties:
                                                         labelSelector:
                                                           description: |-
                                                             A label query over a set of resources, in this case pods.
                                                             If it's null, this PodAffinityTerm matches with no Pods.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                                   relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: key is the label key that the selector applies to.
@@ -7230,19 +7602,25 @@ spec:
                                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                       the values array must be empty. This array is replaced during a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: |-
                                                                 matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                 map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                 operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         matchLabelKeys:
                                                           description: |-
@@ -7254,10 +7632,9 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         mismatchLabelKeys:
                                                           description: |-
@@ -7269,10 +7646,9 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         namespaceSelector:
                                                           description: |-
@@ -7281,19 +7657,13 @@ spec:
                                                             and the ones listed in the namespaces field.
                                                             null selector and null or empty namespaces list means "this pod's namespace".
                                                             An empty selector ({}) matches all namespaces.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                                   relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: key is the label key that the selector applies to.
@@ -7309,19 +7679,25 @@ spec:
                                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                       the values array must be empty. This array is replaced during a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: |-
                                                                 matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                 map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                 operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         namespaces:
                                                           description: |-
@@ -7329,9 +7705,9 @@ spec:
                                                             The term is applied to the union of the namespaces listed in this field
                                                             and the ones selected by namespaceSelector.
                                                             null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         topologyKey:
                                                           description: |-
@@ -7341,17 +7717,22 @@ spec:
                                                             selected pods is running.
                                                             Empty topologyKey is not allowed.
                                                           type: string
+                                                      required:
+                                                        - topologyKey
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
+                                                type: object
+                                            type: object
                                           imagePullSecrets:
                                             description: If specified, the pod's imagePullSecrets
-                                            type: array
                                             items:
                                               description: |-
                                                 LocalObjectReference contains enough information to let you locate the
                                                 referenced object inside the same namespace.
-                                              type: object
                                               properties:
                                                 name:
+                                                  default: ""
                                                   description: |-
                                                     Name of the referent.
                                                     This field is effectively required, but due to backwards compatibility is
@@ -7359,22 +7740,59 @@ spec:
                                                     almost certainly wrong.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                                   type: string
-                                                  default: ""
+                                              type: object
                                               x-kubernetes-map-type: atomic
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
                                           nodeSelector:
+                                            additionalProperties:
+                                              type: string
                                             description: |-
                                               NodeSelector is a selector which must be true for the pod to fit on a node.
                                               Selector which must match a node's labels for the pod to be scheduled on that node.
                                               More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                                             type: object
-                                            additionalProperties:
-                                              type: string
                                           priorityClassName:
                                             description: If specified, the pod's priorityClassName.
                                             type: string
+                                          resources:
+                                            description: |-
+                                              If specified, the pod's resource requirements.
+                                              These values override the global resource configuration flags.
+                                              Note that when only specifying resource limits, ensure they are greater than or equal
+                                              to the corresponding global resource requests configured via controller flags
+                                              (--acme-http01-solver-resource-request-cpu, --acme-http01-solver-resource-request-memory).
+                                              Kubernetes will reject pod creation if limits are lower than requests, causing challenge failures.
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Requests describes the minimum amount of compute resources required.
+                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                  otherwise to the global values configured via controller flags. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                            type: object
                                           securityContext:
                                             description: If specified, the pod's security context
-                                            type: object
                                             properties:
                                               fsGroup:
                                                 description: |-
@@ -7388,8 +7806,8 @@ spec:
 
                                                   If unset, the Kubelet will not modify the ownership and permissions of any volume.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: integer
                                                 format: int64
+                                                type: integer
                                               fsGroupChangePolicy:
                                                 description: |-
                                                   fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
@@ -7408,8 +7826,8 @@ spec:
                                                   PodSecurityContext, the value specified in SecurityContext takes precedence
                                                   for that container.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: integer
                                                 format: int64
+                                                type: integer
                                               runAsNonRoot:
                                                 description: |-
                                                   Indicates that the container must run as a non-root user.
@@ -7427,8 +7845,8 @@ spec:
                                                   PodSecurityContext, the value specified in SecurityContext takes precedence
                                                   for that container.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: integer
                                                 format: int64
+                                                type: integer
                                               seLinuxOptions:
                                                 description: |-
                                                   The SELinux context to be applied to all containers.
@@ -7437,7 +7855,6 @@ spec:
                                                   both SecurityContext and PodSecurityContext, the value specified in SecurityContext
                                                   takes precedence for that container.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: object
                                                 properties:
                                                   level:
                                                     description: Level is SELinux level label that applies to the container.
@@ -7451,13 +7868,11 @@ spec:
                                                   user:
                                                     description: User is a SELinux user label that applies to the container.
                                                     type: string
+                                                type: object
                                               seccompProfile:
                                                 description: |-
                                                   The seccomp options to use by the containers in this pod.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: object
-                                                required:
-                                                  - type
                                                 properties:
                                                   localhostProfile:
                                                     description: |-
@@ -7475,6 +7890,9 @@ spec:
                                                       RuntimeDefault - the container runtime default profile should be used.
                                                       Unconfined - no profile should be applied.
                                                     type: string
+                                                required:
+                                                  - type
+                                                type: object
                                               supplementalGroups:
                                                 description: |-
                                                   A list of groups applied to the first process run in each container, in addition
@@ -7484,22 +7902,18 @@ spec:
                                                   defined in the container image for the uid of the container process are still effective,
                                                   even if they are not included in this list.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: array
                                                 items:
-                                                  type: integer
                                                   format: int64
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               sysctls:
                                                 description: |-
                                                   Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
                                                   sysctls (by the container runtime) might fail to launch.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: array
                                                 items:
                                                   description: Sysctl defines a kernel parameter to be set
-                                                  type: object
-                                                  required:
-                                                    - name
-                                                    - value
                                                   properties:
                                                     name:
                                                       description: Name of a property to set
@@ -7507,17 +7921,22 @@ spec:
                                                     value:
                                                       description: Value of a property to set
                                                       type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
                                           serviceAccountName:
                                             description: If specified, the pod's service account
                                             type: string
                                           tolerations:
                                             description: If specified, the pod's tolerations.
-                                            type: array
                                             items:
                                               description: |-
                                                 The pod this Toleration is attached to tolerates any taint that matches
                                                 the triple <key,value,effect> using the matching operator <operator>.
-                                              type: object
                                               properties:
                                                 effect:
                                                   description: |-
@@ -7542,18 +7961,25 @@ spec:
                                                     of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                                                     it is not set, which means tolerate the taint forever (do not evict). Zero and
                                                     negative values will be treated as 0 (evict immediately) by the system.
-                                                  type: integer
                                                   format: int64
+                                                  type: integer
                                                 value:
                                                   description: |-
                                                     Value is the taint value the toleration matches to.
                                                     If the operator is Exists, the value should be empty, otherwise just a regular string.
                                                   type: string
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                    type: object
                                   serviceType:
                                     description: |-
                                       Optional service type for Kubernetes solver service. Supported values
                                       are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
+                                type: object
+                            type: object
                           selector:
                             description: |-
                               Selector selects a set of DNSNames on the Certificate resource that
@@ -7561,7 +7987,6 @@ spec:
                               If not specified, the solver will be treated as the 'default' solver
                               with the lowest priority, i.e. if any other solver has a more specific
                               match, it will be used instead.
-                            type: object
                             properties:
                               dnsNames:
                                 description: |-
@@ -7572,9 +7997,10 @@ spec:
                                   with the most matching labels in matchLabels will be selected.
                                   If neither has more matches, the solver defined earlier in the list
                                   will be selected.
-                                type: array
                                 items:
                                   type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
                               dnsZones:
                                 description: |-
                                   List of DNSZones that this solver will be used to solve.
@@ -7586,41 +8012,49 @@ spec:
                                   with the most matching labels in matchLabels will be selected.
                                   If neither has more matches, the solver defined earlier in the list
                                   will be selected.
-                                type: array
                                 items:
                                   type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
                               matchLabels:
+                                additionalProperties:
+                                  type: string
                                 description: |-
                                   A label selector that is used to refine the set of certificate's that
                                   this challenge solver will apply to.
                                 type: object
-                                additionalProperties:
-                                  type: string
+                            type: object
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  type: object
                 ca:
                   description: |-
                     CA configures this issuer to sign certificates using a signing CA keypair
                     stored in a Secret resource.
                     This is used to build internal PKIs that are managed by cert-manager.
-                  type: object
-                  required:
-                    - secretName
                   properties:
                     crlDistributionPoints:
                       description: |-
                         The CRL distribution points is an X.509 v3 certificate extension which identifies
                         the location of the CRL from which the revocation of this certificate can be checked.
                         If not set, certificates will be issued without distribution points set.
-                      type: array
                       items:
                         type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     issuingCertificateURLs:
                       description: |-
                         IssuingCertificateURLs is a list of URLs which this issuer should embed into certificates
                         it creates. See https://www.rfc-editor.org/rfc/rfc5280#section-4.2.2.1 for more details.
                         As an example, such a URL might be "http://ca.domain.com/ca.crt".
-                      type: array
                       items:
                         type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     ocspServers:
                       description: |-
                         The OCSP server list is an X.509 v3 extension that defines a list of
@@ -7628,51 +8062,45 @@ spec:
                         revocation status of an issued certificate. If not set, the
                         certificate will be issued with no OCSP servers set. For example, an
                         OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
-                      type: array
                       items:
                         type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     secretName:
                       description: |-
                         SecretName is the name of the secret used to sign Certificates issued
                         by this Issuer.
                       type: string
+                  required:
+                    - secretName
+                  type: object
                 selfSigned:
                   description: |-
                     SelfSigned configures this issuer to 'self sign' certificates using the
                     private key used to create the CertificateRequest object.
-                  type: object
                   properties:
                     crlDistributionPoints:
                       description: |-
                         The CRL distribution points is an X.509 v3 certificate extension which identifies
                         the location of the CRL from which the revocation of this certificate can be checked.
                         If not set certificate will be issued without CDP. Values are strings.
-                      type: array
                       items:
                         type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
                 vault:
                   description: |-
                     Vault configures this issuer to sign certificates using a HashiCorp Vault
                     PKI backend.
-                  type: object
-                  required:
-                    - auth
-                    - path
-                    - server
                   properties:
                     auth:
                       description: Auth configures how cert-manager authenticates with the Vault server.
-                      type: object
                       properties:
                         appRole:
                           description: |-
                             AppRole authenticates with Vault using the App Role auth mechanism,
                             with the role and secret stored in a Kubernetes Secret resource.
-                          type: object
-                          required:
-                            - path
-                            - roleId
-                            - secretRef
                           properties:
                             path:
                               description: |-
@@ -7690,9 +8118,6 @@ spec:
                                 to authenticate with Vault.
                                 The `key` field must be specified and denotes which entry within the Secret
                                 resource is used as the app role secret.
-                              type: object
-                              required:
-                                - name
                               properties:
                                 key:
                                   description: |-
@@ -7705,12 +8130,19 @@ spec:
                                     Name of the resource being referred to.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          type: object
                         clientCertificate:
                           description: |-
                             ClientCertificate authenticates with Vault by presenting a client
                             certificate during the request's TLS handshake.
                             Works only when using HTTPS protocol.
-                          type: object
                           properties:
                             mountPath:
                               description: |-
@@ -7730,13 +8162,11 @@ spec:
                                 tls.crt and tls.key) used to authenticate to Vault using TLS client
                                 authentication.
                               type: string
+                          type: object
                         kubernetes:
                           description: |-
                             Kubernetes authenticates with Vault by passing the ServiceAccount
                             token stored in the named Secret resource to the Vault server.
-                          type: object
-                          required:
-                            - role
                           properties:
                             mountPath:
                               description: |-
@@ -7755,9 +8185,6 @@ spec:
                                 The required Secret field containing a Kubernetes ServiceAccount JWT used
                                 for authenticating with Vault. Use of 'ambient credentials' is not
                                 supported.
-                              type: object
-                              required:
-                                - name
                               properties:
                                 key:
                                   description: |-
@@ -7770,6 +8197,9 @@ spec:
                                     Name of the resource being referred to.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
+                              required:
+                                - name
+                              type: object
                             serviceAccountRef:
                               description: |-
                                 A reference to a service account that will be used to request a bound
@@ -7777,25 +8207,26 @@ spec:
                                 using this field means that you don't rely on statically bound tokens. To
                                 use this field, you must configure an RBAC rule to let cert-manager
                                 request a token.
-                              type: object
-                              required:
-                                - name
                               properties:
                                 audiences:
                                   description: |-
                                     TokenAudiences is an optional list of extra audiences to include in the token passed to Vault. The default token
                                     consisting of the issuer's namespace and name is always included.
-                                  type: array
                                   items:
                                     type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 name:
                                   description: Name of the ServiceAccount used to request a token.
                                   type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - role
+                          type: object
                         tokenSecretRef:
                           description: TokenSecretRef authenticates with Vault by presenting a token.
-                          type: object
-                          required:
-                            - name
                           properties:
                             key:
                               description: |-
@@ -7808,6 +8239,10 @@ spec:
                                 Name of the resource being referred to.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
+                          required:
+                            - name
+                          type: object
+                      type: object
                     caBundle:
                       description: |-
                         Base64-encoded bundle of PEM CAs which will be used to validate the certificate
@@ -7816,8 +8251,8 @@ spec:
                         Mutually exclusive with CABundleSecretRef.
                         If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in
                         the cert-manager controller container is used to validate the TLS connection.
-                      type: string
                       format: byte
+                      type: string
                     caBundleSecretRef:
                       description: |-
                         Reference to a Secret containing a bundle of PEM-encoded CAs to use when
@@ -7826,9 +8261,6 @@ spec:
                         If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in
                         the cert-manager controller container is used to validate the TLS connection.
                         If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
-                      type: object
-                      required:
-                        - name
                       properties:
                         key:
                           description: |-
@@ -7841,13 +8273,13 @@ spec:
                             Name of the resource being referred to.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                           type: string
+                      required:
+                        - name
+                      type: object
                     clientCertSecretRef:
                       description: |-
                         Reference to a Secret containing a PEM-encoded Client Certificate to use when the
                         Vault server requires mTLS.
-                      type: object
-                      required:
-                        - name
                       properties:
                         key:
                           description: |-
@@ -7860,13 +8292,13 @@ spec:
                             Name of the resource being referred to.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                           type: string
+                      required:
+                        - name
+                      type: object
                     clientKeySecretRef:
                       description: |-
                         Reference to a Secret containing a PEM-encoded Client Private Key to use when the
                         Vault server requires mTLS.
-                      type: object
-                      required:
-                        - name
                       properties:
                         key:
                           description: |-
@@ -7879,6 +8311,9 @@ spec:
                             Name of the resource being referred to.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                           type: string
+                      required:
+                        - name
+                      type: object
                     namespace:
                       description: |-
                         Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1"
@@ -7897,27 +8332,23 @@ spec:
                         ServerName is used to verify the hostname on the returned certificates
                         by the Vault server.
                       type: string
+                  required:
+                    - auth
+                    - path
+                    - server
+                  type: object
                 venafi:
                   description: |-
                     Venafi configures this issuer to sign certificates using a Venafi TPP
                     or Venafi Cloud policy zone.
-                  type: object
-                  required:
-                    - zone
                   properties:
                     cloud:
                       description: |-
                         Cloud specifies the Venafi cloud configuration settings.
                         Only one of TPP or Cloud may be specified.
-                      type: object
-                      required:
-                        - apiTokenSecretRef
                       properties:
                         apiTokenSecretRef:
                           description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
-                          type: object
-                          required:
-                            - name
                           properties:
                             key:
                               description: |-
@@ -7930,19 +8361,21 @@ spec:
                                 Name of the resource being referred to.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
+                          required:
+                            - name
+                          type: object
                         url:
                           description: |-
                             URL is the base URL for Venafi Cloud.
                             Defaults to "https://api.venafi.cloud/".
                           type: string
+                      required:
+                        - apiTokenSecretRef
+                      type: object
                     tpp:
                       description: |-
                         TPP specifies Trust Protection Platform configuration settings.
                         Only one of TPP or Cloud may be specified.
-                      type: object
-                      required:
-                        - credentialsRef
-                        - url
                       properties:
                         caBundle:
                           description: |-
@@ -7950,8 +8383,8 @@ spec:
                             chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP.
                             If undefined, the certificate bundle in the cert-manager controller container
                             is used to validate the chain.
-                          type: string
                           format: byte
+                          type: string
                         caBundleSecretRef:
                           description: |-
                             Reference to a Secret containing a base64-encoded bundle of PEM CAs
@@ -7959,9 +8392,6 @@ spec:
                             Only used if using HTTPS; ignored for HTTP. Mutually exclusive with CABundle.
                             If neither CABundle nor CABundleSecretRef is defined, the certificate bundle in
                             the cert-manager controller container is used to validate the TLS connection.
-                          type: object
-                          required:
-                            - name
                           properties:
                             key:
                               description: |-
@@ -7974,25 +8404,32 @@ spec:
                                 Name of the resource being referred to.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
+                          required:
+                            - name
+                          type: object
                         credentialsRef:
                           description: |-
                             CredentialsRef is a reference to a Secret containing the Venafi TPP API credentials.
                             The secret must contain the key 'access-token' for the Access Token Authentication,
                             or two keys, 'username' and 'password' for the API Keys Authentication.
-                          type: object
-                          required:
-                            - name
                           properties:
                             name:
                               description: |-
                                 Name of the resource being referred to.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
+                          required:
+                            - name
+                          type: object
                         url:
                           description: |-
                             URL is the base URL for the vedsdk endpoint of the Venafi TPP instance,
                             for example: "https://tpp.example.com/vedsdk".
                           type: string
+                      required:
+                        - credentialsRef
+                        - url
+                      type: object
                     zone:
                       description: |-
                         Zone is the Venafi Policy Zone to use for this issuer.
@@ -8000,16 +8437,18 @@ spec:
                         zone policy.
                         This field is required.
                       type: string
+                  required:
+                    - zone
+                  type: object
+              type: object
             status:
               description: Status of the ClusterIssuer. This is set and managed automatically.
-              type: object
               properties:
                 acme:
                   description: |-
                     ACME specific status options.
                     This field should only be set if the Issuer is configured to use an ACME
                     server to issue certificates.
-                  type: object
                   properties:
                     lastPrivateKeyHash:
                       description: |-
@@ -8028,24 +8467,20 @@ spec:
                         URI is the unique account identifier, which can also be used to retrieve
                         account details from the CA
                       type: string
+                  type: object
                 conditions:
                   description: |-
                     List of status conditions to indicate the status of a CertificateRequest.
                     Known condition types are `Ready`.
-                  type: array
                   items:
                     description: IssuerCondition contains condition information for an Issuer.
-                    type: object
-                    required:
-                      - status
-                      - type
                     properties:
                       lastTransitionTime:
                         description: |-
                           LastTransitionTime is the timestamp corresponding to the last status
                           change of this condition.
-                        type: string
                         format: date-time
+                        type: string
                       message:
                         description: |-
                           Message is a human readable description of the details of the last
@@ -8058,8 +8493,8 @@ spec:
                           For instance, if .metadata.generation is currently 12, but the
                           .status.condition[x].observedGeneration is 9, the condition is out of date
                           with respect to the current state of the Issuer.
-                        type: integer
                         format: int64
+                        type: integer
                       reason:
                         description: |-
                           Reason is a brief machine readable explanation for the condition's last
@@ -8067,67 +8502,70 @@ spec:
                         type: string
                       status:
                         description: Status of the condition, one of (`True`, `False`, `Unknown`).
-                        type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
+                        type: string
                       type:
                         description: Type of the condition, known values are (`Ready`).
                         type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
+              type: object
+          required:
+            - spec
+          type: object
       served: true
       storage: true
-
-# END crd
+      subresources:
+        status: {}
 ---
-# Source: cert-manager/templates/crds.yaml
-# START crd
+# Source: cert-manager/templates/crd-cert-manager.io_issuers.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: issuers.cert-manager.io
-  # START annotations
+  name: "issuers.cert-manager.io"
   annotations:
     helm.sh/resource-policy: keep
-  # END annotations
   labels:
-    app: 'cert-manager'
-    app.kubernetes.io/name: 'cert-manager'
-    app.kubernetes.io/instance: 'cert-manager'
+    app: "cert-manager"
+    app.kubernetes.io/name: "cert-manager"
+    app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    # Generated labels
-    app.kubernetes.io/version: "v1.18.2"
+    app.kubernetes.io/version: "v1.19.6"
 spec:
   group: cert-manager.io
   names:
+    categories:
+      - cert-manager
     kind: Issuer
     listKind: IssuerList
     plural: issuers
     shortNames:
       - iss
     singular: issuer
-    categories:
-      - cert-manager
   scope: Namespaced
   versions:
-    - name: v1
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type == "Ready")].status
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+        - jsonPath: .status.conditions[?(@.type == "Ready")].message
           name: Status
           priority: 1
           type: string
-        - jsonPath: .metadata.creationTimestamp
-          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
+      name: v1
       schema:
         openAPIV3Schema:
           description: |-
@@ -8135,9 +8573,6 @@ spec:
             referenced as part of `issuerRef` fields.
             It is scoped to a single namespace and can therefore only be referenced by
             resources within the same namespace.
-          type: object
-          required:
-            - spec
           properties:
             apiVersion:
               description: |-
@@ -8158,16 +8593,11 @@ spec:
               type: object
             spec:
               description: Desired state of the Issuer resource.
-              type: object
               properties:
                 acme:
                   description: |-
                     ACME configures this issuer to communicate with a RFC8555 (ACME) server
                     to obtain signed x509 certificates.
-                  type: object
-                  required:
-                    - privateKeySecretRef
-                    - server
                   properties:
                     caBundle:
                       description: |-
@@ -8177,8 +8607,8 @@ spec:
                         kinds of security vulnerabilities.
                         If CABundle and SkipTLSVerify are unset, the system certificate bundle inside
                         the container is used to validate the TLS connection.
-                      type: string
                       format: byte
+                      type: string
                     disableAccountKeyGeneration:
                       description: |-
                         Enables or disables generating a new ACME account key.
@@ -8210,21 +8640,17 @@ spec:
                         server.
                         If set, upon registration cert-manager will attempt to associate the given
                         external account credentials with the registered ACME account.
-                      type: object
-                      required:
-                        - keyID
-                        - keySecretRef
                       properties:
                         keyAlgorithm:
                           description: |-
                             Deprecated: keyAlgorithm field exists for historical compatibility
                             reasons and should not be used. The algorithm is now hardcoded to HS256
                             in golang/x/crypto/acme.
-                          type: string
                           enum:
                             - HS256
                             - HS384
                             - HS512
+                          type: string
                         keyID:
                           description: keyID is the ID of the CA key that the External Account is bound to.
                           type: string
@@ -8237,9 +8663,6 @@ spec:
                             the External Account Binding keyID above.
                             The secret key stored in the Secret **must** be un-padded, base64 URL
                             encoded data.
-                          type: object
-                          required:
-                            - name
                           properties:
                             key:
                               description: |-
@@ -8252,6 +8675,13 @@ spec:
                                 Name of the resource being referred to.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
+                          required:
+                            - name
+                          type: object
+                      required:
+                        - keyID
+                        - keySecretRef
+                      type: object
                     preferredChain:
                       description: |-
                         PreferredChain is the chain to use if the ACME server outputs multiple.
@@ -8262,8 +8692,8 @@ spec:
                         This value picks the first certificate bundle in the combined set of
                         ACME default and alternative chains that has a root-most certificate with
                         this value as its issuer's commonname.
-                      type: string
                       maxLength: 64
+                      type: string
                     privateKeySecretRef:
                       description: |-
                         PrivateKey is the name of a Kubernetes Secret resource that will be used to
@@ -8271,9 +8701,6 @@ spec:
                         Optionally, a `key` may be specified to select a specific entry within
                         the named Secret resource.
                         If `key` is not specified, a default of `tls.key` will be used.
-                      type: object
-                      required:
-                        - name
                       properties:
                         key:
                           description: |-
@@ -8286,6 +8713,9 @@ spec:
                             Name of the resource being referred to.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                           type: string
+                      required:
+                        - name
+                      type: object
                     profile:
                       description: |-
                         Profile allows requesting a certificate profile from the ACME server.
@@ -8317,36 +8747,26 @@ spec:
                         Solver configurations must be provided in order to obtain certificates
                         from an ACME server.
                         For more information, see: https://cert-manager.io/docs/configuration/acme/
-                      type: array
                       items:
                         description: |-
                           An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of.
                           A selector may be provided to use different solving strategies for different DNS names.
                           Only one of HTTP01 or DNS01 must be provided.
-                        type: object
                         properties:
                           dns01:
                             description: |-
                               Configures cert-manager to attempt to complete authorizations by
                               performing the DNS01 challenge flow.
-                            type: object
                             properties:
                               acmeDNS:
                                 description: |-
                                   Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage
                                   DNS01 challenge records.
-                                type: object
-                                required:
-                                  - accountSecretRef
-                                  - host
                                 properties:
                                   accountSecretRef:
                                     description: |-
                                       A reference to a specific 'key' within a Secret resource.
                                       In some instances, `key` is a required field.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -8359,24 +8779,22 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
                                   host:
                                     type: string
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                type: object
                               akamai:
                                 description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
-                                type: object
-                                required:
-                                  - accessTokenSecretRef
-                                  - clientSecretSecretRef
-                                  - clientTokenSecretRef
-                                  - serviceConsumerDomain
                                 properties:
                                   accessTokenSecretRef:
                                     description: |-
                                       A reference to a specific 'key' within a Secret resource.
                                       In some instances, `key` is a required field.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -8389,13 +8807,13 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
                                   clientSecretSecretRef:
                                     description: |-
                                       A reference to a specific 'key' within a Secret resource.
                                       In some instances, `key` is a required field.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -8408,13 +8826,13 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
                                   clientTokenSecretRef:
                                     description: |-
                                       A reference to a specific 'key' within a Secret resource.
                                       In some instances, `key` is a required field.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -8427,14 +8845,19 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
                                   serviceConsumerDomain:
                                     type: string
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                type: object
                               azureDNS:
                                 description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
-                                type: object
-                                required:
-                                  - resourceGroupName
-                                  - subscriptionID
                                 properties:
                                   clientID:
                                     description: |-
@@ -8447,9 +8870,6 @@ spec:
                                       Auth: Azure Service Principal:
                                       A reference to a Secret containing the password associated with the Service Principal.
                                       If set, ClientID and TenantID must also be set.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -8462,14 +8882,17 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
                                   environment:
                                     description: name of the Azure environment (default AzurePublicCloud)
-                                    type: string
                                     enum:
                                       - AzurePublicCloud
                                       - AzureChinaCloud
                                       - AzureGermanCloud
                                       - AzureUSGovernmentCloud
+                                    type: string
                                   hostedZoneName:
                                     description: name of the DNS zone that should be used
                                     type: string
@@ -8478,7 +8901,6 @@ spec:
                                       Auth: Azure Workload Identity or Azure Managed Service Identity:
                                       Settings to enable Azure Workload Identity or Azure Managed Service Identity
                                       If set, ClientID, ClientSecret and TenantID must not be set.
-                                    type: object
                                     properties:
                                       clientID:
                                         description: client ID of the managed identity, cannot be used at the same time as resourceID
@@ -8491,6 +8913,7 @@ spec:
                                       tenantID:
                                         description: tenant ID of the managed identity, cannot be used at the same time as resourceID
                                         type: string
+                                    type: object
                                   resourceGroupName:
                                     description: resource group the DNS zone is located in
                                     type: string
@@ -8503,11 +8926,12 @@ spec:
                                       The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
                                       If set, ClientID and ClientSecret must also be set.
                                     type: string
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                type: object
                               cloudDNS:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
-                                type: object
-                                required:
-                                  - project
                                 properties:
                                   hostedZoneName:
                                     description: |-
@@ -8521,9 +8945,6 @@ spec:
                                     description: |-
                                       A reference to a specific 'key' within a Secret resource.
                                       In some instances, `key` is a required field.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -8536,18 +8957,20 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - project
+                                type: object
                               cloudflare:
                                 description: Use the Cloudflare API to manage DNS01 challenge records.
-                                type: object
                                 properties:
                                   apiKeySecretRef:
                                     description: |-
                                       API key to use to authenticate with Cloudflare.
                                       Note: using an API token to authenticate is now the recommended method
                                       as it allows greater control of permissions.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -8560,11 +8983,11 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
                                   apiTokenSecretRef:
                                     description: API token used to authenticate with Cloudflare.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -8577,30 +9000,28 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
                                   email:
                                     description: Email of the account, only required when using API key based authentication.
                                     type: string
+                                type: object
                               cnameStrategy:
                                 description: |-
                                   CNAMEStrategy configures how the DNS01 provider should handle CNAME
                                   records when found in DNS zones.
-                                type: string
                                 enum:
                                   - None
                                   - Follow
+                                type: string
                               digitalocean:
                                 description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
-                                type: object
-                                required:
-                                  - tokenSecretRef
                                 properties:
                                   tokenSecretRef:
                                     description: |-
                                       A reference to a specific 'key' within a Secret resource.
                                       In some instances, `key` is a required field.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -8613,20 +9034,29 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - tokenSecretRef
+                                type: object
                               rfc2136:
                                 description: |-
                                   Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/)
                                   to manage DNS01 challenge records.
-                                type: object
-                                required:
-                                  - nameserver
                                 properties:
                                   nameserver:
                                     description: |-
                                       The IP address or hostname of an authoritative DNS server supporting
                                       RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                      enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                      enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                       This field is required.
+                                    type: string
+                                  protocol:
+                                    description: Protocol to use for dynamic DNS update queries. Valid values are (case-sensitive) ``TCP`` and ``UDP``; ``UDP`` (default).
+                                    enum:
+                                      - TCP
+                                      - UDP
                                     type: string
                                   tsigAlgorithm:
                                     description: |-
@@ -8644,9 +9074,6 @@ spec:
                                     description: |-
                                       The name of the secret containing the TSIG value.
                                       If ``tsigKeyName`` is defined, this field is required.
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -8659,9 +9086,14 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - nameserver
+                                type: object
                               route53:
                                 description: Use the AWS Route53 API to manage DNS01 challenge records.
-                                type: object
                                 properties:
                                   accessKeyID:
                                     description: |-
@@ -8679,9 +9111,6 @@ spec:
                                       If neither the Access Key nor Key ID are set, we fall-back to using env
                                       vars, shared credentials file or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -8694,28 +9123,22 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
                                   auth:
                                     description: Auth configures how cert-manager authenticates.
-                                    type: object
-                                    required:
-                                      - kubernetes
                                     properties:
                                       kubernetes:
                                         description: |-
                                           Kubernetes authenticates with Route53 using AssumeRoleWithWebIdentity
                                           by passing a bound ServiceAccount token.
-                                        type: object
-                                        required:
-                                          - serviceAccountRef
                                         properties:
                                           serviceAccountRef:
                                             description: |-
                                               A reference to a service account that will be used to request a bound
                                               token (also known as "projected token"). To use this field, you must
                                               configure an RBAC rule to let cert-manager request a token.
-                                            type: object
-                                            required:
-                                              - name
                                             properties:
                                               audiences:
                                                 description: |-
@@ -8723,12 +9146,22 @@ spec:
                                                   token passed to AWS. The default token consisting of the issuer's namespace
                                                   and name is always included.
                                                   If unset the audience defaults to `sts.amazonaws.com`.
-                                                type: array
                                                 items:
                                                   type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               name:
                                                 description: Name of the ServiceAccount used to request a token.
                                                 type: string
+                                            required:
+                                              - name
+                                            type: object
+                                        required:
+                                          - serviceAccountRef
+                                        type: object
+                                    required:
+                                      - kubernetes
+                                    type: object
                                   hostedZoneID:
                                     description: If set, the provider will manage only this zone in Route53 and will not do a lookup using the route53:ListHostedZonesByName api call.
                                     type: string
@@ -8768,9 +9201,6 @@ spec:
                                       If neither the Access Key nor Key ID are set, we fall-back to using env
                                       vars, shared credentials file or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                                    type: object
-                                    required:
-                                      - name
                                     properties:
                                       key:
                                         description: |-
@@ -8783,14 +9213,14 @@ spec:
                                           Name of the resource being referred to.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
+                                    required:
+                                      - name
+                                    type: object
+                                type: object
                               webhook:
                                 description: |-
                                   Configure an external webhook based DNS01 challenge solver to manage
                                   DNS01 challenge records.
-                                type: object
-                                required:
-                                  - groupName
-                                  - solverName
                                 properties:
                                   config:
                                     description: |-
@@ -8816,13 +9246,17 @@ spec:
                                       implementation.
                                       This will typically be the name of the provider, e.g., 'cloudflare'.
                                     type: string
+                                required:
+                                  - groupName
+                                  - solverName
+                                type: object
+                            type: object
                           http01:
                             description: |-
                               Configures cert-manager to attempt to complete authorizations by
                               performing the HTTP01 challenge flow.
                               It is not possible to obtain certificates for wildcard domain names
                               (e.g., `*.example.com`) using the HTTP01 challenge mechanism.
-                            type: object
                             properties:
                               gatewayHTTPRoute:
                                 description: |-
@@ -8830,22 +9264,20 @@ spec:
                                   in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will
                                   create HTTPRoutes with the specified labels in the same namespace as the challenge.
                                   This solver is experimental, and fields / behaviour may change in the future.
-                                type: object
                                 properties:
                                   labels:
+                                    additionalProperties:
+                                      type: string
                                     description: |-
                                       Custom labels that will be applied to HTTPRoutes created by cert-manager
                                       while solving HTTP-01 challenges.
                                     type: object
-                                    additionalProperties:
-                                      type: string
                                   parentRefs:
                                     description: |-
                                       When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.
                                       cert-manager needs to know which parentRefs should be used when creating
                                       the HTTPRoute. Usually, the parentRef references a Gateway. See:
                                       https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways
-                                    type: array
                                     items:
                                       description: |-
                                         ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -8860,11 +9292,9 @@ spec:
 
                                         The API object must be valid in the cluster; the Group and Kind must
                                         be registered in the cluster for this reference to be valid.
-                                      type: object
-                                      required:
-                                        - name
                                       properties:
                                         group:
+                                          default: gateway.networking.k8s.io
                                           description: |-
                                             Group is the group of the referent.
                                             When unspecified, "gateway.networking.k8s.io" is inferred.
@@ -8872,11 +9302,11 @@ spec:
                                             Group must be explicitly set to "" (empty string).
 
                                             Support: Core
-                                          type: string
-                                          default: gateway.networking.k8s.io
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
                                         kind:
+                                          default: Gateway
                                           description: |-
                                             Kind is kind of the referent.
 
@@ -8886,19 +9316,18 @@ spec:
                                             * Service (Mesh conformance profile, ClusterIP Services only)
 
                                             Support for other resources is Implementation-Specific.
-                                          type: string
-                                          default: Gateway
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
                                         name:
                                           description: |-
                                             Name is the name of the referent.
 
                                             Support: Core
-                                          type: string
                                           maxLength: 253
                                           minLength: 1
+                                          type: string
                                         namespace:
                                           description: |-
                                             Namespace is the namespace of the referent. When unspecified, this refers
@@ -8923,10 +9352,10 @@ spec:
                                             </gateway:experimental:description>
 
                                             Support: Core
-                                          type: string
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
                                         port:
                                           description: |-
                                             Port is the network port this Route targets. It can be interpreted
@@ -8959,10 +9388,10 @@ spec:
                                             the Route MUST be considered detached from the Gateway.
 
                                             Support: Extended
-                                          type: integer
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
+                                          type: integer
                                         sectionName:
                                           description: |-
                                             SectionName is the name of a section within the target resource. In the
@@ -8989,15 +9418,19 @@ spec:
                                             Route MUST be considered detached from the Gateway.
 
                                             Support: Core
-                                          type: string
                                           maxLength: 253
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   podTemplate:
                                     description: |-
                                       Optional pod template used to configure the ACME challenge solver pods
                                       used for HTTP01 challenges.
-                                    type: object
                                     properties:
                                       metadata:
                                         description: |-
@@ -9005,32 +9438,29 @@ spec:
                                           Only the 'labels' and 'annotations' fields may be set.
                                           If labels or annotations overlap with in-built values, the values here
                                           will override the in-built values.
-                                        type: object
                                         properties:
                                           annotations:
+                                            additionalProperties:
+                                              type: string
                                             description: Annotations that should be added to the created ACME HTTP01 solver pods.
                                             type: object
+                                          labels:
                                             additionalProperties:
                                               type: string
-                                          labels:
                                             description: Labels that should be added to the created ACME HTTP01 solver pods.
                                             type: object
-                                            additionalProperties:
-                                              type: string
+                                        type: object
                                       spec:
                                         description: |-
                                           PodSpec defines overrides for the HTTP01 challenge solver pod.
                                           Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
                                           All other fields will be ignored.
-                                        type: object
                                         properties:
                                           affinity:
                                             description: If specified, the pod's scheduling constraints
-                                            type: object
                                             properties:
                                               nodeAffinity:
                                                 description: Describes node affinity scheduling rules for the pod.
-                                                type: object
                                                 properties:
                                                   preferredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -9043,31 +9473,20 @@ spec:
                                                       compute a sum by iterating through the elements of this field and adding
                                                       "weight" to the sum if the node matches the corresponding matchExpressions; the
                                                       node(s) with the highest sum are the most preferred.
-                                                    type: array
                                                     items:
                                                       description: |-
                                                         An empty preferred scheduling term matches all objects with implicit weight 0
                                                         (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
-                                                      type: object
-                                                      required:
-                                                        - preference
-                                                        - weight
                                                       properties:
                                                         preference:
                                                           description: A node selector term, associated with the corresponding weight.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: A list of node selector requirements by node's labels.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A node selector requirement is a selector that contains values, a key, and an operator
                                                                   that relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: The label key that the selector applies to.
@@ -9084,22 +9503,22 @@ spec:
                                                                       the values array must be empty. If the operator is Gt or Lt, the values
                                                                       array must have a single element, which will be interpreted as an integer.
                                                                       This array is replaced during a strategic merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchFields:
                                                               description: A list of node selector requirements by node's fields.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A node selector requirement is a selector that contains values, a key, and an operator
                                                                   that relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: The label key that the selector applies to.
@@ -9116,16 +9535,27 @@ spec:
                                                                       the values array must be empty. If the operator is Gt or Lt, the values
                                                                       array must have a single element, which will be interpreted as an integer.
                                                                       This array is replaced during a strategic merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         weight:
                                                           description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
-                                                          type: integer
                                                           format: int32
+                                                          type: integer
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   requiredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -9134,31 +9564,21 @@ spec:
                                                       If the affinity requirements specified by this field cease to be met
                                                       at some point during pod execution (e.g. due to an update), the system
                                                       may or may not try to eventually evict the pod from its node.
-                                                    type: object
-                                                    required:
-                                                      - nodeSelectorTerms
                                                     properties:
                                                       nodeSelectorTerms:
                                                         description: Required. A list of node selector terms. The terms are ORed.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A null or empty node selector term matches no objects. The requirements of
                                                             them are ANDed.
                                                             The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: A list of node selector requirements by node's labels.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A node selector requirement is a selector that contains values, a key, and an operator
                                                                   that relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: The label key that the selector applies to.
@@ -9175,22 +9595,22 @@ spec:
                                                                       the values array must be empty. If the operator is Gt or Lt, the values
                                                                       array must have a single element, which will be interpreted as an integer.
                                                                       This array is replaced during a strategic merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchFields:
                                                               description: A list of node selector requirements by node's fields.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A node selector requirement is a selector that contains values, a key, and an operator
                                                                   that relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: The label key that the selector applies to.
@@ -9207,17 +9627,27 @@ spec:
                                                                       the values array must be empty. If the operator is Gt or Lt, the values
                                                                       array must have a single element, which will be interpreted as an integer.
                                                                       This array is replaced during a strategic merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    type: object
                                                     x-kubernetes-map-type: atomic
+                                                type: object
                                               podAffinity:
                                                 description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
-                                                type: object
                                                 properties:
                                                   preferredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -9230,37 +9660,23 @@ spec:
                                                       compute a sum by iterating through the elements of this field and adding
                                                       "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                       node(s) with the highest sum are the most preferred.
-                                                    type: array
                                                     items:
                                                       description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                                                      type: object
-                                                      required:
-                                                        - podAffinityTerm
-                                                        - weight
                                                       properties:
                                                         podAffinityTerm:
                                                           description: Required. A pod affinity term, associated with the corresponding weight.
-                                                          type: object
-                                                          required:
-                                                            - topologyKey
                                                           properties:
                                                             labelSelector:
                                                               description: |-
                                                                 A label query over a set of resources, in this case pods.
                                                                 If it's null, this PodAffinityTerm matches with no Pods.
-                                                              type: object
                                                               properties:
                                                                 matchExpressions:
                                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                                  type: array
                                                                   items:
                                                                     description: |-
                                                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                                                       relates the key and values.
-                                                                    type: object
-                                                                    required:
-                                                                      - key
-                                                                      - operator
                                                                     properties:
                                                                       key:
                                                                         description: key is the label key that the selector applies to.
@@ -9276,19 +9692,25 @@ spec:
                                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                           the values array must be empty. This array is replaced during a strategic
                                                                           merge patch.
-                                                                        type: array
                                                                         items:
                                                                           type: string
+                                                                        type: array
                                                                         x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
                                                                 matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
                                                                   description: |-
                                                                     matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                     map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                     operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                                   type: object
-                                                                  additionalProperties:
-                                                                    type: string
+                                                              type: object
                                                               x-kubernetes-map-type: atomic
                                                             matchLabelKeys:
                                                               description: |-
@@ -9300,10 +9722,9 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             mismatchLabelKeys:
                                                               description: |-
@@ -9315,10 +9736,9 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             namespaceSelector:
                                                               description: |-
@@ -9327,19 +9747,13 @@ spec:
                                                                 and the ones listed in the namespaces field.
                                                                 null selector and null or empty namespaces list means "this pod's namespace".
                                                                 An empty selector ({}) matches all namespaces.
-                                                              type: object
                                                               properties:
                                                                 matchExpressions:
                                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                                  type: array
                                                                   items:
                                                                     description: |-
                                                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                                                       relates the key and values.
-                                                                    type: object
-                                                                    required:
-                                                                      - key
-                                                                      - operator
                                                                     properties:
                                                                       key:
                                                                         description: key is the label key that the selector applies to.
@@ -9355,19 +9769,25 @@ spec:
                                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                           the values array must be empty. This array is replaced during a strategic
                                                                           merge patch.
-                                                                        type: array
                                                                         items:
                                                                           type: string
+                                                                        type: array
                                                                         x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
                                                                 matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
                                                                   description: |-
                                                                     matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                     map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                     operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                                   type: object
-                                                                  additionalProperties:
-                                                                    type: string
+                                                              type: object
                                                               x-kubernetes-map-type: atomic
                                                             namespaces:
                                                               description: |-
@@ -9375,9 +9795,9 @@ spec:
                                                                 The term is applied to the union of the namespaces listed in this field
                                                                 and the ones selected by namespaceSelector.
                                                                 null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             topologyKey:
                                                               description: |-
@@ -9387,12 +9807,20 @@ spec:
                                                                 selected pods is running.
                                                                 Empty topologyKey is not allowed.
                                                               type: string
+                                                          required:
+                                                            - topologyKey
+                                                          type: object
                                                         weight:
                                                           description: |-
                                                             weight associated with matching the corresponding podAffinityTerm,
                                                             in the range 1-100.
-                                                          type: integer
                                                           format: int32
+                                                          type: integer
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   requiredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -9403,7 +9831,6 @@ spec:
                                                       system may or may not try to eventually evict the pod from its node.
                                                       When there are multiple elements, the lists of nodes corresponding to each
                                                       podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                                                    type: array
                                                     items:
                                                       description: |-
                                                         Defines a set of pods (namely those matching the labelSelector
@@ -9412,27 +9839,18 @@ spec:
                                                         where co-located is defined as running on a node whose value of
                                                         the label with key <topologyKey> matches that of any node on which
                                                         a pod of the set of pods is running
-                                                      type: object
-                                                      required:
-                                                        - topologyKey
                                                       properties:
                                                         labelSelector:
                                                           description: |-
                                                             A label query over a set of resources, in this case pods.
                                                             If it's null, this PodAffinityTerm matches with no Pods.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                                   relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: key is the label key that the selector applies to.
@@ -9448,19 +9866,25 @@ spec:
                                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                       the values array must be empty. This array is replaced during a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: |-
                                                                 matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                 map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                 operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         matchLabelKeys:
                                                           description: |-
@@ -9472,10 +9896,9 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         mismatchLabelKeys:
                                                           description: |-
@@ -9487,10 +9910,9 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         namespaceSelector:
                                                           description: |-
@@ -9499,19 +9921,13 @@ spec:
                                                             and the ones listed in the namespaces field.
                                                             null selector and null or empty namespaces list means "this pod's namespace".
                                                             An empty selector ({}) matches all namespaces.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                                   relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: key is the label key that the selector applies to.
@@ -9527,19 +9943,25 @@ spec:
                                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                       the values array must be empty. This array is replaced during a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: |-
                                                                 matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                 map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                 operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         namespaces:
                                                           description: |-
@@ -9547,9 +9969,9 @@ spec:
                                                             The term is applied to the union of the namespaces listed in this field
                                                             and the ones selected by namespaceSelector.
                                                             null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         topologyKey:
                                                           description: |-
@@ -9559,10 +9981,14 @@ spec:
                                                             selected pods is running.
                                                             Empty topologyKey is not allowed.
                                                           type: string
+                                                      required:
+                                                        - topologyKey
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
+                                                type: object
                                               podAntiAffinity:
                                                 description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
-                                                type: object
                                                 properties:
                                                   preferredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -9572,40 +9998,26 @@ spec:
                                                       most preferred is the one with the greatest sum of weights, i.e.
                                                       for each node that meets all of the scheduling requirements (resource
                                                       request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                                      compute a sum by iterating through the elements of this field and adding
-                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      compute a sum by iterating through the elements of this field and subtracting
+                                                      "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                       node(s) with the highest sum are the most preferred.
-                                                    type: array
                                                     items:
                                                       description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                                                      type: object
-                                                      required:
-                                                        - podAffinityTerm
-                                                        - weight
                                                       properties:
                                                         podAffinityTerm:
                                                           description: Required. A pod affinity term, associated with the corresponding weight.
-                                                          type: object
-                                                          required:
-                                                            - topologyKey
                                                           properties:
                                                             labelSelector:
                                                               description: |-
                                                                 A label query over a set of resources, in this case pods.
                                                                 If it's null, this PodAffinityTerm matches with no Pods.
-                                                              type: object
                                                               properties:
                                                                 matchExpressions:
                                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                                  type: array
                                                                   items:
                                                                     description: |-
                                                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                                                       relates the key and values.
-                                                                    type: object
-                                                                    required:
-                                                                      - key
-                                                                      - operator
                                                                     properties:
                                                                       key:
                                                                         description: key is the label key that the selector applies to.
@@ -9621,19 +10033,25 @@ spec:
                                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                           the values array must be empty. This array is replaced during a strategic
                                                                           merge patch.
-                                                                        type: array
                                                                         items:
                                                                           type: string
+                                                                        type: array
                                                                         x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
                                                                 matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
                                                                   description: |-
                                                                     matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                     map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                     operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                                   type: object
-                                                                  additionalProperties:
-                                                                    type: string
+                                                              type: object
                                                               x-kubernetes-map-type: atomic
                                                             matchLabelKeys:
                                                               description: |-
@@ -9645,10 +10063,9 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             mismatchLabelKeys:
                                                               description: |-
@@ -9660,10 +10077,9 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             namespaceSelector:
                                                               description: |-
@@ -9672,19 +10088,13 @@ spec:
                                                                 and the ones listed in the namespaces field.
                                                                 null selector and null or empty namespaces list means "this pod's namespace".
                                                                 An empty selector ({}) matches all namespaces.
-                                                              type: object
                                                               properties:
                                                                 matchExpressions:
                                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                                  type: array
                                                                   items:
                                                                     description: |-
                                                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                                                       relates the key and values.
-                                                                    type: object
-                                                                    required:
-                                                                      - key
-                                                                      - operator
                                                                     properties:
                                                                       key:
                                                                         description: key is the label key that the selector applies to.
@@ -9700,19 +10110,25 @@ spec:
                                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                           the values array must be empty. This array is replaced during a strategic
                                                                           merge patch.
-                                                                        type: array
                                                                         items:
                                                                           type: string
+                                                                        type: array
                                                                         x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
                                                                 matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
                                                                   description: |-
                                                                     matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                     map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                     operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                                   type: object
-                                                                  additionalProperties:
-                                                                    type: string
+                                                              type: object
                                                               x-kubernetes-map-type: atomic
                                                             namespaces:
                                                               description: |-
@@ -9720,9 +10136,9 @@ spec:
                                                                 The term is applied to the union of the namespaces listed in this field
                                                                 and the ones selected by namespaceSelector.
                                                                 null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             topologyKey:
                                                               description: |-
@@ -9732,12 +10148,20 @@ spec:
                                                                 selected pods is running.
                                                                 Empty topologyKey is not allowed.
                                                               type: string
+                                                          required:
+                                                            - topologyKey
+                                                          type: object
                                                         weight:
                                                           description: |-
                                                             weight associated with matching the corresponding podAffinityTerm,
                                                             in the range 1-100.
-                                                          type: integer
                                                           format: int32
+                                                          type: integer
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   requiredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -9748,7 +10172,6 @@ spec:
                                                       system may or may not try to eventually evict the pod from its node.
                                                       When there are multiple elements, the lists of nodes corresponding to each
                                                       podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                                                    type: array
                                                     items:
                                                       description: |-
                                                         Defines a set of pods (namely those matching the labelSelector
@@ -9757,27 +10180,18 @@ spec:
                                                         where co-located is defined as running on a node whose value of
                                                         the label with key <topologyKey> matches that of any node on which
                                                         a pod of the set of pods is running
-                                                      type: object
-                                                      required:
-                                                        - topologyKey
                                                       properties:
                                                         labelSelector:
                                                           description: |-
                                                             A label query over a set of resources, in this case pods.
                                                             If it's null, this PodAffinityTerm matches with no Pods.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                                   relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: key is the label key that the selector applies to.
@@ -9793,19 +10207,25 @@ spec:
                                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                       the values array must be empty. This array is replaced during a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: |-
                                                                 matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                 map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                 operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         matchLabelKeys:
                                                           description: |-
@@ -9817,10 +10237,9 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         mismatchLabelKeys:
                                                           description: |-
@@ -9832,10 +10251,9 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         namespaceSelector:
                                                           description: |-
@@ -9844,19 +10262,13 @@ spec:
                                                             and the ones listed in the namespaces field.
                                                             null selector and null or empty namespaces list means "this pod's namespace".
                                                             An empty selector ({}) matches all namespaces.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                                   relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: key is the label key that the selector applies to.
@@ -9872,19 +10284,25 @@ spec:
                                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                       the values array must be empty. This array is replaced during a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: |-
                                                                 matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                 map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                 operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         namespaces:
                                                           description: |-
@@ -9892,9 +10310,9 @@ spec:
                                                             The term is applied to the union of the namespaces listed in this field
                                                             and the ones selected by namespaceSelector.
                                                             null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         topologyKey:
                                                           description: |-
@@ -9904,17 +10322,22 @@ spec:
                                                             selected pods is running.
                                                             Empty topologyKey is not allowed.
                                                           type: string
+                                                      required:
+                                                        - topologyKey
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
+                                                type: object
+                                            type: object
                                           imagePullSecrets:
                                             description: If specified, the pod's imagePullSecrets
-                                            type: array
                                             items:
                                               description: |-
                                                 LocalObjectReference contains enough information to let you locate the
                                                 referenced object inside the same namespace.
-                                              type: object
                                               properties:
                                                 name:
+                                                  default: ""
                                                   description: |-
                                                     Name of the referent.
                                                     This field is effectively required, but due to backwards compatibility is
@@ -9922,22 +10345,59 @@ spec:
                                                     almost certainly wrong.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                                   type: string
-                                                  default: ""
+                                              type: object
                                               x-kubernetes-map-type: atomic
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
                                           nodeSelector:
+                                            additionalProperties:
+                                              type: string
                                             description: |-
                                               NodeSelector is a selector which must be true for the pod to fit on a node.
                                               Selector which must match a node's labels for the pod to be scheduled on that node.
                                               More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                                             type: object
-                                            additionalProperties:
-                                              type: string
                                           priorityClassName:
                                             description: If specified, the pod's priorityClassName.
                                             type: string
+                                          resources:
+                                            description: |-
+                                              If specified, the pod's resource requirements.
+                                              These values override the global resource configuration flags.
+                                              Note that when only specifying resource limits, ensure they are greater than or equal
+                                              to the corresponding global resource requests configured via controller flags
+                                              (--acme-http01-solver-resource-request-cpu, --acme-http01-solver-resource-request-memory).
+                                              Kubernetes will reject pod creation if limits are lower than requests, causing challenge failures.
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Requests describes the minimum amount of compute resources required.
+                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                  otherwise to the global values configured via controller flags. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                            type: object
                                           securityContext:
                                             description: If specified, the pod's security context
-                                            type: object
                                             properties:
                                               fsGroup:
                                                 description: |-
@@ -9951,8 +10411,8 @@ spec:
 
                                                   If unset, the Kubelet will not modify the ownership and permissions of any volume.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: integer
                                                 format: int64
+                                                type: integer
                                               fsGroupChangePolicy:
                                                 description: |-
                                                   fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
@@ -9971,8 +10431,8 @@ spec:
                                                   PodSecurityContext, the value specified in SecurityContext takes precedence
                                                   for that container.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: integer
                                                 format: int64
+                                                type: integer
                                               runAsNonRoot:
                                                 description: |-
                                                   Indicates that the container must run as a non-root user.
@@ -9990,8 +10450,8 @@ spec:
                                                   PodSecurityContext, the value specified in SecurityContext takes precedence
                                                   for that container.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: integer
                                                 format: int64
+                                                type: integer
                                               seLinuxOptions:
                                                 description: |-
                                                   The SELinux context to be applied to all containers.
@@ -10000,7 +10460,6 @@ spec:
                                                   both SecurityContext and PodSecurityContext, the value specified in SecurityContext
                                                   takes precedence for that container.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: object
                                                 properties:
                                                   level:
                                                     description: Level is SELinux level label that applies to the container.
@@ -10014,13 +10473,11 @@ spec:
                                                   user:
                                                     description: User is a SELinux user label that applies to the container.
                                                     type: string
+                                                type: object
                                               seccompProfile:
                                                 description: |-
                                                   The seccomp options to use by the containers in this pod.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: object
-                                                required:
-                                                  - type
                                                 properties:
                                                   localhostProfile:
                                                     description: |-
@@ -10038,6 +10495,9 @@ spec:
                                                       RuntimeDefault - the container runtime default profile should be used.
                                                       Unconfined - no profile should be applied.
                                                     type: string
+                                                required:
+                                                  - type
+                                                type: object
                                               supplementalGroups:
                                                 description: |-
                                                   A list of groups applied to the first process run in each container, in addition
@@ -10047,22 +10507,18 @@ spec:
                                                   defined in the container image for the uid of the container process are still effective,
                                                   even if they are not included in this list.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: array
                                                 items:
-                                                  type: integer
                                                   format: int64
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               sysctls:
                                                 description: |-
                                                   Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
                                                   sysctls (by the container runtime) might fail to launch.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: array
                                                 items:
                                                   description: Sysctl defines a kernel parameter to be set
-                                                  type: object
-                                                  required:
-                                                    - name
-                                                    - value
                                                   properties:
                                                     name:
                                                       description: Name of a property to set
@@ -10070,17 +10526,22 @@ spec:
                                                     value:
                                                       description: Value of a property to set
                                                       type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
                                           serviceAccountName:
                                             description: If specified, the pod's service account
                                             type: string
                                           tolerations:
                                             description: If specified, the pod's tolerations.
-                                            type: array
                                             items:
                                               description: |-
                                                 The pod this Toleration is attached to tolerates any taint that matches
                                                 the triple <key,value,effect> using the matching operator <operator>.
-                                              type: object
                                               properties:
                                                 effect:
                                                   description: |-
@@ -10105,25 +10566,30 @@ spec:
                                                     of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                                                     it is not set, which means tolerate the taint forever (do not evict). Zero and
                                                     negative values will be treated as 0 (evict immediately) by the system.
-                                                  type: integer
                                                   format: int64
+                                                  type: integer
                                                 value:
                                                   description: |-
                                                     Value is the taint value the toleration matches to.
                                                     If the operator is Exists, the value should be empty, otherwise just a regular string.
                                                   type: string
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                    type: object
                                   serviceType:
                                     description: |-
                                       Optional service type for Kubernetes solver service. Supported values
                                       are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
+                                type: object
                               ingress:
                                 description: |-
                                   The ingress based HTTP01 challenge solver will solve challenges by
                                   creating or modifying Ingress resources in order to route requests for
                                   '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are
                                   provisioned by cert-manager for each Challenge to be completed.
-                                type: object
                                 properties:
                                   class:
                                     description: |-
@@ -10143,7 +10609,6 @@ spec:
                                     description: |-
                                       Optional ingress template used to configure the ACME challenge solver
                                       ingress used for HTTP01 challenges.
-                                    type: object
                                     properties:
                                       metadata:
                                         description: |-
@@ -10151,18 +10616,19 @@ spec:
                                           Only the 'labels' and 'annotations' fields may be set.
                                           If labels or annotations overlap with in-built values, the values here
                                           will override the in-built values.
-                                        type: object
                                         properties:
                                           annotations:
+                                            additionalProperties:
+                                              type: string
                                             description: Annotations that should be added to the created ACME HTTP01 solver ingress.
                                             type: object
+                                          labels:
                                             additionalProperties:
                                               type: string
-                                          labels:
                                             description: Labels that should be added to the created ACME HTTP01 solver ingress.
                                             type: object
-                                            additionalProperties:
-                                              type: string
+                                        type: object
+                                    type: object
                                   name:
                                     description: |-
                                       The name of the ingress resource that should have ACME challenge solving
@@ -10176,7 +10642,6 @@ spec:
                                     description: |-
                                       Optional pod template used to configure the ACME challenge solver pods
                                       used for HTTP01 challenges.
-                                    type: object
                                     properties:
                                       metadata:
                                         description: |-
@@ -10184,32 +10649,29 @@ spec:
                                           Only the 'labels' and 'annotations' fields may be set.
                                           If labels or annotations overlap with in-built values, the values here
                                           will override the in-built values.
-                                        type: object
                                         properties:
                                           annotations:
+                                            additionalProperties:
+                                              type: string
                                             description: Annotations that should be added to the created ACME HTTP01 solver pods.
                                             type: object
+                                          labels:
                                             additionalProperties:
                                               type: string
-                                          labels:
                                             description: Labels that should be added to the created ACME HTTP01 solver pods.
                                             type: object
-                                            additionalProperties:
-                                              type: string
+                                        type: object
                                       spec:
                                         description: |-
                                           PodSpec defines overrides for the HTTP01 challenge solver pod.
                                           Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
                                           All other fields will be ignored.
-                                        type: object
                                         properties:
                                           affinity:
                                             description: If specified, the pod's scheduling constraints
-                                            type: object
                                             properties:
                                               nodeAffinity:
                                                 description: Describes node affinity scheduling rules for the pod.
-                                                type: object
                                                 properties:
                                                   preferredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -10222,31 +10684,20 @@ spec:
                                                       compute a sum by iterating through the elements of this field and adding
                                                       "weight" to the sum if the node matches the corresponding matchExpressions; the
                                                       node(s) with the highest sum are the most preferred.
-                                                    type: array
                                                     items:
                                                       description: |-
                                                         An empty preferred scheduling term matches all objects with implicit weight 0
                                                         (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
-                                                      type: object
-                                                      required:
-                                                        - preference
-                                                        - weight
                                                       properties:
                                                         preference:
                                                           description: A node selector term, associated with the corresponding weight.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: A list of node selector requirements by node's labels.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A node selector requirement is a selector that contains values, a key, and an operator
                                                                   that relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: The label key that the selector applies to.
@@ -10263,22 +10714,22 @@ spec:
                                                                       the values array must be empty. If the operator is Gt or Lt, the values
                                                                       array must have a single element, which will be interpreted as an integer.
                                                                       This array is replaced during a strategic merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchFields:
                                                               description: A list of node selector requirements by node's fields.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A node selector requirement is a selector that contains values, a key, and an operator
                                                                   that relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: The label key that the selector applies to.
@@ -10295,16 +10746,27 @@ spec:
                                                                       the values array must be empty. If the operator is Gt or Lt, the values
                                                                       array must have a single element, which will be interpreted as an integer.
                                                                       This array is replaced during a strategic merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         weight:
                                                           description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
-                                                          type: integer
                                                           format: int32
+                                                          type: integer
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   requiredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -10313,31 +10775,21 @@ spec:
                                                       If the affinity requirements specified by this field cease to be met
                                                       at some point during pod execution (e.g. due to an update), the system
                                                       may or may not try to eventually evict the pod from its node.
-                                                    type: object
-                                                    required:
-                                                      - nodeSelectorTerms
                                                     properties:
                                                       nodeSelectorTerms:
                                                         description: Required. A list of node selector terms. The terms are ORed.
-                                                        type: array
                                                         items:
                                                           description: |-
                                                             A null or empty node selector term matches no objects. The requirements of
                                                             them are ANDed.
                                                             The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: A list of node selector requirements by node's labels.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A node selector requirement is a selector that contains values, a key, and an operator
                                                                   that relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: The label key that the selector applies to.
@@ -10354,22 +10806,22 @@ spec:
                                                                       the values array must be empty. If the operator is Gt or Lt, the values
                                                                       array must have a single element, which will be interpreted as an integer.
                                                                       This array is replaced during a strategic merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchFields:
                                                               description: A list of node selector requirements by node's fields.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A node selector requirement is a selector that contains values, a key, and an operator
                                                                   that relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: The label key that the selector applies to.
@@ -10386,17 +10838,27 @@ spec:
                                                                       the values array must be empty. If the operator is Gt or Lt, the values
                                                                       array must have a single element, which will be interpreted as an integer.
                                                                       This array is replaced during a strategic merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
+                                                        type: array
                                                         x-kubernetes-list-type: atomic
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    type: object
                                                     x-kubernetes-map-type: atomic
+                                                type: object
                                               podAffinity:
                                                 description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
-                                                type: object
                                                 properties:
                                                   preferredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -10409,37 +10871,23 @@ spec:
                                                       compute a sum by iterating through the elements of this field and adding
                                                       "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                       node(s) with the highest sum are the most preferred.
-                                                    type: array
                                                     items:
                                                       description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                                                      type: object
-                                                      required:
-                                                        - podAffinityTerm
-                                                        - weight
                                                       properties:
                                                         podAffinityTerm:
                                                           description: Required. A pod affinity term, associated with the corresponding weight.
-                                                          type: object
-                                                          required:
-                                                            - topologyKey
                                                           properties:
                                                             labelSelector:
                                                               description: |-
                                                                 A label query over a set of resources, in this case pods.
                                                                 If it's null, this PodAffinityTerm matches with no Pods.
-                                                              type: object
                                                               properties:
                                                                 matchExpressions:
                                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                                  type: array
                                                                   items:
                                                                     description: |-
                                                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                                                       relates the key and values.
-                                                                    type: object
-                                                                    required:
-                                                                      - key
-                                                                      - operator
                                                                     properties:
                                                                       key:
                                                                         description: key is the label key that the selector applies to.
@@ -10455,19 +10903,25 @@ spec:
                                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                           the values array must be empty. This array is replaced during a strategic
                                                                           merge patch.
-                                                                        type: array
                                                                         items:
                                                                           type: string
+                                                                        type: array
                                                                         x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
                                                                 matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
                                                                   description: |-
                                                                     matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                     map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                     operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                                   type: object
-                                                                  additionalProperties:
-                                                                    type: string
+                                                              type: object
                                                               x-kubernetes-map-type: atomic
                                                             matchLabelKeys:
                                                               description: |-
@@ -10479,10 +10933,9 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             mismatchLabelKeys:
                                                               description: |-
@@ -10494,10 +10947,9 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             namespaceSelector:
                                                               description: |-
@@ -10506,19 +10958,13 @@ spec:
                                                                 and the ones listed in the namespaces field.
                                                                 null selector and null or empty namespaces list means "this pod's namespace".
                                                                 An empty selector ({}) matches all namespaces.
-                                                              type: object
                                                               properties:
                                                                 matchExpressions:
                                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                                  type: array
                                                                   items:
                                                                     description: |-
                                                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                                                       relates the key and values.
-                                                                    type: object
-                                                                    required:
-                                                                      - key
-                                                                      - operator
                                                                     properties:
                                                                       key:
                                                                         description: key is the label key that the selector applies to.
@@ -10534,19 +10980,25 @@ spec:
                                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                           the values array must be empty. This array is replaced during a strategic
                                                                           merge patch.
-                                                                        type: array
                                                                         items:
                                                                           type: string
+                                                                        type: array
                                                                         x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
                                                                 matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
                                                                   description: |-
                                                                     matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                     map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                     operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                                   type: object
-                                                                  additionalProperties:
-                                                                    type: string
+                                                              type: object
                                                               x-kubernetes-map-type: atomic
                                                             namespaces:
                                                               description: |-
@@ -10554,9 +11006,9 @@ spec:
                                                                 The term is applied to the union of the namespaces listed in this field
                                                                 and the ones selected by namespaceSelector.
                                                                 null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             topologyKey:
                                                               description: |-
@@ -10566,12 +11018,20 @@ spec:
                                                                 selected pods is running.
                                                                 Empty topologyKey is not allowed.
                                                               type: string
+                                                          required:
+                                                            - topologyKey
+                                                          type: object
                                                         weight:
                                                           description: |-
                                                             weight associated with matching the corresponding podAffinityTerm,
                                                             in the range 1-100.
-                                                          type: integer
                                                           format: int32
+                                                          type: integer
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   requiredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -10582,7 +11042,6 @@ spec:
                                                       system may or may not try to eventually evict the pod from its node.
                                                       When there are multiple elements, the lists of nodes corresponding to each
                                                       podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                                                    type: array
                                                     items:
                                                       description: |-
                                                         Defines a set of pods (namely those matching the labelSelector
@@ -10591,27 +11050,18 @@ spec:
                                                         where co-located is defined as running on a node whose value of
                                                         the label with key <topologyKey> matches that of any node on which
                                                         a pod of the set of pods is running
-                                                      type: object
-                                                      required:
-                                                        - topologyKey
                                                       properties:
                                                         labelSelector:
                                                           description: |-
                                                             A label query over a set of resources, in this case pods.
                                                             If it's null, this PodAffinityTerm matches with no Pods.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                                   relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: key is the label key that the selector applies to.
@@ -10627,19 +11077,25 @@ spec:
                                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                       the values array must be empty. This array is replaced during a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: |-
                                                                 matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                 map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                 operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         matchLabelKeys:
                                                           description: |-
@@ -10651,10 +11107,9 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         mismatchLabelKeys:
                                                           description: |-
@@ -10666,10 +11121,9 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         namespaceSelector:
                                                           description: |-
@@ -10678,19 +11132,13 @@ spec:
                                                             and the ones listed in the namespaces field.
                                                             null selector and null or empty namespaces list means "this pod's namespace".
                                                             An empty selector ({}) matches all namespaces.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                                   relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: key is the label key that the selector applies to.
@@ -10706,19 +11154,25 @@ spec:
                                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                       the values array must be empty. This array is replaced during a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: |-
                                                                 matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                 map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                 operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         namespaces:
                                                           description: |-
@@ -10726,9 +11180,9 @@ spec:
                                                             The term is applied to the union of the namespaces listed in this field
                                                             and the ones selected by namespaceSelector.
                                                             null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         topologyKey:
                                                           description: |-
@@ -10738,10 +11192,14 @@ spec:
                                                             selected pods is running.
                                                             Empty topologyKey is not allowed.
                                                           type: string
+                                                      required:
+                                                        - topologyKey
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
+                                                type: object
                                               podAntiAffinity:
                                                 description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
-                                                type: object
                                                 properties:
                                                   preferredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -10751,40 +11209,26 @@ spec:
                                                       most preferred is the one with the greatest sum of weights, i.e.
                                                       for each node that meets all of the scheduling requirements (resource
                                                       request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                                      compute a sum by iterating through the elements of this field and adding
-                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      compute a sum by iterating through the elements of this field and subtracting
+                                                      "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                                                       node(s) with the highest sum are the most preferred.
-                                                    type: array
                                                     items:
                                                       description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                                                      type: object
-                                                      required:
-                                                        - podAffinityTerm
-                                                        - weight
                                                       properties:
                                                         podAffinityTerm:
                                                           description: Required. A pod affinity term, associated with the corresponding weight.
-                                                          type: object
-                                                          required:
-                                                            - topologyKey
                                                           properties:
                                                             labelSelector:
                                                               description: |-
                                                                 A label query over a set of resources, in this case pods.
                                                                 If it's null, this PodAffinityTerm matches with no Pods.
-                                                              type: object
                                                               properties:
                                                                 matchExpressions:
                                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                                  type: array
                                                                   items:
                                                                     description: |-
                                                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                                                       relates the key and values.
-                                                                    type: object
-                                                                    required:
-                                                                      - key
-                                                                      - operator
                                                                     properties:
                                                                       key:
                                                                         description: key is the label key that the selector applies to.
@@ -10800,19 +11244,25 @@ spec:
                                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                           the values array must be empty. This array is replaced during a strategic
                                                                           merge patch.
-                                                                        type: array
                                                                         items:
                                                                           type: string
+                                                                        type: array
                                                                         x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
                                                                 matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
                                                                   description: |-
                                                                     matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                     map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                     operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                                   type: object
-                                                                  additionalProperties:
-                                                                    type: string
+                                                              type: object
                                                               x-kubernetes-map-type: atomic
                                                             matchLabelKeys:
                                                               description: |-
@@ -10824,10 +11274,9 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             mismatchLabelKeys:
                                                               description: |-
@@ -10839,10 +11288,9 @@ spec:
                                                                 pod labels will be ignored. The default value is empty.
                                                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             namespaceSelector:
                                                               description: |-
@@ -10851,19 +11299,13 @@ spec:
                                                                 and the ones listed in the namespaces field.
                                                                 null selector and null or empty namespaces list means "this pod's namespace".
                                                                 An empty selector ({}) matches all namespaces.
-                                                              type: object
                                                               properties:
                                                                 matchExpressions:
                                                                   description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                                  type: array
                                                                   items:
                                                                     description: |-
                                                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                                                       relates the key and values.
-                                                                    type: object
-                                                                    required:
-                                                                      - key
-                                                                      - operator
                                                                     properties:
                                                                       key:
                                                                         description: key is the label key that the selector applies to.
@@ -10879,19 +11321,25 @@ spec:
                                                                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                           the values array must be empty. This array is replaced during a strategic
                                                                           merge patch.
-                                                                        type: array
                                                                         items:
                                                                           type: string
+                                                                        type: array
                                                                         x-kubernetes-list-type: atomic
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    type: object
+                                                                  type: array
                                                                   x-kubernetes-list-type: atomic
                                                                 matchLabels:
+                                                                  additionalProperties:
+                                                                    type: string
                                                                   description: |-
                                                                     matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                     map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                     operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                                   type: object
-                                                                  additionalProperties:
-                                                                    type: string
+                                                              type: object
                                                               x-kubernetes-map-type: atomic
                                                             namespaces:
                                                               description: |-
@@ -10899,9 +11347,9 @@ spec:
                                                                 The term is applied to the union of the namespaces listed in this field
                                                                 and the ones selected by namespaceSelector.
                                                                 null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                              type: array
                                                               items:
                                                                 type: string
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             topologyKey:
                                                               description: |-
@@ -10911,12 +11359,20 @@ spec:
                                                                 selected pods is running.
                                                                 Empty topologyKey is not allowed.
                                                               type: string
+                                                          required:
+                                                            - topologyKey
+                                                          type: object
                                                         weight:
                                                           description: |-
                                                             weight associated with matching the corresponding podAffinityTerm,
                                                             in the range 1-100.
-                                                          type: integer
                                                           format: int32
+                                                          type: integer
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
                                                   requiredDuringSchedulingIgnoredDuringExecution:
                                                     description: |-
@@ -10927,7 +11383,6 @@ spec:
                                                       system may or may not try to eventually evict the pod from its node.
                                                       When there are multiple elements, the lists of nodes corresponding to each
                                                       podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                                                    type: array
                                                     items:
                                                       description: |-
                                                         Defines a set of pods (namely those matching the labelSelector
@@ -10936,27 +11391,18 @@ spec:
                                                         where co-located is defined as running on a node whose value of
                                                         the label with key <topologyKey> matches that of any node on which
                                                         a pod of the set of pods is running
-                                                      type: object
-                                                      required:
-                                                        - topologyKey
                                                       properties:
                                                         labelSelector:
                                                           description: |-
                                                             A label query over a set of resources, in this case pods.
                                                             If it's null, this PodAffinityTerm matches with no Pods.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                                   relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: key is the label key that the selector applies to.
@@ -10972,19 +11418,25 @@ spec:
                                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                       the values array must be empty. This array is replaced during a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: |-
                                                                 matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                 map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                 operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         matchLabelKeys:
                                                           description: |-
@@ -10996,10 +11448,9 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         mismatchLabelKeys:
                                                           description: |-
@@ -11011,10 +11462,9 @@ spec:
                                                             pod labels will be ignored. The default value is empty.
                                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         namespaceSelector:
                                                           description: |-
@@ -11023,19 +11473,13 @@ spec:
                                                             and the ones listed in the namespaces field.
                                                             null selector and null or empty namespaces list means "this pod's namespace".
                                                             An empty selector ({}) matches all namespaces.
-                                                          type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                                              type: array
                                                               items:
                                                                 description: |-
                                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                                   relates the key and values.
-                                                                type: object
-                                                                required:
-                                                                  - key
-                                                                  - operator
                                                                 properties:
                                                                   key:
                                                                     description: key is the label key that the selector applies to.
@@ -11051,19 +11495,25 @@ spec:
                                                                       the values array must be non-empty. If the operator is Exists or DoesNotExist,
                                                                       the values array must be empty. This array is replaced during a strategic
                                                                       merge patch.
-                                                                    type: array
                                                                     items:
                                                                       type: string
+                                                                    type: array
                                                                     x-kubernetes-list-type: atomic
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                type: object
+                                                              type: array
                                                               x-kubernetes-list-type: atomic
                                                             matchLabels:
+                                                              additionalProperties:
+                                                                type: string
                                                               description: |-
                                                                 matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
                                                                 map is equivalent to an element of matchExpressions, whose key field is "key", the
                                                                 operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                               type: object
-                                                              additionalProperties:
-                                                                type: string
+                                                          type: object
                                                           x-kubernetes-map-type: atomic
                                                         namespaces:
                                                           description: |-
@@ -11071,9 +11521,9 @@ spec:
                                                             The term is applied to the union of the namespaces listed in this field
                                                             and the ones selected by namespaceSelector.
                                                             null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                                          type: array
                                                           items:
                                                             type: string
+                                                          type: array
                                                           x-kubernetes-list-type: atomic
                                                         topologyKey:
                                                           description: |-
@@ -11083,17 +11533,22 @@ spec:
                                                             selected pods is running.
                                                             Empty topologyKey is not allowed.
                                                           type: string
+                                                      required:
+                                                        - topologyKey
+                                                      type: object
+                                                    type: array
                                                     x-kubernetes-list-type: atomic
+                                                type: object
+                                            type: object
                                           imagePullSecrets:
                                             description: If specified, the pod's imagePullSecrets
-                                            type: array
                                             items:
                                               description: |-
                                                 LocalObjectReference contains enough information to let you locate the
                                                 referenced object inside the same namespace.
-                                              type: object
                                               properties:
                                                 name:
+                                                  default: ""
                                                   description: |-
                                                     Name of the referent.
                                                     This field is effectively required, but due to backwards compatibility is
@@ -11101,22 +11556,59 @@ spec:
                                                     almost certainly wrong.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                                   type: string
-                                                  default: ""
+                                              type: object
                                               x-kubernetes-map-type: atomic
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
                                           nodeSelector:
+                                            additionalProperties:
+                                              type: string
                                             description: |-
                                               NodeSelector is a selector which must be true for the pod to fit on a node.
                                               Selector which must match a node's labels for the pod to be scheduled on that node.
                                               More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                                             type: object
-                                            additionalProperties:
-                                              type: string
                                           priorityClassName:
                                             description: If specified, the pod's priorityClassName.
                                             type: string
+                                          resources:
+                                            description: |-
+                                              If specified, the pod's resource requirements.
+                                              These values override the global resource configuration flags.
+                                              Note that when only specifying resource limits, ensure they are greater than or equal
+                                              to the corresponding global resource requests configured via controller flags
+                                              (--acme-http01-solver-resource-request-cpu, --acme-http01-solver-resource-request-memory).
+                                              Kubernetes will reject pod creation if limits are lower than requests, causing challenge failures.
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Requests describes the minimum amount of compute resources required.
+                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                  otherwise to the global values configured via controller flags. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                            type: object
                                           securityContext:
                                             description: If specified, the pod's security context
-                                            type: object
                                             properties:
                                               fsGroup:
                                                 description: |-
@@ -11130,8 +11622,8 @@ spec:
 
                                                   If unset, the Kubelet will not modify the ownership and permissions of any volume.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: integer
                                                 format: int64
+                                                type: integer
                                               fsGroupChangePolicy:
                                                 description: |-
                                                   fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
@@ -11150,8 +11642,8 @@ spec:
                                                   PodSecurityContext, the value specified in SecurityContext takes precedence
                                                   for that container.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: integer
                                                 format: int64
+                                                type: integer
                                               runAsNonRoot:
                                                 description: |-
                                                   Indicates that the container must run as a non-root user.
@@ -11169,8 +11661,8 @@ spec:
                                                   PodSecurityContext, the value specified in SecurityContext takes precedence
                                                   for that container.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: integer
                                                 format: int64
+                                                type: integer
                                               seLinuxOptions:
                                                 description: |-
                                                   The SELinux context to be applied to all containers.
@@ -11179,7 +11671,6 @@ spec:
                                                   both SecurityContext and PodSecurityContext, the value specified in SecurityContext
                                                   takes precedence for that container.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: object
                                                 properties:
                                                   level:
                                                     description: Level is SELinux level label that applies to the container.
@@ -11193,13 +11684,11 @@ spec:
                                                   user:
                                                     description: User is a SELinux user label that applies to the container.
                                                     type: string
+                                                type: object
                                               seccompProfile:
                                                 description: |-
                                                   The seccomp options to use by the containers in this pod.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: object
-                                                required:
-                                                  - type
                                                 properties:
                                                   localhostProfile:
                                                     description: |-
@@ -11217,6 +11706,9 @@ spec:
                                                       RuntimeDefault - the container runtime default profile should be used.
                                                       Unconfined - no profile should be applied.
                                                     type: string
+                                                required:
+                                                  - type
+                                                type: object
                                               supplementalGroups:
                                                 description: |-
                                                   A list of groups applied to the first process run in each container, in addition
@@ -11226,22 +11718,18 @@ spec:
                                                   defined in the container image for the uid of the container process are still effective,
                                                   even if they are not included in this list.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: array
                                                 items:
-                                                  type: integer
                                                   format: int64
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: atomic
                                               sysctls:
                                                 description: |-
                                                   Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
                                                   sysctls (by the container runtime) might fail to launch.
                                                   Note that this field cannot be set when spec.os.name is windows.
-                                                type: array
                                                 items:
                                                   description: Sysctl defines a kernel parameter to be set
-                                                  type: object
-                                                  required:
-                                                    - name
-                                                    - value
                                                   properties:
                                                     name:
                                                       description: Name of a property to set
@@ -11249,17 +11737,22 @@ spec:
                                                     value:
                                                       description: Value of a property to set
                                                       type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
                                           serviceAccountName:
                                             description: If specified, the pod's service account
                                             type: string
                                           tolerations:
                                             description: If specified, the pod's tolerations.
-                                            type: array
                                             items:
                                               description: |-
                                                 The pod this Toleration is attached to tolerates any taint that matches
                                                 the triple <key,value,effect> using the matching operator <operator>.
-                                              type: object
                                               properties:
                                                 effect:
                                                   description: |-
@@ -11284,18 +11777,25 @@ spec:
                                                     of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                                                     it is not set, which means tolerate the taint forever (do not evict). Zero and
                                                     negative values will be treated as 0 (evict immediately) by the system.
-                                                  type: integer
                                                   format: int64
+                                                  type: integer
                                                 value:
                                                   description: |-
                                                     Value is the taint value the toleration matches to.
                                                     If the operator is Exists, the value should be empty, otherwise just a regular string.
                                                   type: string
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                    type: object
                                   serviceType:
                                     description: |-
                                       Optional service type for Kubernetes solver service. Supported values
                                       are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
+                                type: object
+                            type: object
                           selector:
                             description: |-
                               Selector selects a set of DNSNames on the Certificate resource that
@@ -11303,7 +11803,6 @@ spec:
                               If not specified, the solver will be treated as the 'default' solver
                               with the lowest priority, i.e. if any other solver has a more specific
                               match, it will be used instead.
-                            type: object
                             properties:
                               dnsNames:
                                 description: |-
@@ -11314,9 +11813,10 @@ spec:
                                   with the most matching labels in matchLabels will be selected.
                                   If neither has more matches, the solver defined earlier in the list
                                   will be selected.
-                                type: array
                                 items:
                                   type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
                               dnsZones:
                                 description: |-
                                   List of DNSZones that this solver will be used to solve.
@@ -11328,41 +11828,49 @@ spec:
                                   with the most matching labels in matchLabels will be selected.
                                   If neither has more matches, the solver defined earlier in the list
                                   will be selected.
-                                type: array
                                 items:
                                   type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
                               matchLabels:
+                                additionalProperties:
+                                  type: string
                                 description: |-
                                   A label selector that is used to refine the set of certificate's that
                                   this challenge solver will apply to.
                                 type: object
-                                additionalProperties:
-                                  type: string
+                            type: object
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  type: object
                 ca:
                   description: |-
                     CA configures this issuer to sign certificates using a signing CA keypair
                     stored in a Secret resource.
                     This is used to build internal PKIs that are managed by cert-manager.
-                  type: object
-                  required:
-                    - secretName
                   properties:
                     crlDistributionPoints:
                       description: |-
                         The CRL distribution points is an X.509 v3 certificate extension which identifies
                         the location of the CRL from which the revocation of this certificate can be checked.
                         If not set, certificates will be issued without distribution points set.
-                      type: array
                       items:
                         type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     issuingCertificateURLs:
                       description: |-
                         IssuingCertificateURLs is a list of URLs which this issuer should embed into certificates
                         it creates. See https://www.rfc-editor.org/rfc/rfc5280#section-4.2.2.1 for more details.
                         As an example, such a URL might be "http://ca.domain.com/ca.crt".
-                      type: array
                       items:
                         type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     ocspServers:
                       description: |-
                         The OCSP server list is an X.509 v3 extension that defines a list of
@@ -11370,51 +11878,45 @@ spec:
                         revocation status of an issued certificate. If not set, the
                         certificate will be issued with no OCSP servers set. For example, an
                         OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
-                      type: array
                       items:
                         type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     secretName:
                       description: |-
                         SecretName is the name of the secret used to sign Certificates issued
                         by this Issuer.
                       type: string
+                  required:
+                    - secretName
+                  type: object
                 selfSigned:
                   description: |-
                     SelfSigned configures this issuer to 'self sign' certificates using the
                     private key used to create the CertificateRequest object.
-                  type: object
                   properties:
                     crlDistributionPoints:
                       description: |-
                         The CRL distribution points is an X.509 v3 certificate extension which identifies
                         the location of the CRL from which the revocation of this certificate can be checked.
                         If not set certificate will be issued without CDP. Values are strings.
-                      type: array
                       items:
                         type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
                 vault:
                   description: |-
                     Vault configures this issuer to sign certificates using a HashiCorp Vault
                     PKI backend.
-                  type: object
-                  required:
-                    - auth
-                    - path
-                    - server
                   properties:
                     auth:
                       description: Auth configures how cert-manager authenticates with the Vault server.
-                      type: object
                       properties:
                         appRole:
                           description: |-
                             AppRole authenticates with Vault using the App Role auth mechanism,
                             with the role and secret stored in a Kubernetes Secret resource.
-                          type: object
-                          required:
-                            - path
-                            - roleId
-                            - secretRef
                           properties:
                             path:
                               description: |-
@@ -11432,9 +11934,6 @@ spec:
                                 to authenticate with Vault.
                                 The `key` field must be specified and denotes which entry within the Secret
                                 resource is used as the app role secret.
-                              type: object
-                              required:
-                                - name
                               properties:
                                 key:
                                   description: |-
@@ -11447,12 +11946,19 @@ spec:
                                     Name of the resource being referred to.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          type: object
                         clientCertificate:
                           description: |-
                             ClientCertificate authenticates with Vault by presenting a client
                             certificate during the request's TLS handshake.
                             Works only when using HTTPS protocol.
-                          type: object
                           properties:
                             mountPath:
                               description: |-
@@ -11472,13 +11978,11 @@ spec:
                                 tls.crt and tls.key) used to authenticate to Vault using TLS client
                                 authentication.
                               type: string
+                          type: object
                         kubernetes:
                           description: |-
                             Kubernetes authenticates with Vault by passing the ServiceAccount
                             token stored in the named Secret resource to the Vault server.
-                          type: object
-                          required:
-                            - role
                           properties:
                             mountPath:
                               description: |-
@@ -11497,9 +12001,6 @@ spec:
                                 The required Secret field containing a Kubernetes ServiceAccount JWT used
                                 for authenticating with Vault. Use of 'ambient credentials' is not
                                 supported.
-                              type: object
-                              required:
-                                - name
                               properties:
                                 key:
                                   description: |-
@@ -11512,6 +12013,9 @@ spec:
                                     Name of the resource being referred to.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
+                              required:
+                                - name
+                              type: object
                             serviceAccountRef:
                               description: |-
                                 A reference to a service account that will be used to request a bound
@@ -11519,25 +12023,26 @@ spec:
                                 using this field means that you don't rely on statically bound tokens. To
                                 use this field, you must configure an RBAC rule to let cert-manager
                                 request a token.
-                              type: object
-                              required:
-                                - name
                               properties:
                                 audiences:
                                   description: |-
                                     TokenAudiences is an optional list of extra audiences to include in the token passed to Vault. The default token
                                     consisting of the issuer's namespace and name is always included.
-                                  type: array
                                   items:
                                     type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 name:
                                   description: Name of the ServiceAccount used to request a token.
                                   type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - role
+                          type: object
                         tokenSecretRef:
                           description: TokenSecretRef authenticates with Vault by presenting a token.
-                          type: object
-                          required:
-                            - name
                           properties:
                             key:
                               description: |-
@@ -11550,6 +12055,10 @@ spec:
                                 Name of the resource being referred to.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
+                          required:
+                            - name
+                          type: object
+                      type: object
                     caBundle:
                       description: |-
                         Base64-encoded bundle of PEM CAs which will be used to validate the certificate
@@ -11558,8 +12067,8 @@ spec:
                         Mutually exclusive with CABundleSecretRef.
                         If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in
                         the cert-manager controller container is used to validate the TLS connection.
-                      type: string
                       format: byte
+                      type: string
                     caBundleSecretRef:
                       description: |-
                         Reference to a Secret containing a bundle of PEM-encoded CAs to use when
@@ -11568,9 +12077,6 @@ spec:
                         If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in
                         the cert-manager controller container is used to validate the TLS connection.
                         If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
-                      type: object
-                      required:
-                        - name
                       properties:
                         key:
                           description: |-
@@ -11583,13 +12089,13 @@ spec:
                             Name of the resource being referred to.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                           type: string
+                      required:
+                        - name
+                      type: object
                     clientCertSecretRef:
                       description: |-
                         Reference to a Secret containing a PEM-encoded Client Certificate to use when the
                         Vault server requires mTLS.
-                      type: object
-                      required:
-                        - name
                       properties:
                         key:
                           description: |-
@@ -11602,13 +12108,13 @@ spec:
                             Name of the resource being referred to.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                           type: string
+                      required:
+                        - name
+                      type: object
                     clientKeySecretRef:
                       description: |-
                         Reference to a Secret containing a PEM-encoded Client Private Key to use when the
                         Vault server requires mTLS.
-                      type: object
-                      required:
-                        - name
                       properties:
                         key:
                           description: |-
@@ -11621,6 +12127,9 @@ spec:
                             Name of the resource being referred to.
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                           type: string
+                      required:
+                        - name
+                      type: object
                     namespace:
                       description: |-
                         Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1"
@@ -11639,27 +12148,23 @@ spec:
                         ServerName is used to verify the hostname on the returned certificates
                         by the Vault server.
                       type: string
+                  required:
+                    - auth
+                    - path
+                    - server
+                  type: object
                 venafi:
                   description: |-
                     Venafi configures this issuer to sign certificates using a Venafi TPP
                     or Venafi Cloud policy zone.
-                  type: object
-                  required:
-                    - zone
                   properties:
                     cloud:
                       description: |-
                         Cloud specifies the Venafi cloud configuration settings.
                         Only one of TPP or Cloud may be specified.
-                      type: object
-                      required:
-                        - apiTokenSecretRef
                       properties:
                         apiTokenSecretRef:
                           description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
-                          type: object
-                          required:
-                            - name
                           properties:
                             key:
                               description: |-
@@ -11672,19 +12177,21 @@ spec:
                                 Name of the resource being referred to.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
+                          required:
+                            - name
+                          type: object
                         url:
                           description: |-
                             URL is the base URL for Venafi Cloud.
                             Defaults to "https://api.venafi.cloud/".
                           type: string
+                      required:
+                        - apiTokenSecretRef
+                      type: object
                     tpp:
                       description: |-
                         TPP specifies Trust Protection Platform configuration settings.
                         Only one of TPP or Cloud may be specified.
-                      type: object
-                      required:
-                        - credentialsRef
-                        - url
                       properties:
                         caBundle:
                           description: |-
@@ -11692,8 +12199,8 @@ spec:
                             chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP.
                             If undefined, the certificate bundle in the cert-manager controller container
                             is used to validate the chain.
-                          type: string
                           format: byte
+                          type: string
                         caBundleSecretRef:
                           description: |-
                             Reference to a Secret containing a base64-encoded bundle of PEM CAs
@@ -11701,9 +12208,6 @@ spec:
                             Only used if using HTTPS; ignored for HTTP. Mutually exclusive with CABundle.
                             If neither CABundle nor CABundleSecretRef is defined, the certificate bundle in
                             the cert-manager controller container is used to validate the TLS connection.
-                          type: object
-                          required:
-                            - name
                           properties:
                             key:
                               description: |-
@@ -11716,25 +12220,32 @@ spec:
                                 Name of the resource being referred to.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
+                          required:
+                            - name
+                          type: object
                         credentialsRef:
                           description: |-
                             CredentialsRef is a reference to a Secret containing the Venafi TPP API credentials.
                             The secret must contain the key 'access-token' for the Access Token Authentication,
                             or two keys, 'username' and 'password' for the API Keys Authentication.
-                          type: object
-                          required:
-                            - name
                           properties:
                             name:
                               description: |-
                                 Name of the resource being referred to.
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
+                          required:
+                            - name
+                          type: object
                         url:
                           description: |-
                             URL is the base URL for the vedsdk endpoint of the Venafi TPP instance,
                             for example: "https://tpp.example.com/vedsdk".
                           type: string
+                      required:
+                        - credentialsRef
+                        - url
+                      type: object
                     zone:
                       description: |-
                         Zone is the Venafi Policy Zone to use for this issuer.
@@ -11742,16 +12253,18 @@ spec:
                         zone policy.
                         This field is required.
                       type: string
+                  required:
+                    - zone
+                  type: object
+              type: object
             status:
               description: Status of the Issuer. This is set and managed automatically.
-              type: object
               properties:
                 acme:
                   description: |-
                     ACME specific status options.
                     This field should only be set if the Issuer is configured to use an ACME
                     server to issue certificates.
-                  type: object
                   properties:
                     lastPrivateKeyHash:
                       description: |-
@@ -11770,24 +12283,20 @@ spec:
                         URI is the unique account identifier, which can also be used to retrieve
                         account details from the CA
                       type: string
+                  type: object
                 conditions:
                   description: |-
                     List of status conditions to indicate the status of a CertificateRequest.
                     Known condition types are `Ready`.
-                  type: array
                   items:
                     description: IssuerCondition contains condition information for an Issuer.
-                    type: object
-                    required:
-                      - status
-                      - type
                     properties:
                       lastTransitionTime:
                         description: |-
                           LastTransitionTime is the timestamp corresponding to the last status
                           change of this condition.
-                        type: string
                         format: date-time
+                        type: string
                       message:
                         description: |-
                           Message is a human readable description of the details of the last
@@ -11800,8 +12309,8 @@ spec:
                           For instance, if .metadata.generation is currently 12, but the
                           .status.condition[x].observedGeneration is 9, the condition is out of date
                           with respect to the current state of the Issuer.
-                        type: integer
                         format: int64
+                        type: integer
                       reason:
                         description: |-
                           Reason is a brief machine readable explanation for the condition's last
@@ -11809,292 +12318,27 @@ spec:
                         type: string
                       status:
                         description: Status of the condition, one of (`True`, `False`, `Unknown`).
-                        type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
+                        type: string
                       type:
                         description: Type of the condition, known values are (`Ready`).
                         type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
+              type: object
+          required:
+            - spec
+          type: object
       served: true
       storage: true
-
-# END crd
----
-# Source: cert-manager/templates/crds.yaml
-# START crd
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: orders.acme.cert-manager.io
-  # START annotations
-  annotations:
-    helm.sh/resource-policy: keep
-  # END annotations
-  labels:
-    app: 'cert-manager'
-    app.kubernetes.io/name: 'cert-manager'
-    app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/component: "crds"
-    # Generated labels
-    app.kubernetes.io/version: "v1.18.2"
-spec:
-  group: acme.cert-manager.io
-  names:
-    kind: Order
-    listKind: OrderList
-    plural: orders
-    singular: order
-    categories:
-      - cert-manager
-      - cert-manager-acme
-  scope: Namespaced
-  versions:
-    - name: v1
       subresources:
         status: {}
-      additionalPrinterColumns:
-        - jsonPath: .status.state
-          name: State
-          type: string
-        - jsonPath: .spec.issuerRef.name
-          name: Issuer
-          priority: 1
-          type: string
-        - jsonPath: .status.reason
-          name: Reason
-          priority: 1
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-          name: Age
-          type: date
-      schema:
-        openAPIV3Schema:
-          description: Order is a type to represent an Order with an ACME server
-          type: object
-          required:
-            - metadata
-            - spec
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              type: object
-              required:
-                - issuerRef
-                - request
-              properties:
-                commonName:
-                  description: |-
-                    CommonName is the common name as specified on the DER encoded CSR.
-                    If specified, this value must also be present in `dnsNames` or `ipAddresses`.
-                    This field must match the corresponding field on the DER encoded CSR.
-                  type: string
-                dnsNames:
-                  description: |-
-                    DNSNames is a list of DNS names that should be included as part of the Order
-                    validation process.
-                    This field must match the corresponding field on the DER encoded CSR.
-                  type: array
-                  items:
-                    type: string
-                duration:
-                  description: |-
-                    Duration is the duration for the not after date for the requested certificate.
-                    this is set on order creation as pe the ACME spec.
-                  type: string
-                ipAddresses:
-                  description: |-
-                    IPAddresses is a list of IP addresses that should be included as part of the Order
-                    validation process.
-                    This field must match the corresponding field on the DER encoded CSR.
-                  type: array
-                  items:
-                    type: string
-                issuerRef:
-                  description: |-
-                    IssuerRef references a properly configured ACME-type Issuer which should
-                    be used to create this Order.
-                    If the Issuer does not exist, processing will be retried.
-                    If the Issuer is not an 'ACME' Issuer, an error will be returned and the
-                    Order will be marked as failed.
-                  type: object
-                  required:
-                    - name
-                  properties:
-                    group:
-                      description: Group of the resource being referred to.
-                      type: string
-                    kind:
-                      description: Kind of the resource being referred to.
-                      type: string
-                    name:
-                      description: Name of the resource being referred to.
-                      type: string
-                profile:
-                  description: |-
-                    Profile allows requesting a certificate profile from the ACME server.
-                    Supported profiles are listed by the server's ACME directory URL.
-                  type: string
-                request:
-                  description: |-
-                    Certificate signing request bytes in DER encoding.
-                    This will be used when finalizing the order.
-                    This field must be set on the order.
-                  type: string
-                  format: byte
-            status:
-              type: object
-              properties:
-                authorizations:
-                  description: |-
-                    Authorizations contains data returned from the ACME server on what
-                    authorizations must be completed in order to validate the DNS names
-                    specified on the Order.
-                  type: array
-                  items:
-                    description: |-
-                      ACMEAuthorization contains data returned from the ACME server on an
-                      authorization that must be completed in order validate a DNS name on an ACME
-                      Order resource.
-                    type: object
-                    required:
-                      - url
-                    properties:
-                      challenges:
-                        description: |-
-                          Challenges specifies the challenge types offered by the ACME server.
-                          One of these challenge types will be selected when validating the DNS
-                          name and an appropriate Challenge resource will be created to perform
-                          the ACME challenge process.
-                        type: array
-                        items:
-                          description: |-
-                            Challenge specifies a challenge offered by the ACME server for an Order.
-                            An appropriate Challenge resource can be created to perform the ACME
-                            challenge process.
-                          type: object
-                          required:
-                            - token
-                            - type
-                            - url
-                          properties:
-                            token:
-                              description: |-
-                                Token is the token that must be presented for this challenge.
-                                This is used to compute the 'key' that must also be presented.
-                              type: string
-                            type:
-                              description: |-
-                                Type is the type of challenge being offered, e.g., 'http-01', 'dns-01',
-                                'tls-sni-01', etc.
-                                This is the raw value retrieved from the ACME server.
-                                Only 'http-01' and 'dns-01' are supported by cert-manager, other values
-                                will be ignored.
-                              type: string
-                            url:
-                              description: |-
-                                URL is the URL of this challenge. It can be used to retrieve additional
-                                metadata about the Challenge from the ACME server.
-                              type: string
-                      identifier:
-                        description: Identifier is the DNS name to be validated as part of this authorization
-                        type: string
-                      initialState:
-                        description: |-
-                          InitialState is the initial state of the ACME authorization when first
-                          fetched from the ACME server.
-                          If an Authorization is already 'valid', the Order controller will not
-                          create a Challenge resource for the authorization. This will occur when
-                          working with an ACME server that enables 'authz reuse' (such as Let's
-                          Encrypt's production endpoint).
-                          If not set and 'identifier' is set, the state is assumed to be pending
-                          and a Challenge will be created.
-                        type: string
-                        enum:
-                          - valid
-                          - ready
-                          - pending
-                          - processing
-                          - invalid
-                          - expired
-                          - errored
-                      url:
-                        description: URL is the URL of the Authorization that must be completed
-                        type: string
-                      wildcard:
-                        description: |-
-                          Wildcard will be true if this authorization is for a wildcard DNS name.
-                          If this is true, the identifier will be the *non-wildcard* version of
-                          the DNS name.
-                          For example, if '*.example.com' is the DNS name being validated, this
-                          field will be 'true' and the 'identifier' field will be 'example.com'.
-                        type: boolean
-                certificate:
-                  description: |-
-                    Certificate is a copy of the PEM encoded certificate for this Order.
-                    This field will be populated after the order has been successfully
-                    finalized with the ACME server, and the order has transitioned to the
-                    'valid' state.
-                  type: string
-                  format: byte
-                failureTime:
-                  description: |-
-                    FailureTime stores the time that this order failed.
-                    This is used to influence garbage collection and back-off.
-                  type: string
-                  format: date-time
-                finalizeURL:
-                  description: |-
-                    FinalizeURL of the Order.
-                    This is used to obtain certificates for this order once it has been completed.
-                  type: string
-                reason:
-                  description: |-
-                    Reason optionally provides more information about a why the order is in
-                    the current state.
-                  type: string
-                state:
-                  description: |-
-                    State contains the current state of this Order resource.
-                    States 'success' and 'expired' are 'final'
-                  type: string
-                  enum:
-                    - valid
-                    - ready
-                    - pending
-                    - processing
-                    - invalid
-                    - expired
-                    - errored
-                url:
-                  description: |-
-                    URL of the Order.
-                    This will initially be empty when the resource is first created.
-                    The Order controller will populate this field when the Order is first processed.
-                    This field will be immutable after it is initially set.
-                  type: string
-      served: true
-      storage: true
-
-# END crd


### PR DESCRIPTION
## What

cert-manager **v1.18.2 → v1.19.6**, plus the vendored `crds.yaml` re-fetched at the matching version.

**This is hop 1 of 3.** See the sequence below.

## Why now

We are running an **EOL cert-manager, two minor versions outside its supported Kubernetes range**:

| version | k8s support | status |
|---|---|---|
| **v1.18 (ours)** | 1.29 → 1.33 | **EOL since 2026-03-10** |
| v1.19 | 1.31 → 1.35 | EOL 2026-07-08 |
| v1.20 | 1.32 → 1.35 | supported |
| v1.21 | 1.33 → 1.36 | supported |

Our cluster is **1.35**.

## Why staged rather than one jump to v1.21.1

Upstream is explicit: *"upgrade cert-manager one minor version at a time, always choosing the latest patch version."*

The rendered diff across the whole 1.18→1.21 span is only three items, so a single hop would very likely work — but Let's Encrypt rate limits (50 certs/domain/week) make an accidental mass re-issuance genuinely expensive. Not worth the gamble.

Planned sequence, each landing in dev and soaking before the next:
1. **v1.18.2 → v1.19.6** ← this PR
2. v1.19.6 → v1.20.3
3. v1.20.3 → v1.21.1

`v1.19.0` is deliberately skipped — it re-issues certificates unnecessarily.

## Verification

- Confirmed the existing vendored `crds.yaml` was **byte-identical** to the upstream v1.18.2 release asset, so re-fetching at v1.19.6 is a clean swap rather than a merge.
- New file has the **same 6 CRDs, all `v1` served + storage** — no API version change, no conversion, no stored-object migration.
- `helm template` renders clean on both versions with our values.
- **All three Deployment selectors identical** (controller, webhook, cainjector) — no immutable-field rejection.
- `installCRDs: false` still honoured in 1.19.6 (deprecated but functional).
- Pod labels unchanged, so `network-policy.yaml`'s `podSelector` still matches — a silent break there would have killed ACME egress.

## Ordering

CRDs must be applied before the chart. Our layout already does this: `crds.yaml` and the HelmRelease are in the same Flux Kustomization, and kustomize-controller applies CRDs before other kinds. Single commit is safe.

## Separate follow-ups, not in this PR

- `post-install-job.yaml` **has never worked and cannot** — it carries `helm.sh/hook` annotations while being applied by Kustomize (inert), a Job's template is immutable so it ran once at creation, and `namespace.yaml:8` sets `cert-manager.io/disable-validation: "true"` which Flux re-applies every 5 minutes, overwriting it. Recommend deleting the job and the annotation; that also removes our `bitnami/kubectl:latest` dependency.
- `cert-manager.yaml` and `helm-repo-jetstack.yaml` are the last two deprecated Flux APIs in the repo (`v2beta1` / `v1beta2`).
- `README.md:16` still claims v1.13.3.



---

## ✅ Dev-validert 2026-08-06

- HelmRelease **v1.18.2 → v1.19.6**, Ready
- Alle tre komponenter rullet: controller, cainjector, webhook — alle på `v1.19.6`, gamle poder borte
- Vendorede CRD-er erstattet, merket `app.kubernetes.io/version: v1.19.6`, `v1` fortsatt eneste serverte versjon

### Ingen re-utstedelse av sertifikater — det var hele poenget med å gå trinnvis

Alle fire sertifikater beholdt nøyaktig sin `renewalTime` fra før oppgraderingen:

```
demo/data-service-catalog-api-tls      2026-09-25T08:32:35Z   (uendret)
demo/keycloak-internal-tls             2026-09-02T09:20:57Z   (uendret)
staging/data-service-catalog-api-tls   2026-09-25T08:32:35Z   (uendret)
staging/keycloak-internal-tls          2026-09-02T07:15:19Z   (uendret)
```

Begge ClusterIssuers (`letsencrypt-dev`, `selfsigned-issuer`) forble Ready gjennom hele rulleringen. Ingen Let's Encrypt rate limit-eksponering.

Steg 2 og 3 (v1.20.3, v1.21.1) spores i #350.
