### PR TITLE
feat: deliver thanos objstore config via eso

### DIFF
--- a/infrastructure/dev/external-secrets/crs/monitoring/thanos-objstore.yaml
+++ b/infrastructure/dev/external-secrets/crs/monitoring/thanos-objstore.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: thanos-objstore
+  namespace: monitoring
+spec:
+  secretStoreRef:
+    name: gcp-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: thanos-objstore
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: thanos-objstore

--- a/terraform/dev/storage-bucket-metrics.tf
+++ b/terraform/dev/storage-bucket-metrics.tf
@@ -55,6 +55,34 @@ resource "google_service_account_iam_member" "thanos_workload_identity" {
   member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.monitoring_namespace}/${each.value}]"
 }
 
+# No service_account key: Thanos falls back to ADC via Workload Identity.
+# External Secrets delivers this into the namespace.
+resource "google_secret_manager_secret" "thanos_objstore" {
+  secret_id = "thanos-objstore"
+  project   = var.project_id
+
+  labels = {
+    namespace = var.monitoring_namespace
+  }
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "thanos_objstore" {
+  secret = google_secret_manager_secret.thanos_objstore.id
+
+  secret_data = jsonencode({
+    "objstore.yml" = yamlencode({
+      type = "GCS"
+      config = {
+        bucket = var.storage_buckets.thanos_bucket_name
+      }
+    })
+  })
+}
+
 # The Helm charts own these service accounts, so only the annotation is managed
 # here rather than the objects. Set from Terraform so the account address is not
 # committed to this repo, which is public.


### PR DESCRIPTION
# Summary

- Step 3 of 3, dev only. Follows #386 and #388. The Thanos object store configuration moves from a hand-created Secret to one delivered by External Secrets, and loses its embedded service account key — Thanos reaches the bucket through the Workload Identity binding instead.
- Terraform owns the Secret Manager entry, built from the same tfvars value that creates the bucket, so there is a single source of truth and nothing lands in this repo.
- External Secrets delivers it into `monitoring`, matching how `postgres-exporter` and `ingress-basic-auth` already work there.

Plan for the Terraform half: `2 to add, 6 to change, 0 to destroy` (the 6 are the usual `google_compute_security_policy` churn).

## Why not a Terraform-managed kubernetes_secret

That was the first approach and it was dropped. `roles/viewer` carries no `container.secrets.*`, so a Secret managed by Terraform in `monitoring` would need its own RBAC grant, plus an `import` block for the existing object, split across two PRs merged in strict order — the same sequencing #387 and #386 needed. External Secrets needs none of that, and `monitoring` already depends on it.

The Secret Manager side is fine for CI: `roles/viewer` includes `secretmanager.secrets.get` and `versions.get`, so plan can refresh both new resources.

## Pre-flight, already done

Probe pods on each of the three annotated service accounts, using the real service accounts in the real namespace:

| service account | identity resolved | read | write | delete |
|---|---|---|---|---|
| compactor | thanos-sa | 200 | 200 | 204 |
| storegateway | thanos-sa | 200 | 200 | 204 |
| prometheus | thanos-sa | 200 | 200 | 204 |

Writes were tested deliberately: read-only success would have looked fine while leaving the compactor unable to upload compacted blocks. Probe objects were deleted and the pods removed.

## What actually changes, and when

Merging rewrites the Secret's contents, but **running pods do not reload it** — Thanos reads the object store config at startup. So the switch to Workload Identity happens on the next restart of the compactor, the storegateway and Prometheus, which will be done deliberately and verified rather than left to chance.

If something is wrong, the compactor halts and the sidecar stops uploading blocks. Note a halted compactor never recovers on its own, so any fix needs a pod restart as well.

The service account key is not removed in this PR. It stays until the switch is confirmed working, then goes separately.
