### PR TITLE
fix: set prometheus resources on prometheusSpec

### DIFF
--- a/infrastructure/base/monitoring/helm-release-prometheus.yaml
+++ b/infrastructure/base/monitoring/helm-release-prometheus.yaml
@@ -299,13 +299,16 @@ spec:
           nginx.ingress.kubernetes.io/auth-type: basic
           nginx.ingress.kubernetes.io/auth-secret: ingress-basic-auth
           nginx.ingress.kubernetes.io/auth-realm: Authentication Required
-      resources:
-        requests:
-          cpu: 250m
-          memory: 1250Mi
       thanosService:
         enabled: true
       prometheusSpec:
+        # Sized from 7 days of measured usage; dev peaked at 2547Mi / 780m.
+        resources:
+          requests:
+            cpu: 300m
+            memory: 4Gi
+          limits:
+            memory: 4Gi
         thanos:
           objectStorageConfig:
             existingSecret:


### PR DESCRIPTION
# Summary 

- Retter #346. Verdiene lå under `prometheus.resources`, en nøkkel charten ikke har, så de ble stille forkastet. Prometheus har kjørt helt uten requests og limits — BestEffort QoS, altså først i køen for eviction.
- Flytter dem til `prometheus.prometheusSpec.resources`, der operatoren faktisk leser dem.
- Verifisert i rendret output at de nå havner på Prometheus-CR-en.

Verdiene er satt etter måling, ikke gjenbrukt:

| | dev | prod |
|---|---|---|
| minne nå | 1804Mi | 1448Mi |
| minne topp 7d | 2547Mi | 2033Mi |
| cpu nå | 148m | 123m |
| cpu topp 7d | 780m | 178m |

De gamle verdiene (250m / 1250Mi) lå under faktisk forbruk, så en ren flytting ville gitt en request ~30 % lavere enn det Prometheus bruker.

Minne-request er satt lik limit, slik at reservasjonen er reell og noden ikke kan overcommite. 4Gi gir ~1,5Gi klaring over målt topp, som er nødvendig nettopp fordi lik limit ikke gir burst-rom. Ingen CPU-limit, for å unngå throttling under query- og compaction-topper.

Merk at dette er en reell endring i scheduling: Prometheus vil nå reservere 4Gi på noden.

Close #346 