### PR TITLE
fix: raise trivy scan job timeout

### DIFF
--- a/infrastructure/base/trivy/helm-release.yaml
+++ b/infrastructure/base/trivy/helm-release.yaml
@@ -30,6 +30,10 @@ spec:
       configFile:
         cache:
           backend: memory
+      # Must be >= operator.scanJobTimeout, otherwise trivy gives up before the
+      # job deadline and the failure is reported as a scan error rather than a
+      # timeout.
+      timeout: 10m0s
       # Each scan job downloads the ~104 MiB vulnerability DB and, because the
       # cache backend is in-memory, holds it decompressed in RAM alongside the
       # scan working set. 256Mi was not enough for larger images and they were
@@ -42,6 +46,12 @@ spec:
           cpu: 50m
           memory: 256Mi
     operator:
+      # Raised from the 5m default: because the cache backend is in-memory, every
+      # scan job re-downloads the ~104 MiB vulnerability DB, so scans were running
+      # at 138-235s against a 300s deadline and larger images tipped over it.
+      # backoffLimit is 0, so a job that exceeds the deadline is never retried and
+      # the workload silently ends up with no VulnerabilityReport.
+      scanJobTimeout: 10m
       vulnerabilityScannerScanOnlyCurrentRevisions: true
       configAuditScannerScanOnlyCurrentRevisions: true
       scanJobTTL: 10m


### PR DESCRIPTION
# Summary 

- Hever `operator.scanJobTimeout` fra 5m til 10m, og `trivy.timeout` tilsvarende.
- Scan-jobber ble drept av `activeDeadlineSeconds: 300`. Med `backoffLimit: 0` retryes de ikke, så arbeidslasten ender stille opp uten VulnerabilityReport — `skosmos-store` i staging manglet rapport av denne grunn.
- Marginen var uansett for tynn: scans som lykkes bruker allerede 138–235s av de 300. Tre `DeadlineExceeded`-hendelser siste time.

Årsaken til at scans er trege: `cache.backend: memory` gjør at hver eneste scan-jobb laster ned ~104 MiB sårbarhetsdatabase på nytt. Det er samme innstilling som ga OOM-ene vi rettet i #352.

Denne PR-en er et plaster, ikke en rot-årsaksfiks. Den ordentlige løsningen er å slippe nedlastingen per scan — enten ved å revurdere in-memory-cachen eller ved å kjøre trivy i ClientServer-modus med en sentral server som holder databasen. Sistnevnte ville også latt oss redusere minnegrensa igjen. Foreslår at det spores separat.

`trivy.timeout` settes likt jobbfristen med vilje: er den lavere, gir trivy opp først og feilen rapporteres som scan-feil framfor timeout.
