### PR TITLE
fix: let terraform plan SA read IAM policies

### DIFF
--- a/terraform/dev/workload-identity-federation.tf
+++ b/terraform/dev/workload-identity-federation.tf
@@ -108,6 +108,14 @@ resource "google_project_iam_member" "terraform_plan_sa_viewer" {
   member  = "serviceAccount:${google_service_account.terraform_plan_sa.email}"
 }
 
+# roles/viewer does not include *.getIamPolicy, so plan cannot refresh IAM
+# resources (e.g. google_storage_bucket_iam_member) without this. Read-only.
+resource "google_project_iam_member" "terraform_plan_sa_security_reviewer" {
+  project = var.project_id
+  role    = "roles/iam.securityReviewer"
+  member  = "serviceAccount:${google_service_account.terraform_plan_sa.email}"
+}
+
 resource "google_project_iam_member" "terraform_plan_sa_secret_accessor" {
   project = var.project_id
   role    = "roles/secretmanager.secretAccessor"

--- a/terraform/prod/workload-identity-federation.tf
+++ b/terraform/prod/workload-identity-federation.tf
@@ -108,6 +108,14 @@ resource "google_project_iam_member" "terraform_plan_sa_viewer" {
   member  = "serviceAccount:${google_service_account.terraform_plan_sa.email}"
 }
 
+# roles/viewer does not include *.getIamPolicy, so plan cannot refresh IAM
+# resources (e.g. google_storage_bucket_iam_member) without this. Read-only.
+resource "google_project_iam_member" "terraform_plan_sa_security_reviewer" {
+  project = var.project_id
+  role    = "roles/iam.securityReviewer"
+  member  = "serviceAccount:${google_service_account.terraform_plan_sa.email}"
+}
+
 resource "google_project_iam_member" "terraform_plan_sa_secret_accessor" {
   project = var.project_id
   role    = "roles/secretmanager.secretAccessor"


### PR DESCRIPTION
# Summary

- Grant `roles/iam.securityReviewer` to the Terraform plan SA in dev and prod
- `roles/viewer` omits `*.getIamPolicy`, so plan could not refresh `google_storage_bucket_iam_member` and failed with a 403 on the new snapshot bucket
- Read-only role; covers every IAM resource type Terraform manages, not just this bucket
- **Merge before #367** — the gate there makes a red plan block apply, so this grant must land while plan is still non-blocking