### PR TITLE
chore: bump cert-manager to v1.20.3 (hop 2/3)

### DIFF
--- a/infrastructure/base/cert-manager/cert-manager.yaml
+++ b/infrastructure/base/cert-manager/cert-manager.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: cert-manager
-      version: v1.19.6
+      version: v1.20.3
       sourceRef:
         kind: HelmRepository
         name: jetstack

--- a/infrastructure/base/cert-manager/crds.yaml
+++ b/infrastructure/base/cert-manager/crds.yaml
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.6"
+    app.kubernetes.io/version: "v1.20.3"
 spec:
   group: acme.cert-manager.io
   names:
@@ -299,6 +299,22 @@ spec:
                                 The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
                                 If set, ClientID and ClientSecret must also be set.
                               type: string
+                            zoneType:
+                              description: |-
+                                ZoneType determines which type of Azure DNS zone to use.
+
+                                Valid values are:
+                                  - AzurePublicZone  (default): Use a public Azure DNS zone.
+                                  - AzurePrivateZone: Use an Azure Private DNS zone.
+
+                                If not specified, AzurePublicZone is used.
+
+                                Support for Azure Private DNS zones is currently
+                                experimental and may change in future releases.
+                              enum:
+                                - AzurePublicZone
+                                - AzurePrivateZone
+                              type: string
                           required:
                             - resourceGroupName
                             - subscriptionID
@@ -472,8 +488,8 @@ spec:
                               description: |-
                                 The AccessKeyID is used for authentication.
                                 Cannot be set when SecretAccessKeyID is set.
-                                If neither the Access Key nor Key ID are set, we fall-back to using env
-                                vars, shared credentials file or AWS Instance metadata,
+                                If neither the Access Key nor Key ID are set, we fall back to using env
+                                vars, shared credentials file, or AWS Instance metadata,
                                 see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                               type: string
                             accessKeyIDSecretRef:
@@ -481,8 +497,8 @@ spec:
                                 The SecretAccessKey is used for authentication. If set, pull the AWS
                                 access key ID from a key within a Kubernetes Secret.
                                 Cannot be set when AccessKeyID is set.
-                                If neither the Access Key nor Key ID are set, we fall-back to using env
-                                vars, shared credentials file or AWS Instance metadata,
+                                If neither the Access Key nor Key ID are set, we fall back to using env
+                                vars, shared credentials file, or AWS Instance metadata,
                                 see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                               properties:
                                 key:
@@ -571,8 +587,8 @@ spec:
                             secretAccessKeySecretRef:
                               description: |-
                                 The SecretAccessKey is used for authentication.
-                                If neither the Access Key nor Key ID are set, we fall-back to using env
-                                vars, shared credentials file or AWS Instance metadata,
+                                If neither the Access Key nor Key ID are set, we fall back to using env
+                                vars, shared credentials file, or AWS Instance metadata,
                                 see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                               properties:
                                 key:
@@ -1929,9 +1945,10 @@ spec:
                                           operator:
                                             description: |-
                                               Operator represents a key's relationship to the value.
-                                              Valid operators are Exists and Equal. Defaults to Equal.
+                                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                               Exists is equivalent to wildcard for value, so that a pod can
                                               tolerate all taints of a particular category.
+                                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                             type: string
                                           tolerationSeconds:
                                             description: |-
@@ -3140,9 +3157,10 @@ spec:
                                           operator:
                                             description: |-
                                               Operator represents a key's relationship to the value.
-                                              Valid operators are Exists and Equal. Defaults to Equal.
+                                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                               Exists is equivalent to wildcard for value, so that a pod can
                                               tolerate all taints of a particular category.
+                                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                             type: string
                                           tolerationSeconds:
                                             description: |-
@@ -3290,6 +3308,10 @@ spec:
             - metadata
             - spec
           type: object
+      selectableFields:
+        - jsonPath: .spec.issuerRef.group
+        - jsonPath: .spec.issuerRef.kind
+        - jsonPath: .spec.issuerRef.name
       served: true
       storage: true
       subresources:
