### PR TITLE
fix: let terraform plan read the snapshot secret

### DIFF
--- a/terraform/dev/storage-bucket-elasticsearch-snapshots.tf
+++ b/terraform/dev/storage-bucket-elasticsearch-snapshots.tf
@@ -44,4 +44,56 @@ resource "kubernetes_secret" "elasticsearch_snapshots" {
   }
 
   type = "Opaque"
+
+  # Create the plan service account's read grant first. Terraform sees no
+  # dependency between the two, so without this an apply could create the Secret
+  # and then fail before the RoleBinding exists - which leaves every subsequent
+  # plan unable to refresh the Secret, and unable to create the grant that would
+  # fix it, because apply is gated on plan.
+  depends_on = [kubernetes_role_binding.terraform_plan_snapshot_secret_reader]
+}
+
+# roles/viewer, which the plan service account holds, grants container.configMaps.get
+# but no container.secrets.* at all, so `terraform plan` cannot refresh the Secret
+# above and every plan fails once it exists. GKE evaluates IAM and Kubernetes RBAC
+# in parallel, so RBAC can grant this without widening the IAM role.
+#
+# Deliberately scoped with resourceNames to the single Secret Terraform manages:
+# get on that one name, in these namespaces only. No list, no other secret. Refresh
+# reads the object by name, so get is all it needs.
+resource "kubernetes_role" "terraform_plan_snapshot_secret_reader" {
+  for_each = toset(var.k8s_namespaces)
+
+  metadata {
+    name      = "terraform-plan-snapshot-secret-reader"
+    namespace = each.value
+  }
+
+  rule {
+    api_groups     = [""]
+    resources      = ["secrets"]
+    resource_names = ["elasticsearch-snapshots"]
+    verbs          = ["get"]
+  }
+}
+
+resource "kubernetes_role_binding" "terraform_plan_snapshot_secret_reader" {
+  for_each = toset(var.k8s_namespaces)
+
+  metadata {
+    name      = "terraform-plan-snapshot-secret-reader"
+    namespace = each.value
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role.terraform_plan_snapshot_secret_reader[each.key].metadata[0].name
+  }
+
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "User"
+    name      = google_service_account.terraform_plan_sa.email
+  }
 }

--- a/terraform/prod/storage-bucket-elasticsearch-snapshots.tf
+++ b/terraform/prod/storage-bucket-elasticsearch-snapshots.tf
@@ -44,4 +44,56 @@ resource "kubernetes_secret" "elasticsearch_snapshots" {
   }
 
   type = "Opaque"
+
+  # Create the plan service account's read grant first. Terraform sees no
+  # dependency between the two, so without this an apply could create the Secret
+  # and then fail before the RoleBinding exists - which leaves every subsequent
+  # plan unable to refresh the Secret, and unable to create the grant that would
+  # fix it, because apply is gated on plan.
+  depends_on = [kubernetes_role_binding.terraform_plan_snapshot_secret_reader]
+}
+
+# roles/viewer, which the plan service account holds, grants container.configMaps.get
+# but no container.secrets.* at all, so `terraform plan` cannot refresh the Secret
+# above and every plan fails once it exists. GKE evaluates IAM and Kubernetes RBAC
+# in parallel, so RBAC can grant this without widening the IAM role.
+#
+# Deliberately scoped with resourceNames to the single Secret Terraform manages:
+# get on that one name, in these namespaces only. No list, no other secret. Refresh
+# reads the object by name, so get is all it needs.
+resource "kubernetes_role" "terraform_plan_snapshot_secret_reader" {
+  for_each = toset(var.k8s_namespaces)
+
+  metadata {
+    name      = "terraform-plan-snapshot-secret-reader"
+    namespace = each.value
+  }
+
+  rule {
+    api_groups     = [""]
+    resources      = ["secrets"]
+    resource_names = ["elasticsearch-snapshots"]
+    verbs          = ["get"]
+  }
+}
+
+resource "kubernetes_role_binding" "terraform_plan_snapshot_secret_reader" {
+  for_each = toset(var.k8s_namespaces)
+
+  metadata {
+    name      = "terraform-plan-snapshot-secret-reader"
+    namespace = each.value
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role.terraform_plan_snapshot_secret_reader[each.key].metadata[0].name
+  }
+
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "User"
+    name      = google_service_account.terraform_plan_sa.email
+  }
 }


### PR DESCRIPTION
# Summary

- `terraform plan` in PR CI has failed on every `terraform/dev` change since the `elasticsearch-snapshots` Secret was created, with `secrets "elasticsearch-snapshots" is forbidden`.
- Cause: the plan service account holds `roles/viewer`, which includes `container.configMaps.get` but **no** `container.secrets.*` at all. Plan must refresh the Secret it manages, and cannot read it.
- Fix: a namespace-scoped Kubernetes `Role` + `RoleBinding` granting `get` on that one Secret by name. GKE evaluates IAM and Kubernetes RBAC in parallel, so this grants the read without widening the IAM role.
- Applied to dev and prod. Prod is not failing yet, but its next `terraform/prod` change would hit the same wall.

## Why not a wider grant

Adding `container.secrets.get` via IAM would work, but it is project-wide: every secret in every namespace, readable by the PR-CI identity. The RBAC grant is scoped with `resourceNames` to a single Secret in the namespaces where Terraform manages one. Verified against dev:

| check, as the plan service account | result |
|---|---|
| `get secrets/elasticsearch-snapshots` in demo / staging | **yes** |
| `get` any other secret in those namespaces | no |
| `list` secrets in those namespaces | no |
| `get` secrets in other namespaces | no |

## Ordering

The Secret now declares `depends_on` the RoleBinding. Terraform sees no relationship between them otherwise, so an apply could create the Secret and then fail before the grant existed - leaving every later plan unable to refresh the Secret, and unable to create the grant that would fix it, since apply is gated on plan. That is a latent trap for a rebuild from empty state, where it would be much harder to diagnose.

## Bootstrap note

This exact deadlock was already in effect, so the four RBAC objects could not be created through CI: plan fails, and `terraform-apply` has `needs: terraform-plan`. They were applied once with `terraform apply -target` for the two RBAC resources only (plan output confirmed 4 to add, 0 to change, 0 to destroy) and are now in both the cluster and remote state. This PR brings the committed configuration in line - a plan against it should show no changes for these resources.

A rebuild from empty state needs no such step: there is nothing to refresh, and apply runs as the apply service account, which can read secrets.
