### PR TITLE
chore: pin karma to v0.132

### DIFF
--- a/infrastructure/base/monitoring/karma.yaml
+++ b/infrastructure/base/monitoring/karma.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: karma
-          image: ghcr.io/prymitive/karma:latest
+          image: ghcr.io/prymitive/karma:v0.132
           ports:
             - containerPort: 8080
           volumeMounts:


### PR DESCRIPTION
# Summary

- karma ran on :latest, which is a rolling main-branch build rather than a release
- The running digest matches no tag, and :latest has already moved on since it was pulled, so any pod restart silently changes the image and lets dev and prod diverge
- v0.132 was released 2026-08-05, after #349 was written, so pinning is now a small step forward rather than the 266-commit regression that blocked this
- Last remaining :latest reference in the repo