@@ -3307,7 +3329,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.6"
+    app.kubernetes.io/version: "v1.20.3"
 spec:
   group: acme.cert-manager.io
   names:
@@ -3566,6 +3588,10 @@ spec:
             - metadata
             - spec
           type: object
+      selectableFields:
+        - jsonPath: .spec.issuerRef.group
+        - jsonPath: .spec.issuerRef.kind
+        - jsonPath: .spec.issuerRef.name
       served: true
       storage: true
       subresources:
@@ -3583,7 +3609,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.6"
+    app.kubernetes.io/version: "v1.20.3"
 spec:
   group: cert-manager.io
   names:
@@ -3887,6 +3913,10 @@ spec:
                   type: string
               type: object
           type: object
+      selectableFields:
+        - jsonPath: .spec.issuerRef.group
+        - jsonPath: .spec.issuerRef.kind
+        - jsonPath: .spec.issuerRef.name
       served: true
       storage: true
       subresources:
@@ -3904,7 +3934,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.6"
+    app.kubernetes.io/version: "v1.20.3"
 spec:
   group: cert-manager.io
   names:
@@ -4347,9 +4377,6 @@ spec:
                         will be generated whenever a re-issuance occurs.
                         Default is `Always`.
                         The default was changed from `Never` to `Always` in cert-manager >=v1.18.0.
-                        The new default can be disabled by setting the
-                        `--feature-gates=DefaultPrivateKeyRotationPolicyAlways=false` option on
-                        the controller component.
                       enum:
                         - Never
                         - Always
@@ -4705,6 +4732,10 @@ spec:
                   type: integer
               type: object
           type: object
+      selectableFields:
+        - jsonPath: .spec.issuerRef.group
+        - jsonPath: .spec.issuerRef.kind
+        - jsonPath: .spec.issuerRef.name
       served: true
       storage: true
       subresources:
@@ -4722,7 +4753,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.6"
+    app.kubernetes.io/version: "v1.20.3"
 spec:
   group: cert-manager.io
   names:
@@ -5110,6 +5141,22 @@ spec:
                                       The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
                                       If set, ClientID and ClientSecret must also be set.
                                     type: string
+                                  zoneType:
+                                    description: |-
+                                      ZoneType determines which type of Azure DNS zone to use.
+
+                                      Valid values are:
+                                        - AzurePublicZone  (default): Use a public Azure DNS zone.
+                                        - AzurePrivateZone: Use an Azure Private DNS zone.
+
+                                      If not specified, AzurePublicZone is used.
+
+                                      Support for Azure Private DNS zones is currently
+                                      experimental and may change in future releases.
+                                    enum:
+                                      - AzurePublicZone
+                                      - AzurePrivateZone
+                                    type: string
                                 required:
                                   - resourceGroupName
                                   - subscriptionID
@@ -5283,8 +5330,8 @@ spec:
                                     description: |-
                                       The AccessKeyID is used for authentication.
                                       Cannot be set when SecretAccessKeyID is set.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     type: string
                                   accessKeyIDSecretRef:
@@ -5292,8 +5339,8 @@ spec:
                                       The SecretAccessKey is used for authentication. If set, pull the AWS
                                       access key ID from a key within a Kubernetes Secret.
                                       Cannot be set when AccessKeyID is set.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     properties:
                                       key:
@@ -5382,8 +5429,8 @@ spec:
                                   secretAccessKeySecretRef:
                                     description: |-
                                       The SecretAccessKey is used for authentication.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     properties:
                                       key:
@@ -6740,9 +6787,10 @@ spec:
                                                 operator:
                                                   description: |-
                                                     Operator represents a key's relationship to the value.
-                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                                     Exists is equivalent to wildcard for value, so that a pod can
                                                     tolerate all taints of a particular category.
+                                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                                   type: string
                                                 tolerationSeconds:
                                                   description: |-
@@ -7951,9 +7999,10 @@ spec:
                                                 operator:
                                                   description: |-
                                                     Operator represents a key's relationship to the value.
-                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                                     Exists is equivalent to wildcard for value, so that a pod can
                                                     tolerate all taints of a particular category.
