### PR TITLE
fix: order workload identity bindings after the SA they bind

### DIFF
--- a/terraform/dev/service-accounts-kubernetes.tf
+++ b/terraform/dev/service-accounts-kubernetes.tf
@@ -82,6 +82,10 @@ resource "google_service_account_iam_member" "workload_identity_bindings" {
   service_account_id = "projects/${var.project_id}/serviceAccounts/${var.k8s_to_gcp_service_account_mapping[split("/", each.key)[1]]}@${var.project_id}.iam.gserviceaccount.com"
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.project_id}.svc.id.goog[${each.key}]"
+
+  # service_account_id is built from a variable, so Terraform sees no edge to the
+  # accounts it creates itself and the binding can race ahead into a 404.
+  depends_on = [google_service_account.es_snapshot_sa]
 }
 
 resource "google_service_account_iam_member" "monitoring_cloud_sql_workload_identity" {


### PR DESCRIPTION
# Summary

- Add `depends_on` on `google_service_account.es_snapshot_sa` to `workload_identity_bindings`
- `service_account_id` is interpolated from a variable, so Terraform saw no edge and the binding raced the account into a 404 during the #363 apply
- Dev only; prod has no Terraform-created SA in the mapping yet