### PR TITLE
feat: elasticsearch snapshots to gcs in dev

### DIFF
--- a/apps/dev/elasticsearch-demo/elasticsearch.yaml
+++ b/apps/dev/elasticsearch-demo/elasticsearch.yaml
@@ -5,7 +5,7 @@ metadata:
   name: elasticsearch
   namespace: demo
 spec:
-  version: 8.17.2
+  version: 8.19.19
   auth:
     roles:
     - secretName: es-roles

--- a/apps/dev/elasticsearch-demo/elasticsearch.yaml
+++ b/apps/dev/elasticsearch-demo/elasticsearch.yaml
@@ -22,6 +22,8 @@ spec:
         node.roles: ["master"]
       podTemplate:
         spec:
+          serviceAccountName: elasticsearch-snapshot-sa
+          automountServiceAccountToken: true
           initContainers:
             - name: increase-the-vm-max-map-count
               securityContext:
@@ -58,6 +60,8 @@ spec:
             storageClassName: standard
       podTemplate:
         spec:
+          serviceAccountName: elasticsearch-snapshot-sa
+          automountServiceAccountToken: true
           initContainers:
             - name: increase-the-vm-max-map-count
               securityContext:

--- a/apps/dev/elasticsearch-staging/elasticsearch.yaml
+++ b/apps/dev/elasticsearch-staging/elasticsearch.yaml
@@ -5,7 +5,7 @@ metadata:
   name: elasticsearch
   namespace: staging
 spec:
-  version: 8.17.2
+  version: 8.19.19
   auth:
     roles:
     - secretName: es-roles

--- a/apps/dev/elasticsearch-staging/elasticsearch.yaml
+++ b/apps/dev/elasticsearch-staging/elasticsearch.yaml
@@ -22,6 +22,8 @@ spec:
         node.roles: ["master"]
       podTemplate:
         spec:
+          serviceAccountName: elasticsearch-snapshot-sa
+          automountServiceAccountToken: true
           initContainers:
             - name: increase-the-vm-max-map-count
               securityContext:
@@ -58,6 +60,8 @@ spec:
             storageClassName: standard
       podTemplate:
         spec:
+          serviceAccountName: elasticsearch-snapshot-sa
+          automountServiceAccountToken: true
           initContainers:
             - name: increase-the-vm-max-map-count
               securityContext:

--- a/terraform/dev/storage-bucket-elasticsearch-snapshots.tf
+++ b/terraform/dev/storage-bucket-elasticsearch-snapshots.tf
@@ -1,0 +1,29 @@
+resource "google_storage_bucket" "elasticsearch_snapshots" {
+  force_destroy = false
+
+  location                 = upper(var.region)
+  name                     = var.storage_buckets.es_snapshot_bucket_name
+  project                  = var.project_id
+  public_access_prevention = "enforced"
+
+  soft_delete_policy {
+    retention_duration_seconds = 604800
+  }
+
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+}
+
+resource "google_service_account" "es_snapshot_sa" {
+  account_id   = var.service_accounts.es_snapshot
+  description  = "Service account for Elasticsearch snapshots to GCS"
+  display_name = "${var.project_id}-es-snapshot-sa"
+  project      = var.project_id
+}
+
+# Scoped to the snapshot bucket only, not project-wide storage access.
+resource "google_storage_bucket_iam_member" "es_snapshot_object_admin" {
+  bucket = google_storage_bucket.elasticsearch_snapshots.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.es_snapshot_sa.email}"
+}

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -102,8 +102,9 @@ variable "service_accounts" {
 variable "storage_buckets" {
   description = "Storage bucket configuration - kept in Secret Manager"
   type = object({
-    project_number     = string
-    thanos_bucket_name = string
+    project_number          = string
+    thanos_bucket_name      = string
+    es_snapshot_bucket_name = string
   })
 }
 


### PR DESCRIPTION
# Summary 

- Første del av #274. Setter opp ES-snapshot til GCS med Workload Identity i dev (demo og staging). Prod tas som eget steg etter at restore er verifisert.
- Ny dedikert bøtte, egen tjenestekonto, og `roles/storage.objectAdmin` avgrenset til den bøtta alene — ikke prosjektnivå. Bøttenavn og kontonavn ligger i Secret Manager, som resten av konvensjonen.
- Kubernetes-tjenestekontoen og workload-identity-bindingen kommer automatisk: `elasticsearch-snapshot-sa` er lagt til i `k8s_service_accounts`, og både `workload_identity_service_accounts` og bindingene fra #355 itererer over samme `setproduct`, så den opprettes i begge namespaces med binding.
- ES-CR-ene får `serviceAccountName` og `automountServiceAccountToken: true` på begge nodeSets. Sistnevnte er påkrevd her — poden trenger den projiserte tokenen for å autentisere mot GCS.

Rekkefølge ved apply — verifisert empirisk:

1. **Secret Manager er allerede oppdatert (dev v24).** Det måtte gjøres først: en tfvars med et ekstra attributt mot gammel variabeldefinisjon planlegger fint, mens ny variabeldefinisjon mot gammel tfvars feiler hardt med `attribute "es_snapshot_bucket_name" is required`.
2. Merge denne PR-en. Terraform oppretter bøtte, tjenestekontoer og bindinger.
3. **Vent til Terraform er ferdig før Flux ruller ut ES-endringen.** Podene refererer en tjenestekonto som Terraform oppretter; finnes den ikke, feiler de å starte.

Etter apply gjenstår to API-kall per cluster, som ikke kan uttrykkes i Git:

```
PUT _snapshot/gcs-snapshots
{ "type": "gcs", "settings": { "bucket": "<se storage_buckets.es_snapshot_bucket_name>", "client": "default" } }

PUT _slm/policy/daily-snapshots
{ "schedule": "0 30 2 * * ?", "name": "<daily-{now/d}>", "repository": "gcs-snapshots",
  "config": { "indices": ["*"] }, "retention": { "expire_after": "30d" } }
```

Ingen credentials i repository-konfigurasjonen — Workload Identity håndterer autentiseringen.

Verifisert: `terraform validate` grønn, begge ES-overlays bygger og renderer tjenestekontoen på alle fire nodeSets, prod urørt.

Til slutt bør en faktisk restore testes i dev før prod settes opp — det er hele poenget med #274, og en snapshot man ikke har gjenopprettet fra er ikke en verifisert backup.
