### PR TITLE
feat: elasticsearch snapshots to gcs in prod

### DIFF
--- a/terraform/prod/service-accounts-kubernetes.tf
+++ b/terraform/prod/service-accounts-kubernetes.tf
@@ -82,6 +82,10 @@ resource "google_service_account_iam_member" "workload_identity_bindings" {
   service_account_id = "projects/${var.project_id}/serviceAccounts/${var.k8s_to_gcp_service_account_mapping[split("/", each.key)[1]]}@${var.project_id}.iam.gserviceaccount.com"
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.project_id}.svc.id.goog[${each.key}]"
+
+  # service_account_id is built from a variable, so Terraform sees no edge to the
+  # accounts it creates itself and the binding can race ahead into a 404.
+  depends_on = [google_service_account.es_snapshot_sa]
 }
 
 resource "google_service_account_iam_member" "monitoring_cloud_sql_workload_identity" {

--- a/terraform/prod/storage-bucket-elasticsearch-snapshots.tf
+++ b/terraform/prod/storage-bucket-elasticsearch-snapshots.tf
@@ -1,0 +1,29 @@
+resource "google_storage_bucket" "elasticsearch_snapshots" {
+  force_destroy = false
+
+  location                 = upper(var.region)
+  name                     = var.storage_buckets.es_snapshot_bucket_name
+  project                  = var.project_id
+  public_access_prevention = "enforced"
+
+  soft_delete_policy {
+    retention_duration_seconds = 604800
+  }
+
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+}
+
+resource "google_service_account" "es_snapshot_sa" {
+  account_id   = var.service_accounts.es_snapshot
+  description  = "Service account for Elasticsearch snapshots to GCS"
+  display_name = "${var.project_id}-es-snapshot-sa"
+  project      = var.project_id
+}
+
+# Scoped to the snapshot bucket only, not project-wide storage access.
+resource "google_storage_bucket_iam_member" "es_snapshot_object_admin" {
+  bucket = google_storage_bucket.elasticsearch_snapshots.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.es_snapshot_sa.email}"
+}

--- a/terraform/prod/variables.tf
+++ b/terraform/prod/variables.tf
@@ -98,8 +98,9 @@ variable "service_accounts" {
 variable "storage_buckets" {
   description = "Storage bucket configuration - kept in Secret Manager"
   type = object({
-    project_number     = string
-    thanos_bucket_name = string
+    project_number          = string
+    thanos_bucket_name      = string
+    es_snapshot_bucket_name = string
   })
 }
 


### PR DESCRIPTION
# Summary

- Add GCS bucket, snapshot service account and bucket-scoped objectAdmin for prod
- Add es_snapshot_bucket_name to the storage_buckets variable
- Add depends_on to workload_identity_bindings, matching #365 in dev — prod now has a Terraform-created SA in the mapping, so it would otherwise hit the same 404 race
- Secret Manager prod tfvars already updated to v4
- ES manifest change follows separately; it needs the Flux Kustomization suspended