### PR TITLE
chore: bump kube-prometheus-stack to 88.x

### DIFF
--- a/infrastructure/base/monitoring/helm-release-prometheus.yaml
+++ b/infrastructure/base/monitoring/helm-release-prometheus.yaml
@@ -9,7 +9,7 @@ spec:
   targetNamespace: monitoring
   chart:
     spec:
-      version: 72.x
+      version: 88.x
       chart: kube-prometheus-stack
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
## What

`kube-prometheus-stack` **72.x → 88.x** (72.9.1 → 88.1.5). One-line pin change.

16 majors, but a single hop is safe — see below.

## Component versions crossed

| component | from | to |
|---|---|---|
| prometheus-operator | v0.82.2 | v0.93.0 |
| Prometheus | v3.4.1 | v3.13.2-distroless |
| Alertmanager | v0.28.1 | v0.33.1 |
| Grafana | 12.0.0 | 13.1.2 |
| kube-state-metrics | v2.15.0 | v2.19.1 |
| node-exporter | v1.9.1 | v1.12.1-distroless |

## Why one hop is safe

Both charts were rendered with our **full merged values** — base, both `valuesFrom` secrets, and the dev/prod overlay patches. Every rendered-object diff is confined to image tags, labels and additive fields. **No values key we set is removed or renamed anywhere between 72 and 88.**

Breaking changes checked against our config:

| ver | change | us |
|---|---|---|
| 73 | drops PSP + `global.pspEnabled`; min k8s 1.25 | not set; on 1.35 |
| 75 | `additionalPrometheusRules*` re-prefixed `name` → `fullname` | key unused |
| 79 | removes hardcoded Grafana admin password | we inject via `valuesFrom` secret |
| 84/85 | Grafana v13; distroless image defaults | runtime only |

Sub-chart majors also checked: KSM 5.33 → 8.1.3 (drops PSP, `networkPolicy.flavor` — neither used), Grafana chart 9.2.1 → 12.10.3 (none of the changed keys used).

## Verification

- Renders clean on both versions.
- **All 4 workload selectors identical** (operator, grafana, KSM, node-exporter) — no immutable-field rejection.
- Service names other components hardcode are intact: `monitoring-kube-prometheus-thanos-discovery` (referenced by `helm-release-thanos.yaml:34`) and `monitoring-kube-prometheus-alertmanager` (by `karma.yaml:43`).
- `ruleSelector` unchanged, and **all 36 PrometheusRules in the live cluster carry the matching `release` label** — verified against dev, no rules orphaned.
- CRD served/storage versions identical across all 10 CRDs, so skipping 15 majors needs no stored-object migration.

## CRDs: no manual step

Two mechanisms already in place — `upgrade.crds: CreateReplace`, and the `crds.upgradeJob` pre-upgrade hook.

Bonus fix: `crds.upgradeJob.forceConflicts` defaults `false` → `true` across this range. On 72.x the job runs `kubectl apply --server-side` *without* `--force-conflicts`, so it cannot take field ownership from helm-controller — it has likely been a silent no-op. On 88.x it renders with the flag and actually works.

## Expect after merge

- **KSM default resource set changes `endpoints` → `endpointslices`.** All `kube_endpoint_*` series disappear. Grepped: nothing in the repo references them — **but Grafana dashboards live in the 10Gi PVC, not in git**, so those need a manual look.
- **Three new alerts start firing**: `AlertmanagerClusterFailedPeers`, `KubeAPIInstanceUnreachable`, `KubeletInstanceUnreachable`. The latter two may be noisy on GKE node churn.
- **Distroless images have no shell** — `kubectl exec` into prometheus/node-exporter for debugging stops working.
- Thanos sidecar moves to 0.42.4 while the separate Thanos chart stays ~0.38. StoreAPI is backward compatible, but it widens an existing gap.

## Separate follow-up, NOT fixed here

`helm-release-prometheus.yaml:302-305` sets `prometheus.resources`. **That key does not exist in this chart** — not in 72.9.1, not in 88.1.5. It has always been silently discarded, meaning **the Prometheus pod runs with no resource requests at all**. Correct key is `prometheus.prometheusSpec.resources`. Fixing it genuinely changes scheduling, so it deserves its own PR.

## Rollout note

If dev-testing this via a branch pin, remember dev does **not** auto-flip back to `main` after merge — patch the `GitRepository` manually or dev GitOps freezes on the deleted branch.



---

## ✅ Dev-validert 2026-08-06

Chart **72.9.1 → 88.1.5** i ett hopp. Ingen manuelle CRD-steg trengtes — de to eksisterende mekanismene håndterte det.

Komponenter etter oppgradering:

```
prometheus-operator  v0.93.0
prometheus           v3.13.2-distroless   (API bekrefter build 3.13.2)
alertmanager         v0.33.1
grafana              13.1.2
kube-state-metrics   v2.19.1
node-exporter        v1.12.1-distroless
thanos sidecar       quay.io/thanos/thanos:v0.42.4
```

Alle poder Running, 36 PrometheusRules uendret, ingen andre HelmReleases regredierte.

### gotk-metrikkene overlevde KSM 2.15 → 2.19

Viktigst å sjekke gitt historikken i #221. `customResourceState`-konfigurasjonen fungerer fortsatt:

```
171x gotk_reconcile_condition
 58x gotk_suspend_status
```

Serier har fortsatt riktig form (`type="Ready"`, `status="True"/"False"`), så `flux-alerts.yaml` matcher som før.

### endpoints → endpointslices bekreftet live

```
kube_endpoint_*:       0
kube_endpointslice_*:  834
```

Som forventet. Ingenting i repoet refererer de gamle navnene — **men Grafana-dashboards ligger i 10Gi-PVC-en, ikke i git**, så de må sjekkes manuelt.

### De tre nye alertene fyrer ikke

`KubeletInstanceUnreachable`, `KubeAPIInstanceUnreachable` og `AlertmanagerClusterFailedPeers` er alle stille i dev.

### Alt som fyrer nå er eldre enn oppgraderingen

Verifisert via `activeAt`:

| alert | aktiv siden |
|---|---|
| TargetDown (kubelet) | **2024-01-04** |
| TargetDown (kubernetes-ingresses) | 2024-08-30 |
| TargetDown (kubernetes-pods, demo) | 2025-12-12 |
| TargetDown (kubernetes-pods, staging) | 2026-03-15 |
| PrometheusRuleFailures | 2026-08-02 |

Ingen regel er i feilet evalueringstilstand nå. Prometheus-targets: 240 up / 38 down, der alle down-ene tilhører de pre-eksisterende jobbene over.
