### PR TITLE
feat: manage alertmanager and grafana secrets via ESO

### DIFF
--- a/infrastructure/dev/external-secrets/crs/flux-system/kube-prometheus-stack-alertmanager.yaml
+++ b/infrastructure/dev/external-secrets/crs/flux-system/kube-prometheus-stack-alertmanager.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kube-prometheus-stack-alertmanager
+  namespace: flux-system
+spec:
+  secretStoreRef:
+    name: gcp-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: kube-prometheus-stack-alertmanager
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: kube-prometheus-stack-alertmanager

--- a/infrastructure/dev/external-secrets/crs/flux-system/kube-prometheus-stack-grafana.yaml
+++ b/infrastructure/dev/external-secrets/crs/flux-system/kube-prometheus-stack-grafana.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kube-prometheus-stack-grafana
+  namespace: flux-system
+spec:
+  secretStoreRef:
+    name: gcp-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: kube-prometheus-stack-grafana
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: kube-prometheus-stack-grafana

--- a/infrastructure/prod/external-secrets/crs/flux-system/kube-prometheus-stack-alertmanager.yaml
+++ b/infrastructure/prod/external-secrets/crs/flux-system/kube-prometheus-stack-alertmanager.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kube-prometheus-stack-alertmanager
+  namespace: flux-system
+spec:
+  secretStoreRef:
+    name: gcp-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: kube-prometheus-stack-alertmanager
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: kube-prometheus-stack-alertmanager

--- a/infrastructure/prod/external-secrets/crs/flux-system/kube-prometheus-stack-grafana.yaml
+++ b/infrastructure/prod/external-secrets/crs/flux-system/kube-prometheus-stack-grafana.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kube-prometheus-stack-grafana
+  namespace: flux-system
+spec:
+  secretStoreRef:
+    name: gcp-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: kube-prometheus-stack-grafana
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: kube-prometheus-stack-grafana


### PR DESCRIPTION
# Summary

- Continues #383/#384: the two remaining `flux-system` Secrets move to GCP Secret Manager — `kube-prometheus-stack-alertmanager` and `kube-prometheus-stack-grafana`, in both dev and prod.
- Four new Secret Manager entries, same name as the k8s Secret, label `namespace=flux-system`, each seeded from the live cluster Secret so it byte-matches.

Both clusters are in one PR because the risk is identical in each — the only way these break is a value that does not match, and all four were verified against the live Secrets by checksum before this was opened.

## Verified

| check | result |
|---|---|
| all four GCM payloads vs live Secrets | keys, lengths and sha256 match on every one |
| ESO can write into `flux-system` (never previously exercised) | throwaway ExternalSecret → `Ready`, value byte-identical |
| live Secrets during the test | untouched, `ownerRefs=0` |
| server-side dry-run, all four files, both clusters | accepted |

ESO adoption of a pre-existing Secret was proven before #383: it takes the ownerReference and `managed=true` label, leaving a byte-matching value untouched.

## Larger blast radius than #383/#384 — worth knowing

Both of these are consumed as `valuesFrom` on the kube-prometheus-stack HelmRelease, so if either Secret disappears the whole HelmRelease fails to reconcile. Deleting an ExternalSecret — or removing its file, since `external-secrets-crs` runs `prune: true` — garbage-collects the Secret. That is the intended behaviour, but the fallback manual copy is gone once ESO owns it.

One of the two also fails **silently** when wrong: nothing errors, the downstream integration simply stops working. Post-merge verification therefore has to exercise that path for real, not just read a green ExternalSecret status.
