### PR TITLE
feat: bind thanos service accounts to workload identity

### DIFF
--- a/terraform/dev/storage-bucket-metrics.tf
+++ b/terraform/dev/storage-bucket-metrics.tf
@@ -54,3 +54,23 @@ resource "google_service_account_iam_member" "thanos_workload_identity" {
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.monitoring_namespace}/${each.value}]"
 }
+
+# The Helm charts own these service accounts, so only the annotation is managed
+# here rather than the objects. Set from Terraform so the account address is not
+# committed to this repo, which is public.
+resource "kubernetes_annotations" "thanos_workload_identity" {
+  for_each = toset(local.thanos_bucket_k8s_service_accounts)
+
+  api_version = "v1"
+  kind        = "ServiceAccount"
+  force       = true
+
+  metadata {
+    name      = each.value
+    namespace = var.monitoring_namespace
+  }
+
+  annotations = {
+    "iam.gke.io/gcp-service-account" = google_service_account.thanos_sa.email
+  }
+}


### PR DESCRIPTION
# Summary

- Step 2 of 3 in moving Thanos off a static GCS service account key and onto Workload Identity, dev only. Follows #386.
- Binds the three Kubernetes service accounts that touch the metrics bucket — compactor, storegateway and the Prometheus Thanos sidecar — to the GCP service account created in #386.

**This PR changes nothing at runtime.** The annotation only takes effect once Thanos stops using its current configuration, which is step 3. Nothing in the monitoring stack restarts.

## Why Terraform and not chart values

The annotation value is a GCP service account address, and this repo is public. Setting it through Terraform keeps it out of Git, sourced from the service account resource itself — the same approach `external_secrets_sa` and `monitoring_cloud_sql_sa` already use in `service-accounts-kubernetes.tf`.

`kubernetes_annotations` manages only the annotation, so the Helm charts keep ownership of the service account objects and there is no ownership conflict. Verified on dev beforehand: an annotation Helm did not set survives a full `flux reconcile helmrelease thanos --with-source`.

`container.serviceAccounts.get` is included in `roles/viewer`, so this adds no CI plan permission problem of the kind fixed in #387.

## Plan

`Plan: 3 to add, 6 to change, 0 to destroy`

The 3 additions are the annotations. The 6 in-place changes are the usual `google_compute_security_policy` rule churn, unrelated.

## Known limitation

`kubernetes_annotations` requires the service account to exist, and the charts create it. In a rebuild from empty state Terraform runs before Flux has deployed the monitoring stack, so this resource fails on the first apply and Terraform needs a second run once Flux has settled. The alternative — having Terraform own the service accounts via `serviceAccount.create: false` — avoids that, but requires handing three live objects over from Helm, including the one the Prometheus chart binds its RBAC to. Deliberately not doing that to a working monitoring stack for a DR re-run.

## Next

3. Drop the service account key from the Thanos object store configuration so it falls back to Workload Identity, after a pre-flight check that the metadata server resolves correctly from an annotated pod. Then remove the key.
