### PR TITLE
feat: wire prod elasticsearch to gcs snapshots

### DIFF
--- a/apps/prod/elasticsearch/config-map-snapshots.yaml
+++ b/apps/prod/elasticsearch/config-map-snapshots.yaml
@@ -1,7 +1,0 @@
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: elasticsearch-snapshots
-data:
-  bucket: digdir-fdk-prod-elasticsearch-snapshots

--- a/apps/prod/elasticsearch/config-map-snapshots.yaml
+++ b/apps/prod/elasticsearch/config-map-snapshots.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: elasticsearch-snapshots
+data:
+  bucket: digdir-fdk-prod-elasticsearch-snapshots

--- a/apps/prod/elasticsearch/elasticsearch.yaml
+++ b/apps/prod/elasticsearch/elasticsearch.yaml
@@ -22,6 +22,8 @@ spec:
         node.roles: ["master"]
       podTemplate:
         spec:
+          serviceAccountName: elasticsearch-snapshot-sa
+          automountServiceAccountToken: true
           initContainers:
             - name: increase-the-vm-max-map-count
               securityContext:
@@ -58,6 +60,8 @@ spec:
             storageClassName: standard
       podTemplate:
         spec:
+          serviceAccountName: elasticsearch-snapshot-sa
+          automountServiceAccountToken: true
           initContainers:
             - name: increase-the-vm-max-map-count
               securityContext:

--- a/apps/prod/elasticsearch/kustomization.yaml
+++ b/apps/prod/elasticsearch/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: prod
 resources:
   - elasticsearch.yaml
+  - config-map-snapshots.yaml
+  - ../../base/elasticsearch-snapshots

--- a/apps/prod/elasticsearch/kustomization.yaml
+++ b/apps/prod/elasticsearch/kustomization.yaml
@@ -3,5 +3,4 @@ kind: Kustomization
 namespace: prod
 resources:
   - elasticsearch.yaml
-  - config-map-snapshots.yaml
   - ../../base/elasticsearch-snapshots


### PR DESCRIPTION
# Summary

- Set serviceAccountName and automountServiceAccountToken on both prod nodeSets
- Add the snapshot bucket ConfigMap and pull in the shared snapshot base
- ES version deliberately unchanged; the 8.19.19 bump stays separate (#351)

Depends on #368 (adds apps/base/elasticsearch-snapshots) and #369 (creates the service account this references).

Merge last, and only once the service account exists. The pod template change restarts the data nodes, and in dev ECK took all four down at once rather than rolling them one at a time. If the service account is missing at that point the pods cannot start.

1. Merge #369, wait for the prod Terraform apply to finish
2. Verify: `kubectl get sa elasticsearch-snapshot-sa -n prod`
3. Merge #368
4. Merge this PR
5. Watch: `kubectl get es,pods -n prod -w`