### PR TITLE
chore: bump eck-operator to 3.5.0

### DIFF
--- a/infrastructure/dev/elasticsearch-operator/helm-release-elasticsearch-operator.yaml
+++ b/infrastructure/dev/elasticsearch-operator/helm-release-elasticsearch-operator.yaml
@@ -13,5 +13,8 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: elasticsearch-operator
-      version: 2.x
+      # Pinned exactly, not `3.x`: ECK 3.4.0 changed the Elasticsearch pod spec,
+      # so the operator upgrade forces a full rolling restart of every ES node.
+      # That should happen on a deliberate merge, not whenever a range moves.
+      version: 3.5.0
   interval: 5m0s

--- a/infrastructure/prod/elasticsearch-operator/helm-release-elasticsearch-operator.yaml
+++ b/infrastructure/prod/elasticsearch-operator/helm-release-elasticsearch-operator.yaml
@@ -13,5 +13,8 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: elasticsearch-operator
-      version: 2.x
+      # Pinned exactly, not `3.x`: ECK 3.4.0 changed the Elasticsearch pod spec,
+      # so the operator upgrade forces a full rolling restart of every ES node.
+      # That should happen on a deliberate merge, not whenever a range moves.
+      version: 3.5.0
   interval: 5m0s


### PR DESCRIPTION
## What

`eck-operator` **2.x → 3.5.0**, in both dev and prod. Pinned exactly, not as a `3.x` range.

2.16.1 (Jan 2025) is the last 2.x that will ever ship.

## Elasticsearch does NOT need upgrading first

This was the suspected blocker and it does not materialise.

All three Elasticsearch CRs pin **8.17.2**:
- `apps/prod/elasticsearch/elasticsearch.yaml:8`
- `apps/dev/elasticsearch-staging/elasticsearch.yaml:8`
- `apps/dev/elasticsearch-demo/elasticsearch.yaml:8`

Verified against ECK source rather than docs prose — `pkg/controller/elasticsearch/version/supported_versions.go` at tag `v3.5.0`:

```go
case 8:
    Min: version.MinFor(7, 17, 0)
    Max: version.MustParse("8.99.99")
```

8.17.2 sits inside that range. Also confirmed `GlobalMinStackVersion` is unset by default (it only applies to UBI builds), so there is no second gate.

For reference, major 9 requires `Min: 8.18.0` — relevant to a future ES bump, not to this one.

**There are no Kibana CRs anywhere** in the repo or cluster, so the ECK 3.4 Kibana default-memory change (1Gi → 2Gi) does not apply.

## Breaking changes

Essentially none for our usage:

- **No CRD migration.** Elastic states no special instructions from any 2.x to 3.5.0, and no intermediate hop.
- **No API versions removed.** Live CRDs serve `v1` (served + storage) and `v1beta1` (served); 3.5.0 only *adds* two CRDs. We use `elasticsearch.k8s.elastic.co/v1`.
- CRDs are Helm-managed by the `eck-operator-crds` subchart with `helm.sh/resource-policy: keep` — they update in-chart, no manual replace.
- k8s compatibility: ECK 3.4+ is tested on 1.31–1.36; we're on 1.35. (3.3 topped out at 1.35, which is why 3.5.0 is the right target rather than an intermediate 3.x.)

## Verification

- Renders clean on both 2.16.1 and 3.5.0.
- **Operator StatefulSet selector identical** — no immutable-field rejection.

## Risk: MEDIUM — churn, not compatibility

**ECK 3.4.0 changed the Elasticsearch pod spec** (adds `seccompProfile: RuntimeDefault`, new pre-stop hook and readiness-probe scripts). The operator upgrade therefore forces a **full rolling restart of every Elasticsearch pod**: 6 nodes each in demo, staging and prod.

That is exactly why this is pinned to `3.5.0` rather than `3.x` — a version range should not get to decide when 18 ES nodes restart.

**Suggested rollout:** merge, confirm dev (demo + staging) goes green and both clusters return to 6/6 healthy nodes, then let prod follow.

## Separate follow-up, NOT in this PR

ES **8.17.2 is itself well behind** — the 8.x line is at 8.19.19 and 8.17 is past maintenance. ECK also requires **≥ 8.18** before any eventual move to 9.x. Worth scheduling an `8.17.2 → 8.19.x` bump, but independently of, and after, this operator upgrade.



---

## ✅ Dev-validert 2026-08-06 — men les avsnittet om nedetid

Sluttresultatet er riktig:

- Operator **2.16.1 → 3.5.0** (`docker.elastic.co/eck/eck-operator:3.5.0`), HelmRelease Ready
- Begge clustere **green 6/6**
- **Elasticsearch forble på 8.17.2** — operator-oppgraderingen rører ikke ES-versjonen, som var hele kompatibilitetsspørsmålet

## ⚠️ Korreksjon: dette var ikke en ren rullerende restart

Beskrivelsen over sier "rullerende restart", som antyder kontinuerlig tilgjengelighet. **Det stemte ikke i praksis.**

De første ~10 podene rullet pent — én om gangen per cluster, health dippet til yellow på 5 noder og kom tilbake til green. Så, på slutten:

```
[19] pending_restart=0 restarted=12 notready=7   green 5 / green 5
[20] pending_restart=0 restarted=12 notready=12  green 5 / green 5
[23] pending_restart=0 restarted=12 notready=12  unknown <none> / unknown <none>
[26] pending_restart=0 restarted=12 notready=6   unknown <none> / green 6
[27] pending_restart=0 restarted=12 notready=0   green 6 / green 6
```

**Alle 12 poder ble unready samtidig, og begge clustere rapporterte `unknown` health uten tilgjengelige noder i omtrent 2–3 minutter.** Master-nodene restartet sist (5 min gamle mot 16 min for første data-node), noe som trolig utløste vinduet.

Det rettet seg selv og sluttilstanden er korrekt, så det er ingenting å fikse i denne PR-en.

**Men: merge av denne bør behandles som et kort planlagt ES-avbrudd i prod**, ikke en transparent oppgradering. Prod har samme 6-noders topologi i tre namespaces, så forvent tilsvarende oppførsel. Dette er også argumentet for å pinne prod sin GitRepository og flytte den bevisst, framfor å la merge til main treffe prod umiddelbart.
