### PR TITLE
fix: actually remove trivy scan job cpu limit

### DIFF
--- a/infrastructure/base/trivy/helm-release.yaml
+++ b/infrastructure/base/trivy/helm-release.yaml
@@ -45,6 +45,10 @@ spec:
       # hold 10Gi cluster-wide for jobs that usually use well under 100Mi.
       resources:
         limits:
+          # Explicit null, not omission: the chart defaults this to 500m, so
+          # leaving it out still sets a limit. `with dig ... ""` skips the key
+          # when it is null, which is the only way to have no CPU limit.
+          cpu: null
           memory: 1Gi
         requests:
           cpu: 50m


### PR DESCRIPTION
# Summary

- #379 removed the explicit `cpu: 100m` from the scan job limits, but the chart defaults `trivy.resources.limits.cpu` to 500m, so scan jobs still had a limit
- Set it to explicit null: the chart uses `with dig ... ""`, which omits the key when the value is null
- Verified by rendering the real values through chart 0.34.0: `limits.cpu` is absent, `limits.memory: 1Gi` and both requests unchanged