### PR TITLE
chore: bump external-secrets to 2.8.x, pin CRD tag

### DIFF
--- a/infrastructure/base/external-secrets/helm-release-external-secrets.yaml
+++ b/infrastructure/base/external-secrets/helm-release-external-secrets.yaml
@@ -11,7 +11,10 @@ spec:
   chart:
     spec:
       chart: external-secrets
-      version: 0.19.x
+      # Keep in lockstep with the GitRepository tag in repos-external-secrets.yaml,
+      # which supplies the CRDs. Pinned to the minor rather than `2.x` so a future
+      # major cannot land unreviewed.
+      version: 2.8.x
       sourceRef:
         kind: HelmRepository
         name: external-secrets

--- a/infrastructure/base/external-secrets/repos-external-secrets.yaml
+++ b/infrastructure/base/external-secrets/repos-external-secrets.yaml
@@ -16,5 +16,10 @@ metadata:
 spec:
   interval: 10m
   url: https://github.com/external-secrets/external-secrets
+  # Supplies ./deploy/crds to the external-secrets-crds Kustomization, which runs
+  # with prune: true. Must be a tag, not a branch: tracking `main` applied
+  # unreleased upstream CRD changes to the cluster within one interval, and a
+  # pruned CRD would cascade-delete the Secrets owned by our ExternalSecrets.
+  # Keep this tag in lockstep with the chart version in the HelmRelease.
   ref:
-    branch: main
+    tag: v2.8.0


### PR DESCRIPTION
## What

Two changes that must land together:

1. `external-secrets` chart **0.19.x → 2.8.x**
2. The `external-secrets` GitRepository **`ref: branch: main` → `ref: tag: v2.8.0`**

## The GitRepository pin is the more urgent half

`repos-external-secrets.yaml` tracked **upstream `main`**, and `crds-external-secrets.yaml` builds `./deploy/crds` from it with **`prune: true`**.

So the cluster has been applying **unreleased upstream CRDs** — currently post-2.8.0 CRDs against a 0.19.2 controller — within one reconcile interval of any upstream push. Combined with `prune: true` and **215 ExternalSecrets on `creationPolicy: Owner`** (which sets an ownerReference on each target Secret), an upstream restructure of that directory could cascade into garbage-collecting synced Secrets.

`deletionPolicy` is unset everywhere (defaults `Retain`), which guards against provider-side deletion but **not** against the ExternalSecret object itself being pruned.

This is a pre-existing hazard independent of the version bump. The bump also *closes* the existing controller/CRD skew.

## Why 0.19 → 2.8 in one step is safe

The frightening part — the v1beta1 → v1 API migration — **is already behind us**:

- `v1` became the storage version in **0.16.0**
- v1beta1 stopped being served in **0.17.0**
- We're on 0.19.2

Verified against the CRD bundles at v0.19.2, v1.0.0, v2.0.0, v2.8.0 and `main` — all identical: `v1` served+storage, `v1beta1` present but `served=false, storage=false`. v1beta1 is deprecated but **never removed**, so applying the 2.8.0 CRDs cannot fail on a still-stored version.

**Checked on the live dev cluster: `status.storedVersions` is `["v1"]` only.** There is no storage migration to perform.

**All 217 external-secrets resources in this repo are already `external-secrets.io/v1`** (215 ExternalSecret + 2 ClusterSecretStore). Zero manifests need editing.

## Breaking changes across the range

| release | change | us |
|---|---|---|
| 1.0.0 | no breaking-change section — semver milestone, not an API GA | n/a |
| 1.1.0 | default registry `oci.external-secrets.io` → `ghcr.io` | no registry pins |
| **2.0.0** | **removed `alibaba` + `device42` providers** | we use `gcpsm` — still present |
| 2.0.1 / 2.3.0 | sprig template function changes | no `template:` blocks anywhere |
| 2.2.0 | Flux OCIRepository needs `layerSelector` | we use a classic HelmRepository |

## Verification

- Renders clean on both 0.19.2 and 2.8.0.
- **All three Deployment selectors identical** (controller, webhook, cert-controller).
- No CRDs rendered by the chart on either version — `installCRDs: false` respected. **This value must stay**, since the chart default is still `true`.
- `rbac.serviceAccountTokenCreate` defaults `true` in 2.8.0 and the `serviceaccounts/token` grant renders — our gcpsm workload-identity auth is preserved. (Flipping it to `false` would break the ClusterSecretStores.)
- Tag `v2.8.0` exists and `./deploy/crds` is valid there.

## Supported-matrix context

| ESO | tested k8s | EOL |
|---|---|---|
| 0.19.x (ours) | 1.33 | **Sep 22, 2025** |
| 2.8 | **1.35–1.36** | release of 2.9 |

Our cluster is 1.35.

## Risk

**Moderate-low.** Existing Secrets are materialized `v1.Secret` objects and survive an operator restart; exposure is a transient sync gap plus the validating webhook briefly rejecting writes while pods cycle. Flux's default `remediation: rollback` applies. Reverting the two edits restores prior state cleanly.

Honest caveat: **upstream publishes no migration guide at all**, so "no staged upgrade needed" is a well-supported inference from the CRD bundles at each tag, not an explicit upstream blessing. This is a large controller jump where the CRD apply is nearly a no-op — **dev soak time is the real mitigation.**

## Unrelated drift spotted

`external-secrets-sa`, referenced by both ClusterSecretStores, is defined **nowhere in this repo** (not in `infrastructure/`, not in `terraform/`). It's manually created in-cluster and unmanaged by GitOps. The upgrade won't touch it, but it's undocumented.



---

## ✅ Dev-validert 2026-08-06

Dette var den med størst logisk blast radius. Den gikk rent.

- Chart **0.19.2 → 2.8.0** over to major-versjoner, alle tre poder rullet og Running
- Images nå `ghcr.io/external-secrets/external-secrets:v2.8.0` — bekrefter registry-flyttet i 1.1.0 (var `oci.external-secrets.io`)
- **GitRepository pinnet til `tag: v2.8.0`** på nøyaktig `2e0f135f...`. Den unpinnede `main`-faren er lukket.

### Hemmelighetssynk uendret

```
før:   142 ExternalSecrets, 141 Ready, 1 False
etter: 142 ExternalSecrets, 141 Ready, 1 False
```

Den ene feilende er `demo/fdk-rss-atom-feed` (*"could not get secret data from provider"*) — samme både før og etter, altså en manglende hemmelighet i GCP Secret Manager, ikke noe med oppgraderingen å gjøre. **Null synk-regresjoner.**

### CRD-tilstanden var som forutsagt

```
externalsecrets.external-secrets.io
  v1      served=true  storage=true
  v1beta1 served=false storage=false
  status.storedVersions: ["v1"]
```

Ingen lagringsmigrering, ingen konvertering. Konklusjonen om at et trinnvis hopp ikke var nødvendig holdt.
