### PR TITLE
feat: manage workload identity bindings in terraform

### DIFF
--- a/terraform/dev/service-accounts-kubernetes.tf
+++ b/terraform/dev/service-accounts-kubernetes.tf
@@ -47,3 +47,20 @@ resource "kubernetes_service_account" "monitoring_cloud_sql_sa" {
     }
   }
 }
+
+# Kubernetes service account for External Secrets Operator
+resource "kubernetes_service_account" "external_secrets_sa" {
+  metadata {
+    name      = var.eso_k8s_sa_name
+    namespace = var.eso_namespace
+    annotations = {
+      "iam.gke.io/gcp-service-account" = google_service_account.eso_reader_sa.email
+    }
+  }
+}
+
+resource "google_service_account_iam_member" "eso_reader_workload_identity" {
+  service_account_id = google_service_account.eso_reader_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.eso_namespace}/${var.eso_k8s_sa_name}]"
+}

--- a/terraform/dev/service-accounts-kubernetes.tf
+++ b/terraform/dev/service-accounts-kubernetes.tf
@@ -64,3 +64,26 @@ resource "google_service_account_iam_member" "eso_reader_workload_identity" {
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.eso_namespace}/${var.eso_k8s_sa_name}]"
 }
+
+resource "google_project_iam_member" "eso_reader_secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.eso_reader_sa.email}"
+}
+
+# Workload Identity bindings for the service accounts created above
+resource "google_service_account_iam_member" "workload_identity_bindings" {
+  for_each = toset([
+    for combination in setproduct(var.k8s_namespaces, var.k8s_service_accounts) : "${combination[0]}/${combination[1]}"
+  ])
+
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${var.k8s_to_gcp_service_account_mapping[split("/", each.key)[1]]}@${var.project_id}.iam.gserviceaccount.com"
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${each.key}]"
+}
+
+resource "google_service_account_iam_member" "monitoring_cloud_sql_workload_identity" {
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${var.monitoring_cloud_sql_gcp_sa}@${var.project_id}.iam.gserviceaccount.com"
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.monitoring_namespace}/${var.monitoring_cloud_sql_k8s_sa_name}]"
+}

--- a/terraform/dev/service-accounts-kubernetes.tf
+++ b/terraform/dev/service-accounts-kubernetes.tf
@@ -50,6 +50,8 @@ resource "kubernetes_service_account" "monitoring_cloud_sql_sa" {
 
 # Kubernetes service account for External Secrets Operator
 resource "kubernetes_service_account" "external_secrets_sa" {
+  automount_service_account_token = false
+
   metadata {
     name      = var.eso_k8s_sa_name
     namespace = var.eso_namespace

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -315,3 +315,13 @@ variable "monitoring_cloud_sql_gcp_sa" {
   type        = string
 }
 
+variable "eso_namespace" {
+  description = "External Secrets Operator namespace - kept in Secret Manager"
+  type        = string
+}
+
+variable "eso_k8s_sa_name" {
+  description = "Kubernetes service account name for External Secrets Operator - kept in Secret Manager"
+  type        = string
+}
+

--- a/terraform/prod/service-accounts-kubernetes.tf
+++ b/terraform/prod/service-accounts-kubernetes.tf
@@ -47,3 +47,20 @@ resource "kubernetes_service_account" "monitoring_cloud_sql_sa" {
     }
   }
 }
+
+# Kubernetes service account for External Secrets Operator
+resource "kubernetes_service_account" "external_secrets_sa" {
+  metadata {
+    name      = var.eso_k8s_sa_name
+    namespace = var.eso_namespace
+    annotations = {
+      "iam.gke.io/gcp-service-account" = google_service_account.eso_reader_sa.email
+    }
+  }
+}
+
+resource "google_service_account_iam_member" "eso_reader_workload_identity" {
+  service_account_id = google_service_account.eso_reader_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.eso_namespace}/${var.eso_k8s_sa_name}]"
+}

--- a/terraform/prod/service-accounts-kubernetes.tf
+++ b/terraform/prod/service-accounts-kubernetes.tf
@@ -64,3 +64,26 @@ resource "google_service_account_iam_member" "eso_reader_workload_identity" {
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.eso_namespace}/${var.eso_k8s_sa_name}]"
 }
+
+resource "google_project_iam_member" "eso_reader_secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.eso_reader_sa.email}"
+}
+
+# Workload Identity bindings for the service accounts created above
+resource "google_service_account_iam_member" "workload_identity_bindings" {
+  for_each = toset([
+    for combination in setproduct(var.k8s_namespaces, var.k8s_service_accounts) : "${combination[0]}/${combination[1]}"
+  ])
+
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${var.k8s_to_gcp_service_account_mapping[split("/", each.key)[1]]}@${var.project_id}.iam.gserviceaccount.com"
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${each.key}]"
+}
+
+resource "google_service_account_iam_member" "monitoring_cloud_sql_workload_identity" {
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${var.monitoring_cloud_sql_gcp_sa}@${var.project_id}.iam.gserviceaccount.com"
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.monitoring_namespace}/${var.monitoring_cloud_sql_k8s_sa_name}]"
+}

--- a/terraform/prod/service-accounts-kubernetes.tf
+++ b/terraform/prod/service-accounts-kubernetes.tf
@@ -50,6 +50,8 @@ resource "kubernetes_service_account" "monitoring_cloud_sql_sa" {
 
 # Kubernetes service account for External Secrets Operator
 resource "kubernetes_service_account" "external_secrets_sa" {
+  automount_service_account_token = false
+
   metadata {
     name      = var.eso_k8s_sa_name
     namespace = var.eso_namespace

--- a/terraform/prod/variables.tf
+++ b/terraform/prod/variables.tf
@@ -308,3 +308,13 @@ variable "monitoring_cloud_sql_gcp_sa" {
   description = "GCP service account for monitoring cloud-sql-proxy - kept in Secret Manager"
   type        = string
 }
+
+variable "eso_namespace" {
+  description = "External Secrets Operator namespace - kept in Secret Manager"
+  type        = string
+}
+
+variable "eso_k8s_sa_name" {
+  description = "Kubernetes service account name for External Secrets Operator - kept in Secret Manager"
+  type        = string
+}


### PR DESCRIPTION
# Summary 

- Legger Workload Identity-bindingene for Kubernetes-tjenestekontoene inn i Terraform. Kontoene har vært styrt, men bindingene på GCP-siden lå ikke i kode.
- Legger til Kubernetes-tjenestekontoen for External Secrets Operator, som til nå har vært opprettet manuelt.
- Legger til den manglende bindingen for Cloud SQL-proxyen i monitoring, som ikke har kunnet autentisere. Postgres-metrikker mangler i begge miljøer som følge av dette.
- Bindingene er skrevet mot faktisk IAM-tilstand, ikke antakelser. `terraform validate` og `fmt -check` er grønne i begge miljøer.

Før apply:

- `eso_namespace` og `eso_k8s_sa_name` må legges inn i Secret Manager for begge prosjekter.
- Den eksisterende tjenestekontoen må importeres framfor å opprettes på nytt: `terraform import kubernetes_service_account.external_secrets_sa external-secrets/external-secrets-sa`
- IAM-ressursene er ikke-autoritative, så de er trygge å apply-e der bindingen finnes fra før. Kun proxy-bindingen er en reell ny tildeling.
