### PR TITLE
chore: bump prod elasticsearch to 8.19.19

### DIFF
--- a/apps/prod/elasticsearch/elasticsearch.yaml
+++ b/apps/prod/elasticsearch/elasticsearch.yaml
@@ -5,7 +5,7 @@ metadata:
   name: elasticsearch
   namespace: prod
 spec:
-  version: 8.17.2
+  version: 8.19.19
   auth:
     roles:
     - secretName: es-roles


### PR DESCRIPTION
# Summary

- Bump prod Elasticsearch 8.17.2 → 8.19.19, matching demo and staging
- 8.17 is past maintenance, and ECK requires ≥ 8.18 before any future 9.x upgrade
- Version change only; no other manifest changes
- Nodes restart as part of the upgrade

A pre-upgrade snapshot `pre-upgrade-8-19-19` was taken (9 indices, 9/9 shards). It is not managed by SLM retention, so delete it manually once the upgrade is confirmed good.