### PR TITLE
fix: drop cpu limits and align memory in infrastructure

### DIFF
--- a/infrastructure/base/cert-manager/cert-manager.yaml
+++ b/infrastructure/base/cert-manager/cert-manager.yaml
@@ -26,8 +26,7 @@ spec:
         cpu: 100m
         memory: 128Mi
       limits:
-        cpu: 500m
-        memory: 512Mi
+        memory: 128Mi
     securityContext:
       runAsNonRoot: true
       runAsUser: 1001

--- a/infrastructure/base/keycloak-operator/operator-resources.yaml
+++ b/infrastructure/base/keycloak-operator/operator-resources.yaml
@@ -454,7 +454,6 @@ spec:
             timeoutSeconds: 10
           resources:
             limits:
-              cpu: 700m
               memory: 450Mi
             requests:
               cpu: 300m

--- a/infrastructure/base/monitoring/helm-release-postgres-exporter.yaml
+++ b/infrastructure/base/monitoring/helm-release-postgres-exporter.yaml
@@ -43,7 +43,7 @@ spec:
       # for ~27% of its runnable CFS periods. The request keeps its scheduling
       # share; the limit only added latency.
       limits:
-        memory: 128Mi
+        memory: 64Mi
 
     securityContext:
       runAsNonRoot: true

--- a/infrastructure/base/monitoring/helm-release-postgres-exporter.yaml
+++ b/infrastructure/base/monitoring/helm-release-postgres-exporter.yaml
@@ -38,8 +38,11 @@ spec:
       requests:
         cpu: 50m
         memory: 64Mi
+      # No CPU limit on purpose. The exporter idles at ~3m and bursts briefly on
+      # each scrape, so a quota it never approaches on average still throttled it
+      # for ~27% of its runnable CFS periods. The request keeps its scheduling
+      # share; the limit only added latency.
       limits:
-        cpu: 200m
         memory: 128Mi
 
     securityContext:

--- a/infrastructure/base/trivy/helm-release.yaml
+++ b/infrastructure/base/trivy/helm-release.yaml
@@ -38,9 +38,13 @@ spec:
       # cache backend is in-memory, holds it decompressed in RAM alongside the
       # scan working set. 256Mi was not enough for larger images and they were
       # being OOMKilled.
+      # No CPU limit: scan containers sat pinned at the 100m limit and throttled
+      # 100% of the time, which is what made scans run 138-235s against the job
+      # deadline. Memory request stays below the limit deliberately - these are
+      # short-lived and up to 10 run concurrently, so reserving 1Gi each would
+      # hold 10Gi cluster-wide for jobs that usually use well under 100Mi.
       resources:
         limits:
-          cpu: 100m
           memory: 1Gi
         requests:
           cpu: 50m


### PR DESCRIPTION
# Summary

- Remove CPU limits across infrastructure: cert-manager, keycloak-operator, postgres-exporter, trivy scan jobs
- Align memory request and limit where a limit exists: cert-manager 512Mi -> 128Mi, postgres-exporter 128Mi -> 64Mi (peaks are 35Mi and 14Mi)
- trivy scan jobs keep request below limit on purpose: up to 10 run concurrently, so 1Gi each would reserve 10Gi cluster-wide
- postgres-exporter was throttled ~27% of periods while using 3m against a 200m limit
- trivy scan containers sat pinned at exactly 100m and throttled 100% of the time, which is what made scans run 138-235s against the job deadline