### PR TITLE
fix: skip hostless ingresses in blackbox probe

### DIFF
--- a/infrastructure/base/monitoring/helm-release-prometheus.yaml
+++ b/infrastructure/base/monitoring/helm-release-prometheus.yaml
@@ -380,10 +380,16 @@ spec:
             kubernetes_sd_configs:
               - role: ingress
             relabel_configs:
-              # Example relabel to probe only some ingresses that have "example.io/should_be_probed = true" annotation
-              #  - source_labels: [__meta_kubernetes_ingress_annotation_example_io_should_be_probed]
-              #    action: keep
-              #    regex: true
+              # Keep only ingresses a probe target can be built from. A hostless
+              # ingress leaves __param_target unset, and blackbox answers /probe
+              # without a target with 400 Bad Request. Same regex as the rule
+              # below so the two cannot drift apart.
+              - source_labels:
+                  - __meta_kubernetes_ingress_scheme
+                  - __address__
+                  - __meta_kubernetes_ingress_path
+                regex: (.+);(.+);(.+?)\*?$
+                action: keep
               - source_labels:
                   - __meta_kubernetes_ingress_scheme
                   - __address__


### PR DESCRIPTION
# Summary 

- Fjerner den permanente `TargetDown`-alerten for `kubernetes-ingresses` i nginx-namespacet, som har fyrt siden 2024-08-30.
- Ingressene `nginx-controller` og `nginx-controller-v6` er GCE-lastbalanserer-ingresser uten host. Relabel-regelen som bygger probe-URL-en krever scheme, adresse og path, så for disse blir `__param_target` aldri satt — og blackbox svarer 400 Bad Request på et `/probe`-kall uten target.
- Legger til en `keep`-regel med samme regex som bygger targetet, slik at bare ingresser det faktisk kan bygges en probe for blir scrapet. De to reglene deler regex med vilje, så de ikke kan komme i utakt.

Verifisert mot faktiske discovery-labels i dev:

| ingress | health | keep | `__address__` |
|---|---|---|---|
| `ingress-staging-v4` | up | true | `nap.staging.fellesdatakatalog…` |
| `ingress-demo-v4` | up | true | `demo.fellesdatakatalog.digdir.no` |
| `access-request-api` | up | true | `access-request.api.staging…` |
| `nginx-controller` | **down** | **false** | tom |
| `nginx-controller-v6` | **down** | **false** | tom |

Regelen treffer alle friske targets og dropper nøyaktig de to som feiler. Ingen fungerende probe går tapt.

Alerten var altså korrekt — de to targetene er reelt nede — men ingenting er nede i drift. De skulle aldri vært probet.

De øvrige `TargetDown`-alertene for `kubernetes-pods` i demo og staging er noe annet, og spores allerede i app-repoene: `concept-catalog#518`, `fdk-mqa-scoring-api#173` og `access-request-api#73`.