+                                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                                   type: string
                                                 tolerationSeconds:
                                                   description: |-
@@ -8210,8 +8259,8 @@ spec:
                               properties:
                                 audiences:
                                   description: |-
-                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault. The default token
-                                    consisting of the issuer's namespace and name is always included.
+                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault.
+                                    The default audiences are always included in the token.
                                   items:
                                     type: string
                                   type: array
@@ -8339,16 +8388,16 @@ spec:
                   type: object
                 venafi:
                   description: |-
-                    Venafi configures this issuer to sign certificates using a Venafi TPP
-                    or Venafi Cloud policy zone.
+                    Venafi configures this issuer to sign certificates using a CyberArk Certificate Manager Self-Hosted
+                    or SaaS policy zone.
                   properties:
                     cloud:
                       description: |-
-                        Cloud specifies the Venafi cloud configuration settings.
-                        Only one of TPP or Cloud may be specified.
+                        Cloud specifies the CyberArk Certificate Manager SaaS configuration settings.
+                        Only one of CyberArk Certificate Manager may be specified.
                       properties:
                         apiTokenSecretRef:
-                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          description: APITokenSecretRef is a secret key selector for the CyberArk Certificate Manager SaaS API token.
                           properties:
                             key:
                               description: |-
@@ -8366,7 +8415,7 @@ spec:
                           type: object
                         url:
                           description: |-
-                            URL is the base URL for Venafi Cloud.
+                            URL is the base URL for CyberArk Certificate Manager SaaS.
                             Defaults to "https://api.venafi.cloud/".
                           type: string
                       required:
@@ -8374,13 +8423,13 @@ spec:
                       type: object
                     tpp:
                       description: |-
-                        TPP specifies Trust Protection Platform configuration settings.
-                        Only one of TPP or Cloud may be specified.
+                        TPP specifies CyberArk Certificate Manager Self-Hosted configuration settings.
+                        Only one of CyberArk Certificate Manager may be specified.
                       properties:
                         caBundle:
                           description: |-
                             Base64-encoded bundle of PEM CAs which will be used to validate the certificate
-                            chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP.
+                            chain presented by the CyberArk Certificate Manager Self-Hosted server. Only used if using HTTPS; ignored for HTTP.
                             If undefined, the certificate bundle in the cert-manager controller container
                             is used to validate the chain.
                           format: byte
@@ -8388,7 +8437,7 @@ spec:
                         caBundleSecretRef:
                           description: |-
                             Reference to a Secret containing a base64-encoded bundle of PEM CAs
-                            which will be used to validate the certificate chain presented by the TPP server.
+                            which will be used to validate the certificate chain presented by the CyberArk Certificate Manager Self-Hosted server.
                             Only used if using HTTPS; ignored for HTTP. Mutually exclusive with CABundle.
                             If neither CABundle nor CABundleSecretRef is defined, the certificate bundle in
                             the cert-manager controller container is used to validate the TLS connection.
@@ -8409,7 +8458,7 @@ spec:
                           type: object
                         credentialsRef:
                           description: |-
-                            CredentialsRef is a reference to a Secret containing the Venafi TPP API credentials.
+                            CredentialsRef is a reference to a Secret containing the CyberArk Certificate Manager Self-Hosted API credentials.
                             The secret must contain the key 'access-token' for the Access Token Authentication,
                             or two keys, 'username' and 'password' for the API Keys Authentication.
                           properties:
@@ -8423,7 +8472,7 @@ spec:
                           type: object
                         url:
                           description: |-
-                            URL is the base URL for the vedsdk endpoint of the Venafi TPP instance,
+                            URL is the base URL for the vedsdk endpoint of the CyberArk Certificate Manager Self-Hosted instance,
                             for example: "https://tpp.example.com/vedsdk".
                           type: string
                       required:
@@ -8432,8 +8481,8 @@ spec:
                       type: object
                     zone:
                       description: |-
