### PR TITLE
feat: manage prod monitoring basic auth via ESO

### DIFF
--- a/infrastructure/prod/external-secrets/crs/monitoring/ingress-basic-auth.yaml
+++ b/infrastructure/prod/external-secrets/crs/monitoring/ingress-basic-auth.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ingress-basic-auth
+  namespace: monitoring
+spec:
+  secretStoreRef:
+    name: gcp-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: ingress-basic-auth
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: ingress-basic-auth-monitoring


### PR DESCRIPTION
# Summary

- Same change as #383, now for prod: `monitoring/ingress-basic-auth` moves from a hand-created Secret to an ExternalSecret backed by GCP Secret Manager.
- New Secret Manager entry `ingress-basic-auth-monitoring` in `digdir-fdk-prod` (automatic replication, label `namespace=monitoring`), seeded from the live cluster Secret so it byte-matches.

The manifest is byte-identical to the dev one merged in #383.

No IAM change needed: `digdir-fdk-prod-eso-reader-sa` already holds `roles/secretmanager.secretAccessor` project-wide.

## Verified

| check | result |
|---|---|
| Secret Manager payload vs live prod Secret | `sha256 3d2131b4…` both, 41 bytes — match |
| dev equivalent, after merge of #383 | ExternalSecret `Ready`, Secret adopted, value unchanged, all five ingresses enforce auth |
| correct credentials still accepted (dev) | confirmed by hand against alertmanager |

ESO adoption of a pre-existing Secret was proven on dev before #383 using throwaway resources: it takes the ownerReference and `managed=true` label with no manual pre-delete step, and the value is untouched when it byte-matches.

## Worth knowing

Deleting this ExternalSecret — or removing the file from git, since `external-secrets-crs` runs with `prune: true` — garbage-collects the Secret and would 401 the prod prometheus, alertmanager, thanos, thanos-store and karma ingresses. That is intended ESO behaviour, but it removes the "a manual copy is still there" fallback.

Once this is confirmed in prod, the README's manual `htpasswd` step can go.

