### PR TITLE
fix: thanos compactor resilience and alerting

### DIFF
--- a/infrastructure/base/alerts/kustomization.yaml
+++ b/infrastructure/base/alerts/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - mail-processing-failure.yaml
   - message-processing-failure.yaml
   - postgres-connection-alerts.yaml
+  - thanos-compactor-alerts.yaml

--- a/infrastructure/base/alerts/thanos-compactor-alerts.yaml
+++ b/infrastructure/base/alerts/thanos-compactor-alerts.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: thanos-compactor-alerts
+  namespace: monitoring
+  labels:
+    release: monitoring-kube-prometheus-stack
+spec:
+  groups:
+    - name: thanos-compactor
+      rules:
+        # A halted compactor stops compaction AND retention, so blocks
+        # accumulate indefinitely until object storage and the storegateway
+        # disk fill up. It halts on the first bad block group and stays halted
+        # until a human intervenes, so this needs to be noisy.
+        - alert: ThanosCompactorHalted
+          annotations:
+            summary: Thanos compactor is halted
+            description: >-
+              The Thanos compactor has halted and is no longer compacting or
+              applying retention. Blocks will accumulate until storage fills up.
+              Check the compactor logs for the critical error that caused the
+              halt.
+          expr: thanos_compact_halted == 1
+          for: 15m
+          labels:
+            severity: critical
+
+        # Backstop in case the compactor stops making progress without setting
+        # the halted flag (crashloop, stuck sync, wedged on object storage).
+        - alert: ThanosCompactorNotRunning
+          annotations:
+            summary: Thanos compactor has not completed an iteration
+            description: >-
+              The Thanos compactor has not completed a compaction iteration in
+              the last 6 hours. Retention is not being applied.
+          expr: increase(thanos_compact_iterations_total[6h]) == 0
+          for: 30m
+          labels:
+            severity: warning
+
+        # Early warning that retention is falling behind, before the disk
+        # pressure shows up somewhere less obvious.
+        - alert: ThanosCompactorDeletionBacklog
+          annotations:
+            summary: Thanos has a large backlog of blocks pending deletion
+            description: >-
+              {{ $value }} blocks are marked for deletion but have not been
+              removed. This usually means retention is not running.
+          expr: thanos_compact_todo_deletion_blocks > 500
+          for: 1h
+          labels:
+            severity: warning

--- a/infrastructure/base/monitoring/helm-release-thanos.yaml
+++ b/infrastructure/base/monitoring/helm-release-thanos.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   interval: 5m
   targetNamespace: monitoring
+  # A cold storegateway resync legitimately takes longer than helm-controller's
+  # 5m default, which made `helm upgrade --wait` time out and leave the release
+  # Stalled with no retry (remediation defaults to 0 retries).
+  timeout: 20m
   chart:
     spec:
       version: 15.x
@@ -19,6 +23,8 @@ spec:
     crds: Create
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 2
   values:
     global:
       security:
@@ -26,6 +32,12 @@ spec:
     image:
       repository: bitnamilegacy/thanos
     existingObjstoreSecret: thanos-objstore
+    # Without these, compaction failures are invisible: no component exposed
+    # metrics and nothing alerted on thanos_compact_halted.
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
     query:
       extraFlags:
         - --query.auto-downsampling
@@ -78,7 +90,10 @@ spec:
     compactor:
       enabled: true
       persistence:
-        size: 24Gi
+        # Compaction needs roughly 2-3x the size of the largest block group as
+        # scratch space. 24Gi was enough at rest but ran out mid-compaction
+        # ("preallocate: no space left on device"), halting the compactor.
+        size: 64Gi
       ingress:
         enabled: false
         ingressClassName: nginx


### PR DESCRIPTION
## Bakgrunn

Thanos-compactoren er halted i begge clustere. Når den halter kjører heller ikke retention, så blokker hoper seg opp i objektlagringen i stedet for å bli ryddet.

Årsakene er ulike i de to clusterne: dev stopper på en enkelt gammel, ødelagt blokk, mens prod gikk tom for scratch-plass midt i en compaction. Begge krever manuell opprydding — den gjøres separat. Denne PR-en fikser rammeverket rundt, slik at det ikke skjer igjen ubemerket.

## Endringer

**1. `timeout: 20m` + `upgrade.remediation.retries: 2`**

Begge var usatt. Helm-controller sin default er 5m, og en kald storegateway-resync tar legitimt lengre tid. `helm upgrade --wait` gikk derfor på `context deadline exceeded`, og med 0 retries endte HelmRelease-en `Stalled` uten å prøve igjen.

**2. `compactor.persistence.size: 24Gi → 64Gi`**

Compaction trenger grovt 2–3x største blokk-gruppe som scratch. 24Gi holder i ro, men ikke under selve compactionen.

Trygt å endre: compactoren er en Deployment med en frittstående PVC (ikke `volumeClaimTemplate`), og `allowVolumeExpansion` er `true` på `standard` i begge clustere. Altså en ren utvidelse, ikke et immutable-felt.

**3. `metrics.enabled: true` + ServiceMonitors**

Charten eksponerte ingen metrikker, og det fantes ingen ServiceMonitor for noen Thanos-komponent. Det er hovedgrunnen til at dette kunne pågå upåaktet.

**4. Nye alerts** — `infrastructure/base/alerts/thanos-compactor-alerts.yaml`

- `ThanosCompactorHalted` (critical) — compactoren har haltet i 15m
- `ThanosCompactorNotRunning` (warning) — ingen fullført iterasjon på 6t, fanger opp stopp uten halted-flagg
- `ThanosCompactorDeletionBacklog` (warning) — for mange blokker venter på sletting

## Verifisering

- `kubectl kustomize infrastructure/base/alerts/` bygger rent
- `helm template` med de nye verdiene renderer rent, og gir ServiceMonitors for alle komponentene
- PrometheusRule-en har `release: monitoring-kube-prometheus-stack`, som er det `ruleSelector` matcher på
- Prometheus velger alle ServiceMonitors (`serviceMonitorSelector: {}`), så de nye plukkes opp uten ekstra labels
- PVC-ene er ikke Terraform-styrt — `google_compute_disk`-ressursene i `terraform/` er alle app-spesifikke, ingen for Thanos

## Etter merge

Dev sin HelmRelease står `Stalled` med `RetriesExceeded`, så Flux prøver ikke av seg selv — denne spec-endringen er selv det som løser den ut. Ellers `flux reconcile helmrelease thanos -n flux-system --force`.

Selve opprydningen i dev gjøres deretter manuelt, og tar tid. Detaljer i internt arbeidsnotat.