-                        Zone is the Venafi Policy Zone to use for this issuer.
-                        All requests made to the Venafi platform will be restricted by the named
+                        Zone is the Certificate Manager Policy Zone to use for this issuer.
+                        All requests made to the Certificate Manager platform will be restricted by the named
                         zone policy.
                         This field is required.
                       type: string
@@ -8539,7 +8588,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.6"
+    app.kubernetes.io/version: "v1.20.3"
 spec:
   group: cert-manager.io
   names:
@@ -8926,6 +8975,22 @@ spec:
                                       The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
                                       If set, ClientID and ClientSecret must also be set.
                                     type: string
+                                  zoneType:
+                                    description: |-
+                                      ZoneType determines which type of Azure DNS zone to use.
+
+                                      Valid values are:
+                                        - AzurePublicZone  (default): Use a public Azure DNS zone.
+                                        - AzurePrivateZone: Use an Azure Private DNS zone.
+
+                                      If not specified, AzurePublicZone is used.
+
+                                      Support for Azure Private DNS zones is currently
+                                      experimental and may change in future releases.
+                                    enum:
+                                      - AzurePublicZone
+                                      - AzurePrivateZone
+                                    type: string
                                 required:
                                   - resourceGroupName
                                   - subscriptionID
@@ -9099,8 +9164,8 @@ spec:
                                     description: |-
                                       The AccessKeyID is used for authentication.
                                       Cannot be set when SecretAccessKeyID is set.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     type: string
                                   accessKeyIDSecretRef:
@@ -9108,8 +9173,8 @@ spec:
                                       The SecretAccessKey is used for authentication. If set, pull the AWS
                                       access key ID from a key within a Kubernetes Secret.
                                       Cannot be set when AccessKeyID is set.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     properties:
                                       key:
@@ -9198,8 +9263,8 @@ spec:
                                   secretAccessKeySecretRef:
                                     description: |-
                                       The SecretAccessKey is used for authentication.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     properties:
                                       key:
@@ -10556,9 +10621,10 @@ spec:
                                                 operator:
                                                   description: |-
                                                     Operator represents a key's relationship to the value.
-                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                                     Exists is equivalent to wildcard for value, so that a pod can
                                                     tolerate all taints of a particular category.
+                                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                                   type: string
                                                 tolerationSeconds:
                                                   description: |-
@@ -11767,9 +11833,10 @@ spec:
                                                 operator:
                                                   description: |-
                                                     Operator represents a key's relationship to the value.
-                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                                     Exists is equivalent to wildcard for value, so that a pod can
                                                     tolerate all taints of a particular category.
+                                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                                   type: string
                                                 tolerationSeconds:
                                                   description: |-
@@ -12026,8 +12093,8 @@ spec:
                               properties:
                                 audiences:
                                   description: |-
-                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault. The default token
-                                    consisting of the issuer's namespace and name is always included.
+                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault.
+                                    The default audiences are always included in the token.
                                   items:
                                     type: string
                                   type: array
@@ -12155,16 +12222,16 @@ spec:
                   type: object
                 venafi:
                   description: |-
-                    Venafi configures this issuer to sign certificates using a Venafi TPP
-                    or Venafi Cloud policy zone.
+                    Venafi configures this issuer to sign certificates using a CyberArk Certificate Manager Self-Hosted
+                    or SaaS policy zone.
                   properties:
                     cloud:
                       description: |-
-                        Cloud specifies the Venafi cloud configuration settings.
-                        Only one of TPP or Cloud may be specified.
+                        Cloud specifies the CyberArk Certificate Manager SaaS configuration settings.
+                        Only one of CyberArk Certificate Manager may be specified.
                       properties:
                         apiTokenSecretRef:
-                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          description: APITokenSecretRef is a secret key selector for the CyberArk Certificate Manager SaaS API token.
                           properties:
                             key:
                               description: |-
@@ -12182,7 +12249,7 @@ spec:
                           type: object
                         url:
                           description: |-
-                            URL is the base URL for Venafi Cloud.
+                            URL is the base URL for CyberArk Certificate Manager SaaS.
                             Defaults to "https://api.venafi.cloud/".
                           type: string
                       required:
