### PR TITLE
fix: raise trivy scan job memory limit

### DIFF
--- a/infrastructure/base/trivy/helm-release.yaml
+++ b/infrastructure/base/trivy/helm-release.yaml
@@ -30,13 +30,17 @@ spec:
       configFile:
         cache:
           backend: memory
+      # Each scan job downloads the ~104 MiB vulnerability DB and, because the
+      # cache backend is in-memory, holds it decompressed in RAM alongside the
+      # scan working set. 256Mi was not enough for larger images and they were
+      # being OOMKilled.
       resources:
         limits:
           cpu: 100m
-          memory: 256Mi
+          memory: 1Gi
         requests:
           cpu: 50m
-          memory: 128Mi
+          memory: 256Mi
     operator:
       vulnerabilityScannerScanOnlyCurrentRevisions: true
       configAuditScannerScanOnlyCurrentRevisions: true


### PR DESCRIPTION
## Problem

Trivy scan-jobber blir `OOMKilled` i både dev og prod. Etter oppgraderingen til chart 0.34.0 / scanner 0.72.0 (#337) fortsetter det — omtrent 2 av 12 jobber ryker.

## Årsak

Loggen fra en OOMKilled scan-pod viser hva den holdt på med da den døde:

```
INFO  Adding schema version to the DB repository for backward compatibility  repository="mirror.gcr.io/aquasec/trivy-db:2"
INFO  [vulndb] Need to update DB
INFO  [vulndb] Downloading vulnerability DB...
      ... 103.68 MiB ...
```

Hver scan-jobb laster ned **~104 MiB sårbarhetsdatabase**, og fordi `trivy.configFile.cache.backend` er satt til `memory` holdes den dekomprimert i RAM sammen med selve scan-arbeidssettet. Minnegrensa var **256Mi**.

Det forklarer mønsteret: de fleste scans går fint, men større images tipper over. Feilene følger *hvilket image* som scannes (`controller`, `zookeeper-1`), ikke tidspunkt eller registry.

Målt forbruk på kjørende scans ligger på 50–99Mi i nedlastingsfasen — toppen kommer senere, ved dekomprimering.

## Endring

```diff
       resources:
         limits:
           cpu: 100m
-          memory: 256Mi
+          memory: 1Gi
         requests:
           cpu: 50m
-          memory: 128Mi
+          memory: 256Mi
```

`requests` heves også, slik at scheduleren reserverer noe som ligner faktisk bruk. Operatoren begrenser samtidige scan-jobber, så reservasjonen er avgrenset.

## Hva dette IKKE er

Dette er **ikke** samme problem som #336 løser. Den PR-en adresserer at `mirror.gcr.io` er en pull-through-cache som kan servere et utdatert manifest og gi `FATAL ... BLOB_UNKNOWN`, uten fallback fordi charten bare lar oss sende én `--db-repository`-verdi. Det er en reell, uavhengig feilmodus — den handler om å få tak i databasen, denne handler om å ha minne nok til å bruke den.

Begge bør inn. De overlapper ikke.

## Verifisering

- `helm template` mot chart 0.34.0 med våre verdier renderer rent
- Resulterende config: `trivy.resources.limits.memory: "1Gi"`, `trivy.resources.requests.memory: "256Mi"`

`1Gi` er satt med margin framfor å treffe blink. Verdt å se på faktisk toppforbruk etter noen dager og justere ned om det viser seg rikelig.

## Merk

`cpu: 100m` er urørt her, men er lavt for dekomprimering og scanning — verdt en egen vurdering hvis scan-jobbene viser seg trege.
