### PR TITLE
chore: bump elasticsearch-exporter to 7.x

### DIFF
--- a/infrastructure/dev/monitoring/helm-release-elasticsearch-exporter.yaml
+++ b/infrastructure/dev/monitoring/helm-release-elasticsearch-exporter.yaml
@@ -9,7 +9,7 @@ spec:
   targetNamespace: monitoring
   chart:
     spec:
-      version: 4.x
+      version: 7.x
       chart: prometheus-elasticsearch-exporter
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
## ⚠️ Requires a manual step at merge time — read before merging

This upgrade **will stall the HelmRelease** unless the existing Deployment is deleted first.

```
kubectl delete deploy -n monitoring -l app=prometheus-elasticsearch-exporter
```

Run that alongside the merge. It targets `monitoring-elasticsearch-exporter-prometheus-elasticsearch-expo` in dev. Safe to delete — stateless exporter, costs only a brief metrics gap.

## What

`prometheus-elasticsearch-exporter` **4.x → 7.x** (4.15.1 → 7.4.0, appVersion v1.5.0 → v1.11.0). Dev only; prod does not deploy this chart.

A 6-major, ~4-year jump.

## Why the manual step is needed

Chart **6.0.0 changed the Deployment's `spec.selector.matchLabels`**. Verified by rendering both versions:

```
4.15.1 -> app=prometheus-elasticsearch-exporter, release=monitoring-elasticsearch-exporter
7.4.0  -> app.kubernetes.io/name=..., app.kubernetes.io/instance=...
```

`spec.selector` is **immutable**. Helm cannot patch it, so the upgrade fails with `field is immutable` and the HelmRelease stalls — the same failure mode this repo has hit before (the legacy `fdk-postgresql-config` Deployment blocked Flux for 235 days for exactly this reason).

The `-l app=prometheus-elasticsearch-exporter` selector above matches the 4.x labels and is the reliable way to catch it.

## Breaking changes

| ver | change | us |
|---|---|---|
| 5.0.0 | `securityContext` → `podSecurityContext`; `securityContext` now means container-level | we set neither |
| **6.0.0** | **immutable selector labels** (above); chart apiVersion v2, Helm 3 only | **manual delete required** |
| 7.0.0 | PodSecurityPolicy dropped | not used |

## Impact on our values: none

We set only `es.uri` and `serviceMonitor.enabled`. Both keys exist unchanged in 7.4.0. Renders clean.

## Behavioural change to be aware of

The pod now defaults to `runAsNonRoot: true`, `runAsUser: 1000`, `seccompProfile: RuntimeDefault`, and the container to `readOnlyRootFilesystem: true` with `drop: [ALL]`. Worth an eye on first rollout.

## Risk

**Medium**, entirely because of the delete step. Mitigating: dev-only, stateless, and the failure mode is a stalled HelmRelease rather than data loss — recoverable by performing the delete after the fact.



---

## ✅ Dev-validert 2026-08-06

Det manuelle steget ble kjørt rett før merge, og oppgraderingen gikk gjennom.

Reconcile-forløpet viser mekanismen tydelig:

```
[poll 1] ver=4.15.1 ready=True     <- før
[poll 2] ver=4.15.1 ready=Unknown  <- "Running 'upgrade' action"
[poll 3] ver=7.4.0  ready=True     <- "Helm upgrade succeeded ... .v3"
```

- Chart **4.15.1 → 7.4.0**
- Ny Deployment har den nye selector-formen (`app.kubernetes.io/name` + `/instance`), 1/1 Running
- `monitoring-elasticsearch-exporter-...` er `up` i Prometheus etterpå

**Uten `kubectl delete deploy` først ville poll 2 feilet på `field is immutable`** i stedet for å gå videre — akkurat slik #278 sannsynligvis stoppet opp.
