### PR TITLE
fix: disable exporter client cert auth

### DIFF
--- a/infrastructure/dev/monitoring/helm-release-elasticsearch-exporter-demo.yaml
+++ b/infrastructure/dev/monitoring/helm-release-elasticsearch-exporter-demo.yaml
@@ -31,6 +31,10 @@ spec:
         useExistingSecrets: true
         ca:
           path: /ssl/ca.crt
+        # Defaults to true, which makes the chart pass --es.client-cert for a
+        # file we do not mount. ECK authenticates with the elastic user.
+        client:
+          enabled: false
     extraEnvSecrets:
       ES_PASSWORD:
         secret: elasticsearch-es-elastic-user

--- a/infrastructure/dev/monitoring/helm-release-elasticsearch-exporter-staging.yaml
+++ b/infrastructure/dev/monitoring/helm-release-elasticsearch-exporter-staging.yaml
@@ -31,6 +31,10 @@ spec:
         useExistingSecrets: true
         ca:
           path: /ssl/ca.crt
+        # Defaults to true, which makes the chart pass --es.client-cert for a
+        # file we do not mount. ECK authenticates with the elastic user.
+        client:
+          enabled: false
     extraEnvSecrets:
       ES_PASSWORD:
         secret: elasticsearch-es-elastic-user

--- a/infrastructure/prod/monitoring/helm-release-elasticsearch-exporter.yaml
+++ b/infrastructure/prod/monitoring/helm-release-elasticsearch-exporter.yaml
@@ -31,6 +31,10 @@ spec:
         useExistingSecrets: true
         ca:
           path: /ssl/ca.crt
+        # Defaults to true, which makes the chart pass --es.client-cert for a
+        # file we do not mount. ECK authenticates with the elastic user.
+        client:
+          enabled: false
     extraEnvSecrets:
       ES_PASSWORD:
         secret: elasticsearch-es-elastic-user


### PR DESCRIPTION
# Summary

- es.ssl.client.enabled defaults to true, so enabling TLS made the chart pass --es.client-cert and --es.client-private-key for files that are not mounted
- The exporter exited on startup and crashlooped in all three namespaces
- ECK authenticates with the elastic user, so client certs are not used