@@ -12190,13 +12257,13 @@ spec:
                       type: object
                     tpp:
                       description: |-
-                        TPP specifies Trust Protection Platform configuration settings.
-                        Only one of TPP or Cloud may be specified.
+                        TPP specifies CyberArk Certificate Manager Self-Hosted configuration settings.
+                        Only one of CyberArk Certificate Manager may be specified.
                       properties:
                         caBundle:
                           description: |-
                             Base64-encoded bundle of PEM CAs which will be used to validate the certificate
-                            chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP.
+                            chain presented by the CyberArk Certificate Manager Self-Hosted server. Only used if using HTTPS; ignored for HTTP.
                             If undefined, the certificate bundle in the cert-manager controller container
                             is used to validate the chain.
                           format: byte
@@ -12204,7 +12271,7 @@ spec:
                         caBundleSecretRef:
                           description: |-
                             Reference to a Secret containing a base64-encoded bundle of PEM CAs
-                            which will be used to validate the certificate chain presented by the TPP server.
+                            which will be used to validate the certificate chain presented by the CyberArk Certificate Manager Self-Hosted server.
                             Only used if using HTTPS; ignored for HTTP. Mutually exclusive with CABundle.
                             If neither CABundle nor CABundleSecretRef is defined, the certificate bundle in
                             the cert-manager controller container is used to validate the TLS connection.
@@ -12225,7 +12292,7 @@ spec:
                           type: object
                         credentialsRef:
                           description: |-
-                            CredentialsRef is a reference to a Secret containing the Venafi TPP API credentials.
+                            CredentialsRef is a reference to a Secret containing the CyberArk Certificate Manager Self-Hosted API credentials.
                             The secret must contain the key 'access-token' for the Access Token Authentication,
                             or two keys, 'username' and 'password' for the API Keys Authentication.
                           properties:
@@ -12239,7 +12306,7 @@ spec:
                           type: object
                         url:
                           description: |-
-                            URL is the base URL for the vedsdk endpoint of the Venafi TPP instance,
+                            URL is the base URL for the vedsdk endpoint of the CyberArk Certificate Manager Self-Hosted instance,
                             for example: "https://tpp.example.com/vedsdk".
                           type: string
                       required:
@@ -12248,8 +12315,8 @@ spec:
                       type: object
                     zone:
                       description: |-
-                        Zone is the Venafi Policy Zone to use for this issuer.
-                        All requests made to the Venafi platform will be restricted by the named
+                        Zone is the Certificate Manager Policy Zone to use for this issuer.
+                        All requests made to the Certificate Manager platform will be restricted by the named
                         zone policy.
                         This field is required.
                       type: string


### PR DESCRIPTION
# Summary 

- Andre av tre trinn mot v1.21.1, jf. #350. Første trinn (v1.19.6) landet i #340.
- Bumper charten til v1.20.3 og henter vendored `crds.yaml` på samme versjon.

Verifisering:

- Rendret v1.19.6 mot v1.20.3 med våre verdier. Hele forskjellen er additive RBAC-regler: `listenersets` for Gateway API, og `issuers/finalizers` + `clusterissuers/finalizers` med `update`. Ingenting fjernes.
- Alle åtte values-nøkler vi setter finnes fortsatt i 1.20.3.
- Deployment-selectors er identiske for controller, webhook og cainjector, så ingen immutable-felt-konflikt.
- CRD-strukturen er uendret: 6 CRD-er, kun `v1`, served og storage. Ingen API-versjonsendring og ingen migrering av lagrede objekter.
- Vendored `crds.yaml` var byte-identisk med upstream v1.19.6-asset før bytte, og er nå byte-identisk med v1.20.3-assetet.
- Sertifikatene har ikke blitt re-utstedt siden trinn 1 — samme `renewalTime` i begge miljøer.

Etter merge bør sertifikatenes `renewalTime` sjekkes igjen. Uendret verdi betyr ingen unødvendig re-utstedelse, som er hele grunnen til at oppgraderingen gjøres trinnvis.
